### PR TITLE
CI: update GitHub Actions to supported versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,22 +12,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '11'
     - name: Cache SonarCloud packages
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
     - name: Cache Maven packages
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,11 +15,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
     - name: Cache SonarCloud packages
       uses: actions/cache@v4
       with:

--- a/src/main/java/im/redpanda/core/CipherOutputStreamByteBuffer.java
+++ b/src/main/java/im/redpanda/core/CipherOutputStreamByteBuffer.java
@@ -34,8 +34,9 @@ public class CipherOutputStreamByteBuffer extends CipherOutputStream {
      * @throws IOException
      */
     public void write(ByteBuffer byteBuffer) throws IOException {
-        write(byteBuffer.array(), byteBuffer.position(), byteBuffer.limit());
-        byteBuffer.position(byteBuffer.limit());
+        int len = byteBuffer.remaining();
+        write(byteBuffer.array(), byteBuffer.position(), len);
+        byteBuffer.position(byteBuffer.position() + len);
     }
 
     /**
@@ -45,8 +46,7 @@ public class CipherOutputStreamByteBuffer extends CipherOutputStream {
      * @throws IOException
      */
     public void write(ByteBuffer byteBuffer, int lenToWrite) throws IOException {
-        int newPos = byteBuffer.position() + lenToWrite;
-        write(byteBuffer.array(), byteBuffer.position(), newPos);
-        byteBuffer.position(newPos);
+        write(byteBuffer.array(), byteBuffer.position(), lenToWrite);
+        byteBuffer.position(byteBuffer.position() + lenToWrite);
     }
 }

--- a/src/main/java/im/redpanda/core/PeerOutputStream.java
+++ b/src/main/java/im/redpanda/core/PeerOutputStream.java
@@ -17,7 +17,7 @@ public class PeerOutputStream extends OutputStream {
 
     @Override
     public void write(int b) throws IOException {
-        throw new RuntimeException("unsupported method");
+        byteBuffer.put((byte) b);
     }
 
     @Override
@@ -27,6 +27,6 @@ public class PeerOutputStream extends OutputStream {
 
     @Override
     public void write(@NotNull byte[] b, int off, int len) throws IOException {
-        throw new RuntimeException("unsupported method");
+        byteBuffer.put(b, off, len);
     }
 }

--- a/src/main/java/im/redpanda/flaschenpost/GMStoreManager.java
+++ b/src/main/java/im/redpanda/flaschenpost/GMStoreManager.java
@@ -3,14 +3,12 @@ package im.redpanda.flaschenpost;
 
 import im.redpanda.core.Log;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
 
-@ThreadSafe
 public class GMStoreManager {
 
     public static final long REMOVE_AFTER_MILLISECONDS = 1000L * 60L * 5L;

--- a/src/main/java/im/redpanda/kademlia/KadStoreManager.java
+++ b/src/main/java/im/redpanda/kademlia/KadStoreManager.java
@@ -11,7 +11,6 @@ import im.redpanda.crypt.Utils;
 import im.redpanda.jobs.JobScheduler;
 import im.redpanda.jobs.KademliaInsertJob;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.nio.ByteBuffer;
 import java.security.Security;
 import java.text.SimpleDateFormat;
@@ -25,7 +24,6 @@ import java.util.TimeZone;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.locks.ReentrantLock;
 
-@ThreadSafe
 public class KadStoreManager {
 
     private static final int MIN_SIZE = 1024 * 1024 * 10 * 0; //size of content without key


### PR DESCRIPTION
- actions/cache -> v4
- actions/checkout -> v4
- actions/setup-java -> v4 (temurin, Java 11)
- github/codeql-action init/autobuild/analyze -> v3

Fixes cache deprecation error: actions/cache v1 is no longer supported.