### PR TITLE
feat: add oh_id to FlaschenpostPut for direct OH routing

### DIFF
--- a/.github/instructions/enterprise-java-quality.instructions.md
+++ b/.github/instructions/enterprise-java-quality.instructions.md
@@ -1,0 +1,64 @@
+---
+name: enterprise-java-quality
+description: Enforces strict enterprise Java coding guidelines, code quality standards, and architectural rules for the redpandaj project. Automatically triggered for Java refactoring, code reviews, and new feature development.
+---
+
+# Enterprise Java Coding & Architecture Guidelines
+
+When this skill is invoked, you act as our Lead Enterprise Java Architect. Whenever you read, write, or review Java code, you must strictly enforce our internal company guidelines:
+
+## 1. Libraries & Frameworks (Company Standard)
+
+- **Logging:** Use SLF4J via Lombok's `@Slf4j` annotation for all new classes. Never use `System.out.println`, `System.err.println`, or `java.util.logging`. Log at appropriate levels (`log.error` for exceptions with stack traces, `log.warn` for recoverable issues, `log.info` for significant events, `log.debug` for tracing).
+- **Testing:** Use **JUnit 4** (`org.junit.Test`, `@Before`, `@After`) for test lifecycles and **AssertJ** (`assertThat(...)`) for fluent assertions. Do not use standard JUnit `assertEquals`/`assertTrue` — prefer `assertThat(actual).isEqualTo(expected)`. Use real instances or simple test doubles over heavy mocking frameworks where possible.
+- **Serialization:** Use **Protocol Buffers** (protobuf) for all wire-format messages and serialization. Never edit generated protobuf sources in `target/generated-sources/`. Define messages in `.proto` files under `src/main/proto/`.
+- **Cryptography:** Use **Bouncy Castle** for all cryptographic operations. Use `SecureRandom` (never `java.util.Random`) for generating random bytes, keys, or nonces — including in tests.
+- **Lombok:** Use `@Slf4j` for logging, `@Getter`/`@Setter` for accessors, and `@Data`/`@Builder` where appropriate. Keep classes clean by letting Lombok generate boilerplate.
+- **Formatting:** Code must pass **Spotless** with **Google Java Format** style. Run `mvn spotless:apply` before committing. The build will fail on style violations.
+
+## 2. Architectural Boundaries
+
+- **Core Layer (`im.redpanda.core`):** Handles peer management, command processing, and server lifecycle. Must not depend on higher-level application logic.
+- **Network/Protocol Layer:** Command handlers in `InboundCommandProcessor` must only dispatch — parsing, validation, and business logic belong in dedicated service classes.
+- **Service Layer (`im.redpanda.outbound`, etc.):** Contains business rules and domain logic. Services must be injectable via constructor parameters and must not depend on network-layer specifics.
+- **Data/Store Layer:** Handles all persistence. Store classes (`OutboundHandleStore`, `OutboundMailboxStore`) encapsulate data access and must not leak storage implementation details.
+
+## 3. Code Quality & Modern Java (21+)
+
+- **Immutability:** Prefer `record` types for DTOs, value objects, and API payloads. Use `final` fields wherever possible. Prefer unmodifiable collections (`List.of()`, `Map.of()`, `Collections.unmodifiable*`).
+- **Dependency Injection:** Use constructor injection exclusively. Declare dependencies as `private final` fields. Never use mutable service references unless explicitly required by lifecycle constraints.
+- **Null-Safety:** Never return `null` from public methods. Use `Optional<T>` for return types that may have no value. Never use `Optional` as a method parameter or class field.
+- **String Encoding:** Always use `StandardCharsets.UTF_8` explicitly. Never call `String.getBytes()` without a charset parameter.
+- **Pattern Matching:** Use modern Java pattern matching for `instanceof` checks and `switch` expressions where it improves readability.
+- **Error Handling:** Catch the most specific exception type possible. Prefer `RuntimeException` over generic `Exception` in catch blocks for command processing. Always log exceptions with their stack trace (`log.error("message", exception)`).
+
+## 4. Testing Standards
+
+- **Test Naming:** Use descriptive method names that document the scenario: `methodUnderTest_givenCondition_expectedBehavior()` (e.g., `flaschenpostPut_withExpiredOhHandle_fallsThroughToLegacy`).
+- **Test Cleanup:** Use the "best effort" pattern for file cleanup in `@After` methods — call `File.delete()` without checking return values or adding warnings.
+- **Test Data:** Use `StandardCharsets.UTF_8` for string-to-byte conversions. Use `SecureRandom` for generating random test data. Use meaningful, descriptive test payloads over arbitrary byte arrays.
+- **Assertions:** Prefer AssertJ's fluent API for all assertions:
+  ```java
+  // Good
+  assertThat(items).hasSize(1);
+  assertThat(items.get(0).getPayload().toByteArray()).isEqualTo(expected);
+
+  // Avoid
+  assertEquals(1, items.size());
+  assertArrayEquals(expected, items.get(0).getPayload().toByteArray());
+  ```
+- **Coverage:** New code paths must have ≥70% branch coverage. Every public method and every conditional branch in new code should have a corresponding test case.
+
+## 5. Security & Cryptography
+
+- **Random Number Generation:** Always use `java.security.SecureRandom` for any random byte generation. Never use `java.util.Random` for security-sensitive or test data generation.
+- **Input Validation:** Validate all externally-supplied data (wire messages, peer input) before processing. Check byte array lengths, protobuf field sizes, and message bounds to prevent DoS vectors.
+- **Key Material:** Never log cryptographic keys, secrets, or raw key material. Use hex-encoded identifiers (`Utils.bytesToHexString`) for logging references only.
+- **Dependency Security:** Run OWASP Dependency Check (`mvn -Psecurity verify`) periodically. Address critical and high-severity CVEs promptly.
+
+## 6. Execution & Output Rules
+
+- Always provide complete, functional code blocks. Never use placeholder comments like `// implementation goes here` or `// TODO: implement`.
+- If existing code violates these standards (e.g., using `assertEquals` instead of AssertJ, missing `StandardCharsets.UTF_8`, using `Random` instead of `SecureRandom`), proactively refactor it and briefly explain the rule violation.
+- Run `mvn spotless:apply` before any build or test command to ensure formatting compliance.
+- Build with `mvn compile` and test with `mvn test -DfailIfNoTests=false`.

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -142,36 +142,6 @@ public class InboundCommandProcessor {
           handleFlaschenpostPut(payload, peer);
           return 1 + 4 + payload.length;
         });
