### PR TITLE
docs: sync milestone mirrors (MS02b/MS03b views, status overview)

### DIFF
--- a/milestones/00_status_overview.md
+++ b/milestones/00_status_overview.md
@@ -1,6 +1,6 @@
 # Backend Milestones — Status Overview
 
-> Last updated: 2026-06-10
+> Last updated: 2026-06-11
 
 Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den fertigen Backend-APIs auf.
 
@@ -18,7 +18,9 @@ Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den
 |----|-------|--------|----------------------|
 | [MS01](ms01_first_real_message.md) | OH Service Stabilization | Done (PoC) | Frontend MS01 kann starten |
 | [MS02](ms02_reliable_delivery.md) | Reliable Mailbox & Lifecycle | Done | Frontend MS02 kann starten |
+| [MS02b](ms02b_oh_discovery_forwarding.md) | OH Discovery & Forwarding | Missing | Messaging über Node-Grenzen hinweg; Deposit-Härtung |
 | [MS03](ms03_authenticated_encryption.md) | Crypto Migration (Ed25519/X25519/GCM) | Missing | Frontend MS03 blocked — Handshake-Protokoll muss zuerst stehen |
+| [MS03b](ms03b_forward_secrecy.md) | Forward Secrecy | Missing | Minimaler Backend-Anteil — Ratchet ist Ende-zu-Ende zwischen Clients |
 | [MS04](ms04_multi_hop_garlic.md) | Multi-Hop Relay | Partial | Frontend MS04 blocked — Relay-Peeling muss serverseitig funktionieren |
 | [MS05](ms05_reverse_garlic.md) | Reverse Garlic (Relay-Seite) | Missing | Frontend MS05 blocked — CMD_DELIVER mit session_tag muss funktionieren |
 | [MS06](ms06_two_layer_ack.md) | R-ACK Generation | Missing | Frontend MS06 blocked — OH muss R-ACK erzeugen können |

--- a/milestones/ms02b_oh_discovery_forwarding.md
+++ b/milestones/ms02b_oh_discovery_forwarding.md
@@ -1,0 +1,40 @@
+# Backend MS02b: OH Discovery & Forwarding
+
+## Status: Missing
+
+> **Master-Spec**: [../ms02b_oh_discovery_forwarding.md](../ms02b_oh_discovery_forwarding.md) — MS02b ist fast vollständig Backend-Arbeit; dies ist die Backend-Sicht.
+> **Frontend-Alignment**: [Frontend MS02b](../frontend/ms02b_oh_discovery_forwarding.md) (kleiner Anteil).
+
+## Warum
+
+Heute funktioniert OH-Zustellung nur, wenn der Sender direkt mit dem OH-Host des Empfängers
+verbunden ist: `GMParser.sendFpToPeer()` baut die weitergeleitete `FlaschenpostPut` ohne das
+`oh_id`-Feld neu auf, und es gibt keine OH→Node-Auflösung. Außerdem ist `depositMessage()`
+unauthentifiziert und die Mailbox evictet drop-oldest — ein Angreifer mit bekannter `oh_id`
+kann echte Nachrichten still verdrängen (Mailbox-Flush).
+
+## Scope (Backend)
+
+1. **Forwarding-Entscheidung** (Option A/B, siehe Master-Spec): `oh_id` beim Forwarding
+   erhalten (`sendFpToPeer()` um `oh_id`-Parameter erweitern) **oder** Zustellung
+   ausschließlich über die Garlic-Destination und den expliziten `oh_id`-Pfad auf direkte
+   Light-Client-Verbindungen beschränken und dokumentieren.
+2. **OH→Node-Auflösung**: DHT-Announce `H(oh_id) → NodeInfo` mit Padding/Delay gegen
+   Lookup-Profiling (der QR-Endpoint im Channel bleibt der kurzfristige Pfad).
+3. **Deposit-Härtung**: reject-new-Eviction bei voller Mailbox (statt drop-oldest),
+   Größenlimit pro `MailItem`, Byte-Quota pro Mailbox, Register-Rate-Limit pro Verbindung.
+   Die Proto-Status-Codes `RATE_LIMIT` / `QUOTA_EXCEEDED` / `BAD_REQUEST` existieren bereits
+   und werden hier erstmals gesendet.
+4. **`oh_id`-Domänentrennung** gegenüber Node-KademliaIds (z. B. `H(domain_tag || pubkey)`)
+   oder geplante Abkündigung des Legacy-Garlic-Header-Fallbacks.
+
+## Betroffene Dateien (erwartet)
+
+| Datei | Änderung |
+|-------|----------|
+| `flaschenpost/GMParser.java` | `oh_id` beim Forwarding erhalten bzw. Pfad-Einschränkung |
+| `outbound/OutboundService.java` | Eviction-Strategie, Quotas, Rate-Limit, Status-Codes |
+| `outbound/OutboundMailboxStore.java` | reject-new statt drop-oldest, Byte-Zählung |
+| `kademlia/…` | OH-Announce/Lookup mit Anti-Profiling-Maßnahmen |
+
+Akzeptanzkriterien und Open Questions: siehe Master-Spec.

