### PR TITLE
fix: effective per-candidate best-route selection in GMParser (B3)

### DIFF
--- a/src/main/java/im/redpanda/flaschenpost/GMParser.java
+++ b/src/main/java/im/redpanda/flaschenpost/GMParser.java
@@ -76,6 +76,11 @@ public class GMParser {
     double bestWeight = maxWeight;
     Peer bestPeer = null;
 
+    if (targetNode == null) {
+      // Destination unknown to the NodeStore — no route can be computed.
+      return new RouteSelection(null, maxWeight);
+    }
+
     for (Peer peer : candidates) {
       Node peerNode = peer.getNode();
       if (peerNode == null) {

--- a/src/main/java/im/redpanda/flaschenpost/GMParser.java
+++ b/src/main/java/im/redpanda/flaschenpost/GMParser.java
@@ -30,7 +30,96 @@ import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
 @Slf4j
 public class GMParser {
 
+  /**
+   * Upper bound on the total route weight a candidate peer may have to still be selected. Kept at
+   * the historical value (20) so single-candidate / well-connected behavior is unchanged.
+   */
+  static final double MAX_ROUTE_WEIGHT = 20;
+
   private GMParser() {}
+
+  /**
+   * Result of {@link #selectBestRoutePeer}: the chosen candidate peer (or {@code null} if none has
+   * a route below the bound) and the total weight of its route.
+   */
+  record RouteSelection(Peer peer, double weight) {}
+
+  /**
+   * Selects the candidate peer that yields the cheapest route to {@code targetNode}.
+   *
+   * <p>The total cost of routing through a candidate is the weight of the edge {@code self ->
+   * candidate.getNode()} (our directly-measured link quality to that neighbour) plus the weight of
+   * the shortest path from the candidate's node onward to the target. This is the formulation the
+   * weighted {@link NodeEdge} graph is built for ({@code NodeStore} adds self↔peer edges and
+   * weights them by link performance), and — unlike the previous code — it actually depends on the
+   * candidate being evaluated.
+   *
+   * <p>The previous implementation computed {@code findPathBetween(self, target)} inside the loop,
+   * which is independent of the candidate, so the first peer in {@link TreeSet} order always won
+   * and Dijkstra ran |peers| times for nothing.
+   *
+   * @param graph the weighted node graph
+   * @param self the local node (route origin)
+   * @param candidates candidate next-hop peers, already filtered to connected non-light-client
+   *     peers
+   * @param targetNode the destination node (may be {@code null} if unknown to the graph)
+   * @param maxWeight inclusive-exclusive upper bound; candidates with total weight {@code >=} this
+   *     are ignored
+   * @return the best candidate and its total weight; {@code peer()} is {@code null} if none qualify
+   */
+  static RouteSelection selectBestRoutePeer(
+      org.jgrapht.Graph<Node, NodeEdge> graph,
+      Node self,
+      Iterable<Peer> candidates,
+      Node targetNode,
+      double maxWeight) {
+    double bestWeight = maxWeight;
+    Peer bestPeer = null;
+
+    for (Peer peer : candidates) {
+      Node peerNode = peer.getNode();
+      if (peerNode == null) {
+        continue;
+      }
+
+      // Cost of our direct link to this candidate next hop.
+      double firstHopWeight;
+      NodeEdge selfToPeer =
+          graph.containsVertex(self) && graph.containsVertex(peerNode)
+              ? graph.getEdge(self, peerNode)
+              : null;
+      if (selfToPeer == null) {
+        // No known direct edge to this candidate — it cannot be our next hop.
+        continue;
+      }
+      firstHopWeight = graph.getEdgeWeight(selfToPeer);
+
+      // Cost of the remaining path from the candidate onward to the target.
+      double remainingWeight;
+      if (peerNode.equals(targetNode)) {
+        remainingWeight = 0;
+      } else {
+        GraphPath<Node, NodeEdge> path = null;
+        try {
+          path = DijkstraShortestPath.findPathBetween(graph, peerNode, targetNode);
+        } catch (IllegalArgumentException ignored) {
+          // peerNode or targetNode not in graph
+        }
+        if (path == null) {
+          continue;
+        }
+        remainingWeight = path.getWeight();
+      }
+
+      double totalWeight = firstHopWeight + remainingWeight;
+      if (totalWeight < bestWeight) {
+        bestWeight = totalWeight;
+        bestPeer = peer;
+      }
+    }
+
+    return new RouteSelection(bestPeer, bestPeer == null ? maxWeight : bestWeight);
+  }
 
   public static GMContent parse(ServerContext serverContext, byte[] content) {
 
@@ -180,28 +269,15 @@ public class GMParser {
       }
 
       Node targetNode = serverContext.getNodeStore().get(garlicMessage.destination);
-      double shortestPathWeight = 20;
-      Peer peerWithShortestPath = null;
-      for (Peer peer : peers) {
-
-        GraphPath<Node, NodeEdge> path = null;
-        try {
-          path =
-              DijkstraShortestPath.findPathBetween(
-                  serverContext.getNodeStore().getNodeGraph(), serverContext.getNode(), targetNode);
-        } catch (IllegalArgumentException ignored) {
-          // nothing to do
-        }
-
-        if (path == null) {
-          continue;
-        }
-        double weight = path.getWeight();
-        if (weight < shortestPathWeight) {
-          shortestPathWeight = weight;
-          peerWithShortestPath = peer;
-        }
-      }
+      RouteSelection selection =
+          selectBestRoutePeer(
+              serverContext.getNodeStore().getNodeGraph(),
+              serverContext.getNode(),
+              peers,
+              targetNode,
+              MAX_ROUTE_WEIGHT);
+      double shortestPathWeight = selection.weight();
+      Peer peerWithShortestPath = selection.peer();
 
       if (peerWithShortestPath != null) {
         sendFpToPeer(peerWithShortestPath, content);

--- a/src/test/java/im/redpanda/flaschenpost/GMParserAdditionalTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/GMParserAdditionalTest.java
@@ -277,8 +277,6 @@ public class GMParserAdditionalTest {
         serverContext.getNodeStore().getNodeGraph();
     graph.addVertex(selfNode);
     graph.addVertex(destinationNode);
-    NodeEdge edge = graph.addEdge(selfNode, destinationNode);
-    graph.setEdgeWeight(edge, 4.0);
 
     NodeInfoModel nodeInfoModel = new NodeInfoModel();
     KadContent kadContent =
@@ -296,6 +294,12 @@ public class GMParserAdditionalTest {
     byte[] content = garlicMessageBytes(serverContext, destination);
     goodPeer.writeBuffer = ByteBuffer.allocate(content.length + BUFFER_PADDING);
     serverContext.getPeerList().add(goodPeer);
+
+    // A real route through goodPeer: self -> goodPeer -> destination. Under correct routing the
+    // candidate must have a direct edge from self and a path onward to the target to be selected.
+    graph.addVertex(goodPeer.getNode());
+    graph.setEdgeWeight(graph.addEdge(selfNode, goodPeer.getNode()), 2.0);
+    graph.setEdgeWeight(graph.addEdge(goodPeer.getNode(), destinationNode), 2.0);
 
     GMParser.parse(serverContext, content);
 
@@ -433,8 +437,6 @@ public class GMParserAdditionalTest {
         serverContext.getNodeStore().getNodeGraph();
     graph.addVertex(selfNode);
     graph.addVertex(destinationNode);
-    NodeEdge edge = graph.addEdge(selfNode, destinationNode);
-    graph.setEdgeWeight(edge, 2.0);
 
     NodeInfoModel nodeInfoModel = new NodeInfoModel();
     KadContent kadContent =
@@ -462,9 +464,128 @@ public class GMParserAdditionalTest {
     serverContext.getPeerList().add(firstPeer);
     serverContext.getPeerList().add(secondPeer);
 
+    // Two equal-cost real routes (self -> peer -> destination, total 2 each). This exercises the
+    // "not strictly less" branch: whichever peer is iterated first stays selected and the other
+    // does not replace it.
+    graph.addVertex(firstPeer.getNode());
+    graph.addVertex(secondPeer.getNode());
+    graph.setEdgeWeight(graph.addEdge(selfNode, firstPeer.getNode()), 1.0);
+    graph.setEdgeWeight(graph.addEdge(firstPeer.getNode(), destinationNode), 1.0);
+    graph.setEdgeWeight(graph.addEdge(selfNode, secondPeer.getNode()), 1.0);
+    graph.setEdgeWeight(graph.addEdge(secondPeer.getNode(), destinationNode), 1.0);
+
     GMParser.parse(serverContext, content);
 
     assertTrue(firstPeer.setWriteBufferCalled || secondPeer.setWriteBufferCalled);
+  }
+
+  /**
+   * Regression test for B3: the candidate that yields the cheapest route must be chosen even when
+   * it is not the first candidate in iteration order. The previous implementation computed the path
+   * {@code self -> target} independent of the candidate, so the first candidate always won.
+   *
+   * <p>Graph: self has a cheap direct link to peerB (weight 1) and an expensive one to peerA
+   * (weight 10); both peers reach the target with weight 1. peerA is iterated first but peerB is
+   * the correct (cheaper) next hop.
+   */
+  @Test
+  public void selectBestRoutePeer_picksCheapestRouteNotFirstCandidate() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+
+    Node selfNode = new Node(serverContext, serverContext.getNodeId());
+    Node targetNode = new Node(serverContext, NodeId.generateWithSimpleKey());
+
+    TestPeer peerA = authedPeerWithNode(serverContext, "10.1.0.1", 1);
+    TestPeer peerB = authedPeerWithNode(serverContext, "10.1.0.2", 2);
+    Node peerANode = peerA.getNode();
+    Node peerBNode = peerB.getNode();
+
+    DefaultDirectedWeightedGraph<Node, NodeEdge> graph =
+        new DefaultDirectedWeightedGraph<>(NodeEdge.class);
+    graph.addVertex(selfNode);
+    graph.addVertex(targetNode);
+    graph.addVertex(peerANode);
+    graph.addVertex(peerBNode);
+
+    graph.setEdgeWeight(graph.addEdge(selfNode, peerANode), 10.0);
+    graph.setEdgeWeight(graph.addEdge(selfNode, peerBNode), 1.0);
+    graph.setEdgeWeight(graph.addEdge(peerANode, targetNode), 1.0);
+    graph.setEdgeWeight(graph.addEdge(peerBNode, targetNode), 1.0);
+
+    // peerA iterated first, but peerB (total 1+1=2) beats peerA (total 10+1=11).
+    java.util.List<Peer> candidates = java.util.List.of(peerA, peerB);
+
+    GMParser.RouteSelection selection =
+        GMParser.selectBestRoutePeer(
+            graph, selfNode, candidates, targetNode, GMParser.MAX_ROUTE_WEIGHT);
+
+    assertEquals(peerB, selection.peer());
+    assertEquals(2.0, selection.weight(), 1e-9);
+  }
+
+  /** A single candidate must be chosen when it has a valid route (behavior parity). */
+  @Test
+  public void selectBestRoutePeer_singleCandidateIsChosen() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+
+    Node selfNode = new Node(serverContext, serverContext.getNodeId());
+    Node targetNode = new Node(serverContext, NodeId.generateWithSimpleKey());
+
+    TestPeer peer = authedPeerWithNode(serverContext, "10.2.0.1", 1);
+    Node peerNode = peer.getNode();
+
+    DefaultDirectedWeightedGraph<Node, NodeEdge> graph =
+        new DefaultDirectedWeightedGraph<>(NodeEdge.class);
+    graph.addVertex(selfNode);
+    graph.addVertex(targetNode);
+    graph.addVertex(peerNode);
+    graph.setEdgeWeight(graph.addEdge(selfNode, peerNode), 3.0);
+    graph.setEdgeWeight(graph.addEdge(peerNode, targetNode), 2.0);
+
+    GMParser.RouteSelection selection =
+        GMParser.selectBestRoutePeer(
+            graph, selfNode, java.util.List.of(peer), targetNode, GMParser.MAX_ROUTE_WEIGHT);
+
+    assertEquals(peer, selection.peer());
+    assertEquals(5.0, selection.weight(), 1e-9);
+  }
+
+  /** No candidate has a known direct edge from self → none is selected. */
+  @Test
+  public void selectBestRoutePeer_returnsNullWhenNoDirectEdge() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+
+    Node selfNode = new Node(serverContext, serverContext.getNodeId());
+    Node targetNode = new Node(serverContext, NodeId.generateWithSimpleKey());
+
+    TestPeer peer = authedPeerWithNode(serverContext, "10.3.0.1", 1);
+    Node peerNode = peer.getNode();
+
+    DefaultDirectedWeightedGraph<Node, NodeEdge> graph =
+        new DefaultDirectedWeightedGraph<>(NodeEdge.class);
+    graph.addVertex(selfNode);
+    graph.addVertex(targetNode);
+    graph.addVertex(peerNode);
+    // Only an edge from the peer onward — no self -> peer edge.
+    graph.setEdgeWeight(graph.addEdge(peerNode, targetNode), 1.0);
+
+    GMParser.RouteSelection selection =
+        GMParser.selectBestRoutePeer(
+            graph, selfNode, java.util.List.of(peer), targetNode, GMParser.MAX_ROUTE_WEIGHT);
+
+    assertNull(selection.peer());
+  }
+
+  /**
+   * Builds an authed + connected peer with a Node attached, so {@link Peer#getNode()} returns the
+   * node (it returns null for un-authed / disconnected peers).
+   */
+  private static TestPeer authedPeerWithNode(ServerContext serverContext, String ip, int port) {
+    TestPeer peer = new TestPeer(ip, port, NodeId.generateWithSimpleKey());
+    peer.authed = true;
+    peer.setConnected(true);
+    peer.setNode(new Node(serverContext, peer.getNodeId()));
+    return peer;
   }
 
   @Test

--- a/src/test/java/im/redpanda/flaschenpost/GMParserAdditionalTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/GMParserAdditionalTest.java
@@ -577,6 +577,31 @@ public class GMParserAdditionalTest {
   }
 
   /**
+   * A null target (destination unknown to the NodeStore) must yield no selection instead of
+   * crashing inside Dijkstra with a NullPointerException.
+   */
+  @Test
+  public void selectBestRoutePeer_nullTargetYieldsNoSelection() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+
+    Node selfNode = new Node(serverContext, serverContext.getNodeId());
+    TestPeer peer = authedPeerWithNode(serverContext, "10.4.0.1", 1);
+    Node peerNode = peer.getNode();
+
+    DefaultDirectedWeightedGraph<Node, NodeEdge> graph =
+        new DefaultDirectedWeightedGraph<>(NodeEdge.class);
+    graph.addVertex(selfNode);
+    graph.addVertex(peerNode);
+    graph.setEdgeWeight(graph.addEdge(selfNode, peerNode), 1.0);
+
+    GMParser.RouteSelection selection =
+        GMParser.selectBestRoutePeer(
+            graph, selfNode, java.util.List.of(peer), null, GMParser.MAX_ROUTE_WEIGHT);
+
+    assertNull(selection.peer());
+  }
+
+  /**
    * Builds an authed + connected peer with a Node attached, so {@link Peer#getNode()} returns the
    * node (it returns null for un-authed / disconnected peers).
    */


### PR DESCRIPTION
## Finding B3 (VISION_CODE_REVIEW §3.2 / ARCHITEKTUR_ANALYSE F5) — ineffective best-route selection

`GMParser.sendGarlicMessageToPeer()` looped over candidate peers and, in every iteration, computed:

```java
path = DijkstraShortestPath.findPathBetween(graph, serverContext.getNode(), targetNode);
```

This path is **independent of the candidate peer**, so the compared weight was identical every iteration. Effectively the first peer in `TreeSet` order always won, and Dijkstra ran `|peers|` times for nothing. MS04 (multi-hop relay) is meant to build on this code.

## Change

Extracted the selection into a package-private, unit-testable static method `selectBestRoutePeer(graph, self, candidates, targetNode, maxWeight)`.

For each candidate it now computes the **actual route cost through that candidate**:

```
total = weight(self -> candidate.getNode())          // our direct link to the next hop
      + shortestPath(candidate.getNode() -> target)  // remaining path onward
```

- `self -> candidate` is the directly-measured link weight — the formulation the weighted `NodeEdge` graph is built for (`NodeStore.addServerEdges()` adds self↔peer edges; `PeerPerformanceTest*` weights them by link quality).
- A candidate with no known `self -> candidate` edge cannot be a next hop and is skipped.
- The candidate with the lowest total weight below `MAX_ROUTE_WEIGHT` (the historical bound of 20) is chosen.
- **Single-candidate behavior is unchanged**: one candidate with a valid route still wins.

The call site is unchanged in effect; it just consumes the returned `RouteSelection(peer, weight)`.

## Tests (`GMParserAdditionalTest`)
- `selectBestRoutePeer_picksCheapestRouteNotFirstCandidate` (the regression test): builds a graph where the **first** candidate in iteration order has the worse route (`self->A`=10, `self->B`=1, both `->target`=1) and asserts the cheaper second candidate **B** is chosen with total weight 2. This fails under the old self->target formulation.
- `selectBestRoutePeer_singleCandidateIsChosen`, `selectBestRoutePeer_returnsNullWhenNoDirectEdge`.
- Two pre-existing graph-routing tests (`graphRoutingSelectsPeerWithShortestPath`, `shortestPathBranchFalseWhenEqualWeight`) only passed because of the bug — they had a `self->destination` edge but no `self->peer` edge. Updated them to build a real `self -> peer -> destination` route so the selected peer is a genuinely valid next hop.

`mvn test`: 202 run, 0 failures, 1 skipped (flaky `InboundCommandProcessorAsyncUpdatesTest` did not fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)