-    commandHandlers.put(
-        Command.OUTBOUND_REGISTER_OH_REQ,
-        (peer, buf, payload) -> {
-          try {
-            outboundService.handleRegister(peer, RegisterOhRequest.parseFrom(payload));
-          } catch (Exception e) {
-            e.printStackTrace();
-          }
-          return 1 + 4 + payload.length;
-        });
-    commandHandlers.put(
-        Command.OUTBOUND_FETCH_REQ,
-        (peer, buf, payload) -> {
-          try {
-            outboundService.handleFetch(peer, FetchRequest.parseFrom(payload));
-          } catch (Exception e) {
-            e.printStackTrace();
-          }
-          return 1 + 4 + payload.length;
-        });
-    commandHandlers.put(
-        Command.OUTBOUND_REVOKE_OH_REQ,
-        (peer, buf, payload) -> {
-          try {
-            outboundService.handleRevoke(peer, RevokeOhRequest.parseFrom(payload));
-          } catch (Exception e) {
-            e.printStackTrace();
-          }
-          return 1 + 4 + payload.length;
-        });
   }
 
   public void loopCommands(Peer peer, ByteBuffer readBuffer) {
@@ -251,7 +221,10 @@ public class InboundCommandProcessor {
         || command == Command.KADEMLIA_GET
         || command == Command.KADEMLIA_STORE
         || command == Command.KADEMLIA_GET_ANSWER
-        || command == Command.FLASCHENPOST_PUT;
+        || command == Command.FLASCHENPOST_PUT
+        || command == Command.OUTBOUND_REGISTER_OH_REQ
+        || command == Command.OUTBOUND_FETCH_REQ
+        || command == Command.OUTBOUND_REVOKE_OH_REQ;
   }
 
   private byte[] readMessage(ByteBuffer readBuffer) {

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -808,8 +808,16 @@ public class InboundCommandProcessor {
     // MS01: Direct OH routing via explicit oh_id field
     ByteString ohIdBytes = putMsg.getOhId();
     if (ohIdBytes != null && !ohIdBytes.isEmpty() && outboundService != null) {
-      if (outboundService.depositMessage(ohIdBytes.toByteArray(), content)) {
-        return;
+      // Validate OH id length before converting to a byte array to avoid large allocations
+      if (ohIdBytes.size() == KademliaId.ID_LENGTH_BYTES) {
+        if (outboundService.depositMessage(ohIdBytes.toByteArray(), content)) {
+          return;
+        }
+      } else {
+        logger.warn(
+            "Received FlaschenpostPut with invalid oh_id length: {}, expected {}",
+            ohIdBytes.size(),
+            KademliaId.ID_LENGTH_BYTES);
       }
     }
 

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -2,6 +2,7 @@ package im.redpanda.core;
 
 import static com.google.protobuf.ByteString.copyFrom;
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import im.redpanda.crypt.Utils;
 import im.redpanda.flaschenpost.GMParser;
@@ -831,7 +832,15 @@ public class InboundCommandProcessor {
     FlaschenpostPut putMsg = FlaschenpostPut.parseFrom(payload);
     byte[] content = putMsg.getContent().toByteArray();
 
-    // MS01: Try to route to a local OH mailbox before standard Kademlia routing.
+    // MS01: Direct OH routing via explicit oh_id field
+    ByteString ohIdBytes = putMsg.getOhId();
+    if (ohIdBytes != null && !ohIdBytes.isEmpty() && outboundService != null) {
+      if (outboundService.depositMessage(ohIdBytes.toByteArray(), content)) {
+        return;
+      }
+    }
+
+    // Legacy: Try to route via GarlicMessage destination header
     if (tryDepositToLocalOh(content)) {
       return;
     }

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -807,7 +807,7 @@ public class InboundCommandProcessor {
 
     // MS01: Direct OH routing via explicit oh_id field
     ByteString ohIdBytes = putMsg.getOhId();
-    if (ohIdBytes != null && !ohIdBytes.isEmpty() && outboundService != null) {
+    if (!ohIdBytes.isEmpty() && outboundService != null) {
       // Validate OH id length before converting to a byte array to avoid large allocations
       if (ohIdBytes.size() == KademliaId.ID_LENGTH_BYTES) {
         if (outboundService.depositMessage(ohIdBytes.toByteArray(), content)) {

--- a/src/main/proto/commands.proto
+++ b/src/main/proto/commands.proto
@@ -59,6 +59,7 @@ message JobAck {
 
 message FlaschenpostPut {
     bytes content = 1;
+    bytes oh_id = 2;    // 20 bytes — target OH mailbox KademliaId
 }
 
 // Unified envelope for future-proofing or batching, 

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
@@ -196,4 +196,198 @@ public class InboundCommandProcessorFlaschenpostPutTest {
 
     assertEquals(1 + 4 + putData.length, consumed);
   }
+
+  /**
+   * When {@code outboundService} is null (not configured) and {@code oh_id} is present, the handler
+   * skips direct deposit and falls through to the legacy GMParser path.
+   */
+  @Test
+  public void flaschenpostPut_withOhIdButNullOutboundService_fallsThroughToLegacy() {
+    // Build a ServerContext without OutboundService
+    ServerContext noServiceCtx = ServerContext.buildDefaultServerContext();
+    InboundCommandProcessor noServiceProc = new InboundCommandProcessor(noServiceCtx);
+
+    byte[] ohId = sampleOhId();
+    byte[] ackBytes = buildAckPayload(42);
+
+    FlaschenpostPut putMsg =
+        FlaschenpostPut.newBuilder()
+            .setContent(copyFrom(ackBytes))
+            .setOhId(ByteString.copyFrom(ohId))
+            .build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9005, noServiceCtx.getNodeId());
+    peer.setConnected(true);
+    noServiceCtx.getPeerList().add(peer);
+
+    int consumed = noServiceProc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+
+    assertEquals(1 + 4 + putData.length, consumed);
+  }
+
+  /**
+   * When {@code oh_id} is absent and the content is a valid GarlicMessage with a destination that
+   * matches a registered OH, {@code tryDepositToLocalOh} deposits the message and returns early.
+   */
+  @Test
+  public void flaschenpostPut_legacyPathDepositsViaGarlicMessageDestination() {
+    byte[] ohId = sampleOhId();
+    registerOh(ohId);
+
+    // Build a GarlicMessage-formatted payload: [1 gmType][4 overallLen][20 destinationId][data]
+    byte[] extraData = "legacy-payload-body".getBytes(StandardCharsets.UTF_8);
+    int overallLen = 4 + KademliaId.ID_LENGTH_BYTES + extraData.length;
+    ByteBuffer gm = ByteBuffer.allocate(1 + 4 + KademliaId.ID_LENGTH_BYTES + extraData.length);
+    gm.put(im.redpanda.flaschenpost.GMType.GARLIC_MESSAGE.getId());
+    gm.putInt(overallLen);
+    gm.put(ohId);
+    gm.put(extraData);
+    gm.flip();
+    byte[] gmBytes = new byte[gm.remaining()];
+    gm.get(gmBytes);
+
+    // No oh_id set → handler will try tryDepositToLocalOh → deposit succeeds
+    FlaschenpostPut putMsg = FlaschenpostPut.newBuilder().setContent(copyFrom(gmBytes)).build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9006, ctx.getNodeId());
+    peer.setConnected(true);
+    ctx.getPeerList().add(peer);
+
+    int consumed = proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+
+    assertEquals(1 + 4 + putData.length, consumed);
+
+    // Verify the message was deposited via the legacy tryDepositToLocalOh path
+    List<MailItem> items = mailboxStore.fetchMessages(ohId, 10, 0);
+    assertEquals(1, items.size());
+    assertArrayEquals(gmBytes, items.get(0).getPayload().toByteArray());
+  }
+
+  /**
+   * When {@code oh_id} is absent and content is too short for a GarlicMessage header, {@code
+   * tryDepositToLocalOh} returns false. The handler then falls through to GMParser which processes
+   * the valid ACK payload. This exercises the {@code content.length < headerLen} guard.
+   */
+  @Test
+  public void flaschenpostPut_withContentShorterThanGarlicHeader_tryDepositReturnsFalse() {
+    // ACK payload is 9 bytes, shorter than GarlicMessage header (25 bytes)
+    byte[] ackBytes = buildAckPayload(33);
+
+    FlaschenpostPut putMsg = FlaschenpostPut.newBuilder().setContent(copyFrom(ackBytes)).build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9007, ctx.getNodeId());
+    peer.setConnected(true);
+    ctx.getPeerList().add(peer);
+
+    int consumed = proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+
+    assertEquals(1 + 4 + putData.length, consumed);
+  }
+
+  /**
+   * When {@code oh_id} targets an expired OH handle, deposit fails and the handler falls through to
+   * the legacy path.
+   */
+  @Test
+  public void flaschenpostPut_withExpiredOhHandle_fallsThroughToLegacy() {
+    byte[] ohId = sampleOhId();
+    // Register with an already-expired handle
+    long now = System.currentTimeMillis();
+    HandleRecord expiredRecord = new HandleRecord(new byte[HANDLE_KEY_LENGTH], now - 2000, now - 1);
+    handleStore.put(ohId, expiredRecord);
+
+    byte[] ackBytes = buildAckPayload(77);
+    FlaschenpostPut putMsg =
+        FlaschenpostPut.newBuilder()
+            .setContent(copyFrom(ackBytes))
+            .setOhId(ByteString.copyFrom(ohId))
+            .build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9008, ctx.getNodeId());
+    peer.setConnected(true);
+    ctx.getPeerList().add(peer);
+
+    int consumed = proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+
+    assertEquals(1 + 4 + putData.length, consumed);
+
+    // Mailbox must be empty — expired handle should not accept deposit
+    List<MailItem> items = mailboxStore.fetchMessages(ohId, 10, 0);
+    assertEquals(0, items.size());
+  }
+
+  /**
+   * Multiple messages deposited to the same OH mailbox are all retrievable and maintain their
+   * ordering.
+   */
+  @Test
+  public void flaschenpostPut_multipleDepositsToSameOh_allStored() {
+    byte[] ohId = sampleOhId();
+    registerOh(ohId);
+
+    Peer peer = new Peer("127.0.0.1", 9009, ctx.getNodeId());
+    peer.setConnected(true);
+    ctx.getPeerList().add(peer);
+
+    byte[][] payloads = {
+      "msg-one".getBytes(StandardCharsets.UTF_8),
+      "msg-two".getBytes(StandardCharsets.UTF_8),
+      "msg-three".getBytes(StandardCharsets.UTF_8)
+    };
+
+    for (byte[] payload : payloads) {
+      FlaschenpostPut putMsg =
+          FlaschenpostPut.newBuilder()
+              .setContent(copyFrom(payload))
+              .setOhId(ByteString.copyFrom(ohId))
+              .build();
+      byte[] putData = putMsg.toByteArray();
+      proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+    }
+
+    List<MailItem> items = mailboxStore.fetchMessages(ohId, 10, 0);
+    assertEquals(3, items.size());
+    assertArrayEquals(payloads[0], items.get(0).getPayload().toByteArray());
+    assertArrayEquals(payloads[1], items.get(1).getPayload().toByteArray());
+    assertArrayEquals(payloads[2], items.get(2).getPayload().toByteArray());
+  }
+
+  /**
+   * When {@code oh_id} is empty bytes (zero-length), the handler treats it the same as absent and
+   * falls through to the legacy path.
+   */
+  @Test
+  public void flaschenpostPut_withEmptyOhId_usesLegacyPath() {
+    byte[] ackBytes = buildAckPayload(88);
+    FlaschenpostPut putMsg =
+        FlaschenpostPut.newBuilder()
+            .setContent(copyFrom(ackBytes))
+            .setOhId(ByteString.EMPTY)
+            .build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9010, ctx.getNodeId());
+    peer.setConnected(true);
+    ctx.getPeerList().add(peer);
+
+    int consumed = proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+
+    assertEquals(1 + 4 + putData.length, consumed);
+  }
+
+  /** Builds a minimal GMAck payload: [1 type][4 len][4 ackId]. */
+  private static byte[] buildAckPayload(int ackId) {
+    ByteBuffer ack = ByteBuffer.allocate(1 + 4 + 4);
+    ack.put(im.redpanda.flaschenpost.GMType.ACK.getId());
+    ack.putInt(4);
+    ack.putInt(ackId);
+    ack.flip();
+    byte[] bytes = new byte[ack.remaining()];
+    ack.get(bytes);
+    return bytes;
+  }
 }

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
@@ -1,0 +1,199 @@
+package im.redpanda.core;
+
+import static com.google.protobuf.ByteString.copyFrom;
+import static org.junit.Assert.*;
+
+import com.google.protobuf.ByteString;
+import im.redpanda.outbound.OutboundHandleStore;
+import im.redpanda.outbound.OutboundHandleStore.HandleRecord;
+import im.redpanda.outbound.OutboundMailboxStore;
+import im.redpanda.outbound.OutboundService;
+import im.redpanda.outbound.v1.MailItem;
+import im.redpanda.proto.FlaschenpostPut;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for the {@code oh_id} routing path introduced in MS01 for {@code FLASCHENPOST_PUT} handling
+ * in {@link InboundCommandProcessor}.
+ *
+ * <p>Covers: direct-OH deposit when {@code oh_id} is present and registered, fall-through to legacy
+ * GMParser when deposit is not applicable, and backward compatibility when {@code oh_id} is absent.
+ */
+public class InboundCommandProcessorFlaschenpostPutTest {
+
+  private static final int HANDLE_KEY_LENGTH = 32;
+  private static final long HANDLE_EXPIRY_MILLIS = 60_000;
+
+  private ServerContext ctx;
+  private InboundCommandProcessor proc;
+  private OutboundHandleStore handleStore;
+  private OutboundMailboxStore mailboxStore;
+
+  @Before
+  public void setup() {
+    ctx = ServerContext.buildDefaultServerContext();
+    handleStore = new OutboundHandleStore();
+    mailboxStore = new OutboundMailboxStore();
+    OutboundService outboundService = new OutboundService(handleStore, mailboxStore);
+    ctx.setOutboundService(outboundService);
+    proc = new InboundCommandProcessor(ctx);
+  }
+
+  /** Builds a [4-byte len][payload] frame as expected by {@code parseCommand}. */
+  private static ByteBuffer buildFrame(byte[] payload) {
+    ByteBuffer buf = ByteBuffer.allocate(4 + payload.length);
+    buf.putInt(payload.length);
+    buf.put(payload);
+    buf.flip();
+    return buf;
+  }
+
+  /** Returns a 20-byte oh_id suitable for registration and deposit tests. */
+  private static byte[] sampleOhId() {
+    byte[] id = new byte[KademliaId.ID_LENGTH_BYTES];
+    for (int i = 0; i < id.length; i++) {
+      id[i] = (byte) (i + 1);
+    }
+    return id;
+  }
+
+  /** Registers an OH handle with a future expiry in the in-memory handle store. */
+  private void registerOh(byte[] ohId) {
+    long now = System.currentTimeMillis();
+    HandleRecord record =
+        new HandleRecord(new byte[HANDLE_KEY_LENGTH], now, now + HANDLE_EXPIRY_MILLIS);
+    handleStore.put(ohId, record);
+  }
+
+  /**
+   * When {@code oh_id} is present and matches a registered OH, the message is deposited directly
+   * into the mailbox and the handler returns early (GMParser is not invoked).
+   */
+  @Test
+  public void flaschenpostPut_withValidRegisteredOhId_depositsToMailbox() {
+    byte[] ohId = sampleOhId();
+    registerOh(ohId);
+
+    byte[] content = "direct-oh-payload".getBytes(StandardCharsets.UTF_8);
+    FlaschenpostPut putMsg =
+        FlaschenpostPut.newBuilder()
+            .setContent(copyFrom(content))
+            .setOhId(ByteString.copyFrom(ohId))
+            .build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9001, ctx.getNodeId());
+    peer.setConnected(true);
+    ctx.getPeerList().add(peer);
+
+    int consumed = proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+
+    assertEquals(1 + 4 + putData.length, consumed);
+
+    // Verify the message was deposited into the mailbox (confirms early return via oh_id path)
+    List<MailItem> items = mailboxStore.fetchMessages(ohId, 10, 0);
+    assertEquals(1, items.size());
+    assertArrayEquals(content, items.get(0).getPayload().toByteArray());
+  }
+
+  /**
+   * When {@code oh_id} is present but no matching OH is registered (deposit returns false), the
+   * handler falls through to the legacy GMParser path and completes without error.
+   */
+  @Test
+  public void flaschenpostPut_withOhIdButNoRegisteredOh_fallsThroughToLegacy() {
+    byte[] ohId = sampleOhId();
+    // Intentionally skip registerOh() so depositMessage returns false
+
+    // Use a valid GMAck payload so the legacy GMParser path handles it gracefully
+    ByteBuffer ack = ByteBuffer.allocate(1 + 4 + 4);
+    ack.put(im.redpanda.flaschenpost.GMType.ACK.getId());
+    ack.putInt(4);
+    ack.putInt(99);
+    ack.flip();
+    byte[] ackBytes = new byte[ack.remaining()];
+    ack.get(ackBytes);
+
+    FlaschenpostPut putMsg =
+        FlaschenpostPut.newBuilder()
+            .setContent(copyFrom(ackBytes))
+            .setOhId(ByteString.copyFrom(ohId))
+            .build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9002, ctx.getNodeId());
+    peer.setConnected(true);
+    ctx.getPeerList().add(peer);
+
+    int consumed = proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+
+    assertEquals(1 + 4 + putData.length, consumed);
+
+    // Mailbox must be empty – deposit was not performed
+    List<MailItem> items = mailboxStore.fetchMessages(ohId, 10, 0);
+    assertEquals(0, items.size());
+  }
+
+  /**
+   * When {@code oh_id} has an invalid byte length, the handler logs a warning and falls through to
+   * the legacy GMParser path without throwing.
+   */
+  @Test
+  public void flaschenpostPut_withInvalidOhIdLength_fallsThroughToLegacy() {
+    byte[] wrongLengthId = new byte[5]; // too short, not ID_LENGTH_BYTES
+
+    ByteBuffer ack = ByteBuffer.allocate(1 + 4 + 4);
+    ack.put(im.redpanda.flaschenpost.GMType.ACK.getId());
+    ack.putInt(4);
+    ack.putInt(7);
+    ack.flip();
+    byte[] ackBytes = new byte[ack.remaining()];
+    ack.get(ackBytes);
+
+    FlaschenpostPut putMsg =
+        FlaschenpostPut.newBuilder()
+            .setContent(copyFrom(ackBytes))
+            .setOhId(ByteString.copyFrom(wrongLengthId))
+            .build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9003, ctx.getNodeId());
+    peer.setConnected(true);
+    ctx.getPeerList().add(peer);
+
+    int consumed = proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+
+    assertEquals(1 + 4 + putData.length, consumed);
+  }
+
+  /**
+   * When {@code oh_id} is absent (pre-MS01 message), the handler uses the legacy GMParser path.
+   * This ensures backward compatibility with messages that do not carry an explicit {@code oh_id}.
+   */
+  @Test
+  public void flaschenpostPut_withoutOhId_usesLegacyPathWithoutError() {
+    // Build GMAck payload with no oh_id field – mimics pre-MS01 behavior
+    ByteBuffer ack = ByteBuffer.allocate(1 + 4 + 4);
+    ack.put(im.redpanda.flaschenpost.GMType.ACK.getId());
+    ack.putInt(4);
+    ack.putInt(55);
+    ack.flip();
+    byte[] ackBytes = new byte[ack.remaining()];
+    ack.get(ackBytes);
+
+    FlaschenpostPut putMsg = FlaschenpostPut.newBuilder().setContent(copyFrom(ackBytes)).build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9004, ctx.getNodeId());
+    peer.setConnected(true);
+    ctx.getPeerList().add(peer);
+
+    int consumed = proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+
+    assertEquals(1 + 4 + putData.length, consumed);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `bytes oh_id = 2` field to `FlaschenpostPut` protobuf message
- `handleFlaschenpostPut` now checks `oh_id` first and deposits directly into the target OH mailbox via `outboundService.depositMessage()`
- Falls back to legacy `tryDepositToLocalOh` / `GMParser.parse` path when `oh_id` is absent (backward compatible)

## Problem
`FlaschenpostPut.content` contains raw encrypted bytes `[IV|ciphertext|HMAC]`, not a GarlicMessage. Without an explicit `oh_id`, the backend tried to parse the first byte as GMType, causing `RuntimeException: Unknown GMType at parsing: -26`.

## Test plan
- [ ] Unit test: `handleFlaschenpostPut` with `oh_id` set → message deposited to OH mailbox, no GMParser call
- [ ] Legacy path: `FlaschenpostPut` without `oh_id` still works via `tryDepositToLocalOh` / `GMParser`
- [ ] E2E: Alice sends message → backend routes via `oh_id` → Bob fetches → plaintext matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)