--- a/milestones/ms02b_oh_discovery_forwarding.md
+++ b/milestones/ms02b_oh_discovery_forwarding.md
@@ -2,8 +2,8 @@
 
 ## Status: Missing
 
-> **Master-Spec**: [../ms02b_oh_discovery_forwarding.md](../ms02b_oh_discovery_forwarding.md) — MS02b ist fast vollständig Backend-Arbeit; dies ist die Backend-Sicht.
-> **Frontend-Alignment**: [Frontend MS02b](../frontend/ms02b_oh_discovery_forwarding.md) (kleiner Anteil).
+> **Master-Spec**: [Master-Spec im docs-Repo](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms02b_oh_discovery_forwarding.md) — MS02b ist fast vollständig Backend-Arbeit; dies ist die Backend-Sicht.
+> **Frontend-Alignment**: [Frontend MS02b](https://github.com/redPanda-project/docs/blob/main/docs/milestones/frontend/ms02b_oh_discovery_forwarding.md) (kleiner Anteil).
 
 ## Warum
 

--- a/milestones/ms03_authenticated_encryption.md
+++ b/milestones/ms03_authenticated_encryption.md
@@ -2,6 +2,13 @@
 
 ## Status: Missing
 
+> **Update 2026-06-11**: Die Master-Spec wurde um das **Message-Format v2** (HKDF-Schlüssel-
+> trennung, Version-Byte, inneres `ChannelMessage`) und das **Versions-/Algorithmus-Byte in
+> allen Signing-Byte-Formaten** erweitert — siehe
+> [../ms03_authenticated_encryption.md](../ms03_authenticated_encryption.md). Das Payload-
+> Format v2 ist client-seitig bereits shipped (Server behandelt Payloads opak — keine
+> Backend-Änderung); das Signing-Versions-Byte ist Teil dieses Backend-Milestones.
+
 > **Frontend-Alignment**: Backend MS03 ist Voraussetzung für [Frontend MS03](../frontend/ms03_authenticated_encryption.md).
 > Das neue Handshake-Protokoll (v23) und das Garlic-Wire-Format müssen zuerst auf dem Server stehen.
 

--- a/milestones/ms03_authenticated_encryption.md
+++ b/milestones/ms03_authenticated_encryption.md
@@ -2,12 +2,13 @@
 
 ## Status: Missing
 
-> **Update 2026-06-11**: Die Master-Spec wurde um das **Message-Format v2** (HKDF-Schlüssel-
-> trennung, Version-Byte, inneres `ChannelMessage`) und das **Versions-/Algorithmus-Byte in
-> allen Signing-Byte-Formaten** erweitert — siehe
-> [../ms03_authenticated_encryption.md](../ms03_authenticated_encryption.md). Das Payload-
-> Format v2 ist client-seitig bereits shipped (Server behandelt Payloads opak — keine
-> Backend-Änderung); das Signing-Versions-Byte ist Teil dieses Backend-Milestones.
+> **Update 2026-06-11**: Die Master-Spec wurde um das **Message-Format v2**
+> (HKDF-Schlüsseltrennung, Version-Byte, inneres `ChannelMessage`) und das
+> **Versions-/Algorithmus-Byte in allen Signing-Byte-Formaten** erweitert — siehe
+> [Master-Spec im docs-Repo](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms03_authenticated_encryption.md).
+> Das Payload-Format v2 ist client-seitig bereits shipped (Server behandelt Payloads
+> opak — keine Backend-Änderung); das Signing-Versions-Byte ist Teil dieses
+> Backend-Milestones.
 
 > **Frontend-Alignment**: Backend MS03 ist Voraussetzung für [Frontend MS03](../frontend/ms03_authenticated_encryption.md).
 > Das neue Handshake-Protokoll (v23) und das Garlic-Wire-Format müssen zuerst auf dem Server stehen.

--- a/milestones/ms03b_forward_secrecy.md
+++ b/milestones/ms03b_forward_secrecy.md
@@ -2,10 +2,10 @@
 
 ## Status: Missing (minimaler Backend-Anteil)
 
-> **Master-Spec**: [../ms03b_forward_secrecy.md](../ms03b_forward_secrecy.md) — der Ratchet
+> **Master-Spec**: [Master-Spec im docs-Repo](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms03b_forward_secrecy.md) — der Ratchet
 > läuft Ende-zu-Ende zwischen den Clients; Relays und OH-Mailboxen transportieren weiterhin
 > opake Payloads.
-> **Frontend-Alignment**: [Frontend MS03b](../frontend/ms03b_forward_secrecy.md) (Hauptanteil).
+> **Frontend-Alignment**: [Frontend MS03b](https://github.com/redPanda-project/docs/blob/main/docs/milestones/frontend/ms03b_forward_secrecy.md) (Hauptanteil).
 
 ## Scope (Backend)
 

--- a/milestones/ms03b_forward_secrecy.md
+++ b/milestones/ms03b_forward_secrecy.md
@@ -1,0 +1,22 @@
+# Backend MS03b: Forward Secrecy
+
+## Status: Missing (minimaler Backend-Anteil)
+
+> **Master-Spec**: [../ms03b_forward_secrecy.md](../ms03b_forward_secrecy.md) — der Ratchet
+> läuft Ende-zu-Ende zwischen den Clients; Relays und OH-Mailboxen transportieren weiterhin
+> opake Payloads.
+> **Frontend-Alignment**: [Frontend MS03b](../frontend/ms03b_forward_secrecy.md) (Hauptanteil).
+
+## Scope (Backend)
+
+1. **Stage 1 (symmetrischer HKDF-Ratchet): voraussichtlich keine Backend-Änderung.**
+   Die Payload bleibt für den Server ein opaker Byte-Block; Format-Änderungen finden
+   innerhalb des verschlüsselten Containers statt.
+2. **Verifikation statt Implementierung**: Sicherstellen, dass kein Backend-Codepfad Annahmen
+   über das innere Payload-Format trifft (Deposit, Mailbox, Forwarding behandeln `payload`
+   als Bytes — Stand heute erfüllt).
+3. **Größenbudget prüfen**: Ratchet-Header (Counter, ggf. ephemere Keys in Stage 2) vergrößern
+   die Payload — muss innerhalb der Flaschenpost-Limits bleiben (relevant für MS04-Padding,
+   2048-Byte-Pakete).
+
+Akzeptanzkriterien und Open Questions: siehe Master-Spec.


### PR DESCRIPTION
Mirror sync generated by `scripts/sync_milestones.sh` from the docs repo (source of truth — see redPanda-project/docs#6). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)