### PR TITLE
MS02b: Deposit hardening — reject-new eviction, size limit, byte quota, register rate limit

### DIFF
--- a/src/main/java/im/redpanda/core/Command.java
+++ b/src/main/java/im/redpanda/core/Command.java
@@ -40,4 +40,5 @@ public final class Command {
   public static final byte OUTBOUND_REVOKE_OH_RES = (byte) 155;
   public static final byte OUTBOUND_ACK_FETCH_REQ = (byte) 156;
   public static final byte OUTBOUND_ACK_FETCH_RES = (byte) 157;
+  public static final byte FLASCHENPOST_PUT_RES = (byte) 158;
 }

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -832,7 +832,7 @@ public class InboundCommandProcessor {
       OutboundService.DepositResult result =
           outboundService.depositMessage(ohIdBytes.toByteArray(), content);
       if (result != OutboundService.DepositResult.DEPOSITED) {
-        logger.info("FlaschenpostPut deposit not stored: {}", result);
+        logger.debug("FlaschenpostPut deposit not stored: {}", result);
       }
       respondToDeposit(peer, putMsg, OutboundService.depositResultToStatus(result));
       return;
@@ -876,8 +876,10 @@ public class InboundCommandProcessor {
     try {
       byte[] ohId = new byte[KademliaId.ID_LENGTH_BYTES];
       System.arraycopy(content, 1 + 4, ohId, 0, KademliaId.ID_LENGTH_BYTES);
+      // Anything other than NOT_FOUND targeted a locally registered OH: a rejected deposit
+      // (quota/size) is handled here and must not leak into the legacy forwarding pipeline.
       return outboundService.depositMessage(ohId, content)
-          == OutboundService.DepositResult.DEPOSITED;
+          != OutboundService.DepositResult.NOT_FOUND;
     } catch (RuntimeException e) {
       logger.warn("Failed to extract destination or deposit message to local OH", e);
       return false;

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -814,20 +814,28 @@ public class InboundCommandProcessor {
     FlaschenpostPut putMsg = FlaschenpostPut.parseFrom(payload);
     byte[] content = putMsg.getContent().toByteArray();
 
-    // MS01: Direct OH routing via explicit oh_id field
+    // MS01: Direct OH routing via explicit oh_id field.
+    // MS02b: this path is authoritative — a packet with an explicit oh_id is deposited or
+    // dropped (with an opt-in status response) and never falls through to the legacy garlic
+    // parsing, which would misinterpret raw client payloads as GarlicMessages.
     ByteString ohIdBytes = putMsg.getOhId();
     if (!ohIdBytes.isEmpty() && outboundService != null) {
       // Validate OH id length before converting to a byte array to avoid large allocations
-      if (ohIdBytes.size() == KademliaId.ID_LENGTH_BYTES) {
-        if (outboundService.depositMessage(ohIdBytes.toByteArray(), content)) {
-          return;
-        }
-      } else {
+      if (ohIdBytes.size() != KademliaId.ID_LENGTH_BYTES) {
         logger.warn(
             "Received FlaschenpostPut with invalid oh_id length: {}, expected {}",
             ohIdBytes.size(),
             KademliaId.ID_LENGTH_BYTES);
+        respondToDeposit(peer, putMsg, im.redpanda.outbound.v1.Status.BAD_REQUEST);
+        return;
       }
+      OutboundService.DepositResult result =
+          outboundService.depositMessage(ohIdBytes.toByteArray(), content);
+      if (result != OutboundService.DepositResult.DEPOSITED) {
+        logger.info("FlaschenpostPut deposit not stored: {}", result);
+      }
+      respondToDeposit(peer, putMsg, OutboundService.depositResultToStatus(result));
+      return;
     }
 
     // Legacy: Try to route via GarlicMessage destination header
@@ -836,6 +844,18 @@ public class InboundCommandProcessor {
     }
 
     GMParser.parse(serverContext, content);
+  }
+
+  /**
+   * Sends the MS02b deposit status response, but only to directly connected light clients that
+   * asked for it via {@code want_response}. Peers and legacy clients never receive command 158 —
+   * their read loops would desync on an unknown command byte.
+   */
+  private void respondToDeposit(
+      Peer peer, FlaschenpostPut putMsg, im.redpanda.outbound.v1.Status status) {
+    if (putMsg.getWantResponse() && peer.isLightClient() && outboundService != null) {
+      outboundService.sendFlaschenpostPutResponse(peer, status);
+    }
   }
 
   /**
@@ -856,7 +876,8 @@ public class InboundCommandProcessor {
     try {
       byte[] ohId = new byte[KademliaId.ID_LENGTH_BYTES];
       System.arraycopy(content, 1 + 4, ohId, 0, KademliaId.ID_LENGTH_BYTES);
-      return outboundService.depositMessage(ohId, content);
+      return outboundService.depositMessage(ohId, content)
+          == OutboundService.DepositResult.DEPOSITED;
     } catch (RuntimeException e) {
       logger.warn("Failed to extract destination or deposit message to local OH", e);
       return false;

--- a/src/main/java/im/redpanda/outbound/OutboundMailboxStore.java
+++ b/src/main/java/im/redpanda/outbound/OutboundMailboxStore.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
@@ -37,14 +38,45 @@ public class OutboundMailboxStore {
   private final ConcurrentHashMap<String, AtomicLong> seqCounters = new ConcurrentHashMap<>();
 
   /**
-   * Transient overflow flags: ohId_hex of OHs that had FIFO eviction since the last fetch. Cleared
-   * by checkAndClearOverflow().
+   * In-memory byte usage per mailbox: ohId_hex → total stored bytes (serialized MailItem sizes).
+   * Rebuilt from the persisted map on startup, updated on every add/delete.
+   */
+  private final ConcurrentHashMap<String, AtomicLong> byteCounters = new ConcurrentHashMap<>();
+
+  /**
+   * Transient overflow flags: ohId_hex of OHs that had deposits rejected (mailbox full or byte
+   * quota reached) since the last fetch. Cleared by checkAndClearOverflow().
+   *
+   * <p>MS02b note: before MS02b this flag meant "oldest items were evicted (FIFO)". With reject-new
+   * eviction nothing stored is ever displaced; the flag now signals "deposits were rejected", so
+   * the client still learns that messages may be missing.
    */
   private final Set<String> overflowFlags = ConcurrentHashMap.newKeySet();
 
   private final String dbPath;
 
   static final int MAX_ITEMS_PER_MAILBOX = 500;
+
+  /**
+   * Per-item limit on the serialized {@link MailItem} size. Deposits above this are rejected
+   * (BAD_REQUEST): the 500-item cap alone counts items, not bytes, so a single item could otherwise
+   * be arbitrarily large.
+   */
+  static final int MAX_ITEM_BYTES = 64 * 1024;
+
+  /**
+   * Byte quota per mailbox, independent of the item count. Deposits that would exceed it are
+   * rejected (QUOTA_EXCEEDED).
+   */
+  static final long MAX_MAILBOX_BYTES = 4L * 1024 * 1024;
+
+  /** Result of {@link #addMessage}: deposited, or rejected with the reason (MS02b hardening). */
+  public enum AddResult {
+    ADDED,
+    REJECTED_ITEM_TOO_LARGE,
+    REJECTED_MAILBOX_FULL,
+    REJECTED_BYTE_QUOTA
+  }
 
   private static final String SEQ_FMT = "%019d";
 
@@ -67,8 +99,9 @@ public class OutboundMailboxStore {
       db = DBMaker.fileDB(dbPath).transactionEnable().make();
       mailboxItems =
           db.treeMap("mailboxItemsV2", Serializer.STRING, Serializer.BYTE_ARRAY).createOrOpen();
-      // Restore in-memory sequence counters from persisted keys
-      for (String key : mailboxItems.keySet()) {
+      // Restore in-memory sequence and byte counters from persisted entries
+      for (Map.Entry<String, byte[]> entry : mailboxItems.entrySet()) {
+        String key = entry.getKey();
         int sep = key.lastIndexOf(':');
         if (sep > 0) {
           String ohKey = key.substring(0, sep);
@@ -76,6 +109,9 @@ public class OutboundMailboxStore {
           seqCounters
               .computeIfAbsent(ohKey, k -> new AtomicLong(1L))
               .updateAndGet(current -> Math.max(current, seqId + 1));
+          byteCounters
+              .computeIfAbsent(ohKey, k -> new AtomicLong(0L))
+              .addAndGet(entry.getValue().length);
         }
       }
     } catch (Exception e) {
@@ -111,24 +147,37 @@ public class OutboundMailboxStore {
 
   /**
    * Adds a message to the mailbox for the given OH. Assigns a monotonically increasing sequence_id.
-   * If the mailbox is full, the oldest item is evicted (FIFO) and the overflow flag is set.
+   *
+   * <p>MS02b deposit hardening — reject-new instead of drop-oldest: a deposit into a full mailbox
+   * (item cap or byte quota) is rejected and the overflow flag is set, but already-stored items are
+   * never displaced. Spam can block a full mailbox, but cannot silently flush real messages.
+   *
+   * @return {@link AddResult#ADDED} or the rejection reason
    */
-  public synchronized void addMessage(byte[] ohId, MailItem item) {
+  public synchronized AddResult addMessage(byte[] ohId, MailItem item) {
     String ohKey = Utils.bytesToHexString(ohId);
 
-    // Enforce limit — evict oldest (FIFO)
+    long seqId = seqCounters.computeIfAbsent(ohKey, k -> new AtomicLong(1L)).get();
+    byte[] serialized = item.toBuilder().setSequenceId(seqId).build().toByteArray();
+
+    if (serialized.length > MAX_ITEM_BYTES) {
+      return AddResult.REJECTED_ITEM_TOO_LARGE;
+    }
     if (countItems(ohKey) >= MAX_ITEMS_PER_MAILBOX) {
-      String firstKey = mailboxItems.ceilingKey(ohPrefix(ohKey));
-      if (firstKey != null && firstKey.startsWith(ohPrefix(ohKey))) {
-        mailboxItems.remove(firstKey);
-        overflowFlags.add(ohKey);
-      }
+      overflowFlags.add(ohKey);
+      return AddResult.REJECTED_MAILBOX_FULL;
+    }
+    AtomicLong usedBytes = byteCounters.computeIfAbsent(ohKey, k -> new AtomicLong(0L));
+    if (usedBytes.get() + serialized.length > MAX_MAILBOX_BYTES) {
+      overflowFlags.add(ohKey);
+      return AddResult.REJECTED_BYTE_QUOTA;
     }
 
-    long seqId = nextSeqId(ohKey);
-    MailItem itemWithSeq = item.toBuilder().setSequenceId(seqId).build();
-    mailboxItems.put(itemKey(ohKey, seqId), itemWithSeq.toByteArray());
+    nextSeqId(ohKey);
+    mailboxItems.put(itemKey(ohKey, seqId), serialized);
+    usedBytes.addAndGet(serialized.length);
     if (db != null) db.commit();
+    return AddResult.ADDED;
   }
 
   /**
@@ -169,13 +218,15 @@ public class OutboundMailboxStore {
     String fromKey = ohPrefix(ohKey);
     String toKey = itemKey(ohKey, sequenceId);
     NavigableMap<String, byte[]> toDelete = mailboxItems.subMap(fromKey, true, toKey, true);
-    Iterator<String> it = toDelete.keySet().iterator();
+    Iterator<Map.Entry<String, byte[]>> it = toDelete.entrySet().iterator();
     boolean changed = false;
+    long freedBytes = 0;
     while (it.hasNext()) {
-      it.next();
+      freedBytes += it.next().getValue().length;
       it.remove();
       changed = true;
     }
+    subtractBytes(ohKey, freedBytes);
     if (db != null && changed) db.commit();
   }
 
@@ -194,7 +245,19 @@ public class OutboundMailboxStore {
       changed = true;
     }
     overflowFlags.remove(ohIdHex);
+    byteCounters.remove(ohIdHex);
     if (db != null && changed) db.commit();
+  }
+
+  /** Reduces the in-memory byte counter for an OH, never going below zero. */
+  private void subtractBytes(String ohKey, long freedBytes) {
+    if (freedBytes <= 0) {
+      return;
+    }
+    AtomicLong counter = byteCounters.get(ohKey);
+    if (counter != null) {
+      counter.updateAndGet(current -> Math.max(0, current - freedBytes));
+    }
   }
 
   /** Deletes all items for the given OH. */
@@ -203,8 +266,9 @@ public class OutboundMailboxStore {
   }
 
   /**
-   * Returns {@code true} if items were evicted from this OH's mailbox since the last call, and
-   * clears the overflow flag. This flag is transient — not persisted across restarts.
+   * Returns {@code true} if deposits into this OH's mailbox were rejected (mailbox full or byte
+   * quota reached) since the last call, and clears the overflow flag. This flag is transient — not
+   * persisted across restarts.
    */
   public boolean checkAndClearOverflow(byte[] ohId) {
     return overflowFlags.remove(Utils.bytesToHexString(ohId));

--- a/src/main/java/im/redpanda/outbound/OutboundService.java
+++ b/src/main/java/im/redpanda/outbound/OutboundService.java
@@ -358,7 +358,11 @@ public class OutboundService {
    * {@link #REGISTER_LIMIT_PER_WINDOW} registers arrived within {@link #REGISTER_WINDOW_MS}.
    */
   private boolean registerRateLimited(Peer peer, long now) {
-    Deque<Long> history = registerHistory.computeIfAbsent(peer, p -> new ArrayDeque<>());
+    Deque<Long> history;
+    // computeIfAbsent is not covered by the synchronizedMap wrapper — do get-or-create atomically
+    synchronized (registerHistory) {
+      history = registerHistory.computeIfAbsent(peer, p -> new ArrayDeque<>());
+    }
     synchronized (history) {
       while (!history.isEmpty() && now - history.peekFirst() > REGISTER_WINDOW_MS) {
         history.pollFirst();

--- a/src/main/java/im/redpanda/outbound/OutboundService.java
+++ b/src/main/java/im/redpanda/outbound/OutboundService.java
@@ -9,6 +9,7 @@ import im.redpanda.outbound.v1.AckFetchRequest;
 import im.redpanda.outbound.v1.AckFetchResponse;
 import im.redpanda.outbound.v1.FetchRequest;
 import im.redpanda.outbound.v1.FetchResponse;
+import im.redpanda.outbound.v1.FlaschenpostPutResponse;
 import im.redpanda.outbound.v1.MailItem;
 import im.redpanda.outbound.v1.RegisterOhRequest;
 import im.redpanda.outbound.v1.RegisterOhResponse;
@@ -17,9 +18,26 @@ import im.redpanda.outbound.v1.RevokeOhResponse;
 import im.redpanda.outbound.v1.Status;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 public class OutboundService {
+
+  /** Result of a deposit attempt (MS02b: callers must distinguish rejection from "not local"). */
+  public enum DepositResult {
+    /** Stored in a locally registered OH mailbox. */
+    DEPOSITED,
+    /** The oh_id is not registered here (or expired) — candidate for forwarding. */
+    NOT_FOUND,
+    /** Mailbox full (item cap or byte quota); deposit rejected, nothing displaced. */
+    QUOTA_EXCEEDED,
+    /** Item exceeds the per-item size limit. */
+    BAD_REQUEST
+  }
 
   /**
    * Length in bytes of the per-item {@code message_id}: a raw RFC-4122 UUIDv4 ("16 bytes UUID raw",
@@ -42,6 +60,18 @@ public class OutboundService {
   private static final int MIN_NONCE_BYTES = 8;
   private static final int MAX_NONCE_BYTES = 64;
 
+  // MS02b: register rate limit per connection (handle-store exhaustion defense).
+  // Counted per RegisterOhRequest before signature verification, sliding window.
+  static final int REGISTER_LIMIT_PER_WINDOW = 5;
+  static final long REGISTER_WINDOW_MS = 60_000;
+
+  /**
+   * Register timestamps per connection. WeakHashMap so entries vanish with the Peer object after
+   * disconnect; all access goes through the synchronized wrapper plus per-deque synchronization.
+   */
+  private final Map<Peer, Deque<Long>> registerHistory =
+      Collections.synchronizedMap(new WeakHashMap<>());
+
   public OutboundService(OutboundHandleStore handleStore, OutboundMailboxStore mailboxStore) {
     this.handleStore = handleStore;
     this.mailboxStore = mailboxStore;
@@ -60,6 +90,12 @@ public class OutboundService {
     if (outOfRange(ohId.length, MIN_OH_ID_BYTES, MAX_OH_ID_BYTES)
         || outOfRange(nonce.length, MIN_NONCE_BYTES, MAX_NONCE_BYTES)) {
       sendRegisterResponse(peer, Status.BAD_REQUEST, 0);
+      return;
+    }
+
+    // MS02b: rate-limit registers per connection before the (expensive) signature check
+    if (registerRateLimited(peer, now)) {
+      sendRegisterResponse(peer, Status.RATE_LIMIT, 0);
       return;
     }
 
@@ -267,16 +303,17 @@ public class OutboundService {
    *
    * @param ohId the outbound handle identifier
    * @param payload the raw message payload to deposit
-   * @return true if the message was deposited, false if the OH was not found or expired
+   * @return {@link DepositResult#DEPOSITED} on success, {@link DepositResult#NOT_FOUND} if the OH
+   *     is not registered here or expired, or the MS02b rejection reason
    */
-  public boolean depositMessage(byte[] ohId, byte[] payload) {
+  public DepositResult depositMessage(byte[] ohId, byte[] payload) {
     HandleRecord handle = handleStore.get(ohId);
     if (handle == null) {
-      return false;
+      return DepositResult.NOT_FOUND;
     }
     long now = System.currentTimeMillis();
     if (handle.getExpiresAtMs() < now) {
-      return false;
+      return DepositResult.NOT_FOUND;
     }
     byte[] messageId = newMessageId();
     MailItem item =
@@ -285,8 +322,53 @@ public class OutboundService {
             .setReceivedAtMs(now)
             .setPayload(ByteString.copyFrom(payload))
             .build();
-    mailboxStore.addMessage(ohId, item);
-    return true;
+    return switch (mailboxStore.addMessage(ohId, item)) {
+      case ADDED -> DepositResult.DEPOSITED;
+      case REJECTED_ITEM_TOO_LARGE -> DepositResult.BAD_REQUEST;
+      case REJECTED_MAILBOX_FULL, REJECTED_BYTE_QUOTA -> DepositResult.QUOTA_EXCEEDED;
+    };
+  }
+
+  /**
+   * Sends a {@link FlaschenpostPutResponse} for a deposit attempt. Only called for directly
+   * connected light clients that set {@code want_response} (full nodes and legacy clients must
+   * never receive command 158 — unknown commands desync their read loop).
+   */
+  public void sendFlaschenpostPutResponse(Peer peer, Status status) {
+    FlaschenpostPutResponse res =
+        FlaschenpostPutResponse.newBuilder()
+            .setStatus(status)
+            .setServerTimeMs(System.currentTimeMillis())
+            .build();
+    writeResponse(peer, Command.FLASCHENPOST_PUT_RES, res.toByteArray());
+  }
+
+  /** Maps a {@link DepositResult} to the wire status for FlaschenpostPutResponse. */
+  public static Status depositResultToStatus(DepositResult result) {
+    return switch (result) {
+      case DEPOSITED -> Status.OK;
+      case NOT_FOUND -> Status.NOT_FOUND;
+      case QUOTA_EXCEEDED -> Status.QUOTA_EXCEEDED;
+      case BAD_REQUEST -> Status.BAD_REQUEST;
+    };
+  }
+
+  /**
+   * Sliding-window register rate limit per connection: returns true (and rejects) if more than
+   * {@link #REGISTER_LIMIT_PER_WINDOW} registers arrived within {@link #REGISTER_WINDOW_MS}.
+   */
+  private boolean registerRateLimited(Peer peer, long now) {
+    Deque<Long> history = registerHistory.computeIfAbsent(peer, p -> new ArrayDeque<>());
+    synchronized (history) {
+      while (!history.isEmpty() && now - history.peekFirst() > REGISTER_WINDOW_MS) {
+        history.pollFirst();
+      }
+      if (history.size() >= REGISTER_LIMIT_PER_WINDOW) {
+        return true;
+      }
+      history.addLast(now);
+      return false;
+    }
   }
 
   // --- Helpers ---

--- a/src/main/proto/commands.proto
+++ b/src/main/proto/commands.proto
@@ -60,6 +60,9 @@ message JobAck {
 message FlaschenpostPut {
     bytes content = 1;
     bytes oh_id = 2;    // 20 bytes — target OH mailbox KademliaId
+    // MS02b: if set by a directly connected light client, the node answers with
+    // FlaschenpostPutResponse (command 158). Full nodes never set this.
+    bool want_response = 3;
 }
 
 // Unified envelope for future-proofing or batching, 

--- a/src/main/proto/outbound.proto
+++ b/src/main/proto/outbound.proto
@@ -71,6 +71,17 @@ message AckFetchResponse {
   int64 server_time_ms = 2;
 }
 
+// MS02b: optional response to a FlaschenpostPut deposit (command 158). Only sent to light
+// clients that set FlaschenpostPut.want_response, so existing clients never see it.
+//   OK             — deposited into a locally registered OH (or accepted for forwarding)
+//   NOT_FOUND      — oh_id not registered here and not forwardable
+//   QUOTA_EXCEEDED — mailbox full (item cap or byte quota); deposit rejected, nothing displaced
+//   BAD_REQUEST    — item exceeds the per-item size limit
+message FlaschenpostPutResponse {
+  Status status = 1;
+  int64 server_time_ms = 2;
+}
+
 message RevokeOhRequest {
   bytes oh_id = 1;
   int64 timestamp_ms = 2;

--- a/src/main/proto/outbound.proto
+++ b/src/main/proto/outbound.proto
@@ -73,8 +73,8 @@ message AckFetchResponse {
 
 // MS02b: optional response to a FlaschenpostPut deposit (command 158). Only sent to light
 // clients that set FlaschenpostPut.want_response, so existing clients never see it.
-//   OK             — deposited into a locally registered OH (or accepted for forwarding)
-//   NOT_FOUND      — oh_id not registered here and not forwardable
+//   OK             — deposited into a locally registered OH
+//   NOT_FOUND      — oh_id not registered here
 //   QUOTA_EXCEEDED — mailbox full (item cap or byte quota); deposit rejected, nothing displaced
 //   BAD_REQUEST    — item exceeds the per-item size limit
 message FlaschenpostPutResponse {

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
@@ -20,8 +20,9 @@ import org.junit.Test;
  * Tests for the {@code oh_id} routing path introduced in MS01 for {@code FLASCHENPOST_PUT} handling
  * in {@link InboundCommandProcessor}.
  *
- * <p>Covers: direct-OH deposit when {@code oh_id} is present and registered, fall-through to legacy
- * GMParser when deposit is not applicable, and backward compatibility when {@code oh_id} is absent.
+ * <p>Covers: direct-OH deposit when {@code oh_id} is present and registered, the authoritative
+ * explicit-oh_id path introduced in MS02b (rejected/unknown deposits are dropped, opt-in status
+ * responses for light clients), and backward compatibility when {@code oh_id} is absent.
  */
 public class InboundCommandProcessorFlaschenpostPutTest {
 
@@ -101,26 +102,22 @@ public class InboundCommandProcessorFlaschenpostPutTest {
   }
 
   /**
-   * When {@code oh_id} is present but no matching OH is registered (deposit returns false), the
-   * handler falls through to the legacy GMParser path and completes without error.
+   * MS02b: when {@code oh_id} is present but no matching OH is registered, the packet is dropped on
+   * the explicit path — it must NOT fall through to the legacy GMParser, which would misinterpret
+   * raw client payloads (e.g. encrypted chat payloads) as GarlicMessages.
    */
   @Test
-  public void flaschenpostPut_withOhIdButNoRegisteredOh_fallsThroughToLegacy() {
+  public void flaschenpostPut_withOhIdButNoRegisteredOh_isDroppedWithoutLegacyFallthrough() {
     byte[] ohId = sampleOhId();
-    // Intentionally skip registerOh() so depositMessage returns false
+    // Intentionally skip registerOh() so depositMessage returns NOT_FOUND
 
-    // Use a valid GMAck payload so the legacy GMParser path handles it gracefully
-    ByteBuffer ack = ByteBuffer.allocate(1 + 4 + 4);
-    ack.put(im.redpanda.flaschenpost.GMType.ACK.getId());
-    ack.putInt(4);
-    ack.putInt(99);
-    ack.flip();
-    byte[] ackBytes = new byte[ack.remaining()];
-    ack.get(ackBytes);
+    // A raw (non-garlic) payload like the mobile client sends; legacy parsing would throw on it
+    byte[] rawPayload = new byte[64];
+    rawPayload[0] = 0x02; // not a known GMType
 
     FlaschenpostPut putMsg =
         FlaschenpostPut.newBuilder()
-            .setContent(copyFrom(ackBytes))
+            .setContent(copyFrom(rawPayload))
             .setOhId(ByteString.copyFrom(ohId))
             .build();
     byte[] putData = putMsg.toByteArray();
@@ -139,24 +136,19 @@ public class InboundCommandProcessorFlaschenpostPutTest {
   }
 
   /**
-   * When {@code oh_id} has an invalid byte length, the handler logs a warning and falls through to
-   * the legacy GMParser path without throwing.
+   * MS02b: when {@code oh_id} has an invalid byte length, the packet is malformed and dropped (a
+   * light client with want_response would receive BAD_REQUEST).
    */
   @Test
-  public void flaschenpostPut_withInvalidOhIdLength_fallsThroughToLegacy() {
+  public void flaschenpostPut_withInvalidOhIdLength_isDropped() {
     byte[] wrongLengthId = new byte[5]; // too short, not ID_LENGTH_BYTES
 
-    ByteBuffer ack = ByteBuffer.allocate(1 + 4 + 4);
-    ack.put(im.redpanda.flaschenpost.GMType.ACK.getId());
-    ack.putInt(4);
-    ack.putInt(7);
-    ack.flip();
-    byte[] ackBytes = new byte[ack.remaining()];
-    ack.get(ackBytes);
+    byte[] rawPayload = new byte[64];
+    rawPayload[0] = 0x02;
 
     FlaschenpostPut putMsg =
         FlaschenpostPut.newBuilder()
-            .setContent(copyFrom(ackBytes))
+            .setContent(copyFrom(rawPayload))
             .setOhId(ByteString.copyFrom(wrongLengthId))
             .build();
     byte[] putData = putMsg.toByteArray();
@@ -288,11 +280,11 @@ public class InboundCommandProcessorFlaschenpostPutTest {
   }
 
   /**
-   * When {@code oh_id} targets an expired OH handle, deposit fails and the handler falls through to
-   * the legacy path.
+   * When {@code oh_id} targets an expired OH handle, deposit fails (NOT_FOUND) and the packet is
+   * dropped on the explicit path.
    */
   @Test
-  public void flaschenpostPut_withExpiredOhHandle_fallsThroughToLegacy() {
+  public void flaschenpostPut_withExpiredOhHandle_isDropped() {
     byte[] ohId = sampleOhId();
     // Register with an already-expired handle
     long now = System.currentTimeMillis();
@@ -377,6 +369,88 @@ public class InboundCommandProcessorFlaschenpostPutTest {
     int consumed = proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
 
     assertEquals(1 + 4 + putData.length, consumed);
+  }
+
+  // --- MS02b: opt-in deposit status responses (want_response) ---
+
+  /** Light client with want_response gets an OK FlaschenpostPutResponse on successful deposit. */
+  @Test
+  public void flaschenpostPut_lightClientWantResponse_receivesOkStatus() {
+    byte[] ohId = sampleOhId();
+    registerOh(ohId);
+
+    im.redpanda.outbound.v1.FlaschenpostPutResponse res =
+        depositAndReadResponse(ohId, "payload-ok".getBytes(StandardCharsets.UTF_8), true, true);
+    assertEquals(im.redpanda.outbound.v1.Status.OK, res.getStatus());
+  }
+
+  /** Light client with want_response gets NOT_FOUND when the OH is not registered here. */
+  @Test
+  public void flaschenpostPut_lightClientWantResponse_receivesNotFoundForUnknownOh() {
+    byte[] ohId = sampleOhId(); // not registered
+
+    im.redpanda.outbound.v1.FlaschenpostPutResponse res =
+        depositAndReadResponse(ohId, new byte[32], true, true);
+    assertEquals(im.redpanda.outbound.v1.Status.NOT_FOUND, res.getStatus());
+  }
+
+  /** Full nodes never receive command 158, even if they set want_response. */
+  @Test
+  public void flaschenpostPut_fullNodeWantResponse_receivesNoResponse() {
+    byte[] ohId = sampleOhId();
+    registerOh(ohId);
+
+    Peer peer = depositWithPeer(ohId, new byte[16], true, false);
+    assertEquals(
+        "no response bytes must be written for full nodes", 0, peer.writeBuffer.position());
+  }
+
+  /** Light clients that do not set want_response keep the fire-and-forget behavior. */
+  @Test
+  public void flaschenpostPut_lightClientWithoutWantResponse_receivesNoResponse() {
+    byte[] ohId = sampleOhId();
+    registerOh(ohId);
+
+    Peer peer = depositWithPeer(ohId, new byte[16], false, true);
+    assertEquals(0, peer.writeBuffer.position());
+  }
+
+  /** Sends a FlaschenpostPut and returns the peer for write-buffer inspection. */
+  private Peer depositWithPeer(
+      byte[] ohId, byte[] content, boolean wantResponse, boolean lightClient) {
+    FlaschenpostPut putMsg =
+        FlaschenpostPut.newBuilder()
+            .setContent(copyFrom(content))
+            .setOhId(ByteString.copyFrom(ohId))
+            .setWantResponse(wantResponse)
+            .build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9100, ctx.getNodeId());
+    peer.setConnected(true);
+    peer.setLightClient(lightClient);
+    peer.writeBuffer = ByteBuffer.allocate(8192);
+    ctx.getPeerList().add(peer);
+
+    proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+    return peer;
+  }
+
+  /** Deposits and parses the FlaschenpostPutResponse (command 158) from the peer write buffer. */
+  private im.redpanda.outbound.v1.FlaschenpostPutResponse depositAndReadResponse(
+      byte[] ohId, byte[] content, boolean wantResponse, boolean lightClient) {
+    Peer peer = depositWithPeer(ohId, content, wantResponse, lightClient);
+    ByteBuffer buf = peer.writeBuffer;
+    buf.flip();
+    assertEquals(Command.FLASCHENPOST_PUT_RES, buf.get());
+    int len = buf.getInt();
+    byte[] payload = new byte[len];
+    buf.get(payload);
+    try {
+      return im.redpanda.outbound.v1.FlaschenpostPutResponse.parseFrom(payload);
+    } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+      throw new AssertionError("response payload must be a FlaschenpostPutResponse", e);
+    }
   }
 
   /** Builds a minimal GMAck payload: [1 type][4 len][4 ackId]. */

--- a/src/test/java/im/redpanda/outbound/OutboundMailboxStoreTest.java
+++ b/src/test/java/im/redpanda/outbound/OutboundMailboxStoreTest.java
@@ -145,23 +145,27 @@ public class OutboundMailboxStoreTest {
     assertThat(store.fetchMessages(ohId2, 10, 0)).hasSize(1);
   }
 
-  // --- AC: Mailbox overflow (>500 items) sets overflow flag ---
+  // --- MS02b AC: full mailbox rejects new deposits (reject-new) and sets overflow flag ---
 
   @Test
-  public void addMessage_whenMailboxFull_evictsOldestAndSetsOverflowFlag() {
+  public void addMessage_whenMailboxFull_rejectsNewAndSetsOverflowFlag() {
     // Fill to capacity
     for (int i = 0; i < OutboundMailboxStore.MAX_ITEMS_PER_MAILBOX; i++) {
-      store.addMessage(
-          ohId, MailItem.newBuilder().setPayload(ByteString.copyFromUtf8("val" + i)).build());
+      OutboundMailboxStore.AddResult result =
+          store.addMessage(
+              ohId, MailItem.newBuilder().setPayload(ByteString.copyFromUtf8("val" + i)).build());
+      assertThat(result).isEqualTo(OutboundMailboxStore.AddResult.ADDED);
     }
 
     // No overflow yet
     assertThat(store.checkAndClearOverflow(ohId)).isFalse();
 
-    // Add one more to trigger eviction
-    store.addMessage(
-        ohId, MailItem.newBuilder().setPayload(ByteString.copyFromUtf8("overflow")).build());
+    // One more is rejected — nothing stored is displaced
+    OutboundMailboxStore.AddResult rejected =
+        store.addMessage(
+            ohId, MailItem.newBuilder().setPayload(ByteString.copyFromUtf8("overflow")).build());
 
+    assertThat(rejected).isEqualTo(OutboundMailboxStore.AddResult.REJECTED_MAILBOX_FULL);
     assertThat(store.checkAndClearOverflow(ohId)).isTrue();
     // After clearing, flag is gone
     assertThat(store.checkAndClearOverflow(ohId)).isFalse();
@@ -181,7 +185,7 @@ public class OutboundMailboxStoreTest {
   }
 
   @Test
-  public void testMailboxLimit_fifoEviction() {
+  public void testMailboxLimit_rejectNewKeepsOldest() {
     int limit = OutboundMailboxStore.MAX_ITEMS_PER_MAILBOX;
     for (int i = 0; i < limit + 5; i++) {
       store.addMessage(
@@ -191,8 +195,89 @@ public class OutboundMailboxStoreTest {
     List<MailItem> messages = store.fetchMessages(ohId, 1000, 0);
     assertThat(messages).hasSize(limit);
 
-    // FIFO: oldest 5 (val0–val4) are evicted; first surviving is val5
-    assertThat(messages.get(0).getPayload().toStringUtf8()).isEqualTo("val5");
-    assertThat(messages.get(limit - 1).getPayload().toStringUtf8()).isEqualTo("val" + (limit + 4));
+    // Reject-new: the first stored items survive, the 5 excess deposits were rejected
+    assertThat(messages.get(0).getPayload().toStringUtf8()).isEqualTo("val0");
+    assertThat(messages.get(limit - 1).getPayload().toStringUtf8()).isEqualTo("val" + (limit - 1));
+  }
+
+  @Test
+  public void addMessage_afterAckFreesSpace_acceptsAgain() {
+    int limit = OutboundMailboxStore.MAX_ITEMS_PER_MAILBOX;
+    for (int i = 0; i < limit; i++) {
+      store.addMessage(
+          ohId, MailItem.newBuilder().setPayload(ByteString.copyFromUtf8("val" + i)).build());
+    }
+    assertThat(
+            store.addMessage(
+                ohId, MailItem.newBuilder().setPayload(ByteString.copyFromUtf8("x")).build()))
+        .isEqualTo(OutboundMailboxStore.AddResult.REJECTED_MAILBOX_FULL);
+
+    // Acknowledge (delete) the first 10 items — deposits are accepted again
+    store.deleteUpTo(ohId, 10);
+    assertThat(
+            store.addMessage(
+                ohId, MailItem.newBuilder().setPayload(ByteString.copyFromUtf8("y")).build()))
+        .isEqualTo(OutboundMailboxStore.AddResult.ADDED);
+  }
+
+  // --- MS02b AC: per-item size limit ---
+
+  @Test
+  public void addMessage_itemAboveSizeLimit_isRejected() {
+    byte[] tooLarge = new byte[OutboundMailboxStore.MAX_ITEM_BYTES + 1];
+
+    OutboundMailboxStore.AddResult result =
+        store.addMessage(
+            ohId, MailItem.newBuilder().setPayload(ByteString.copyFrom(tooLarge)).build());
+
+    assertThat(result).isEqualTo(OutboundMailboxStore.AddResult.REJECTED_ITEM_TOO_LARGE);
+    assertThat(store.fetchMessages(ohId, 10, 0)).isEmpty();
+  }
+
+  @Test
+  public void addMessage_itemJustBelowSizeLimit_isAccepted() {
+    // Leave room for the message_id/seq/timestamp fields of the serialized MailItem
+    byte[] payload = new byte[OutboundMailboxStore.MAX_ITEM_BYTES - 64];
+
+    OutboundMailboxStore.AddResult result =
+        store.addMessage(
+            ohId, MailItem.newBuilder().setPayload(ByteString.copyFrom(payload)).build());
+
+    assertThat(result).isEqualTo(OutboundMailboxStore.AddResult.ADDED);
+  }
+
+  // --- MS02b AC: per-mailbox byte quota independent of item count ---
+
+  @Test
+  public void addMessage_byteQuotaReached_rejectsBeforeItemCap() {
+    // ~63 KiB per item: the 4 MiB quota is hit after ~66 items, far below the 500-item cap
+    byte[] payload = new byte[63 * 1024];
+
+    int accepted = 0;
+    OutboundMailboxStore.AddResult last = OutboundMailboxStore.AddResult.ADDED;
+    for (int i = 0; i < OutboundMailboxStore.MAX_ITEMS_PER_MAILBOX; i++) {
+      last =
+          store.addMessage(
+              ohId, MailItem.newBuilder().setPayload(ByteString.copyFrom(payload)).build());
+      if (last != OutboundMailboxStore.AddResult.ADDED) {
+        break;
+      }
+      accepted++;
+    }
+
+    assertThat(last).isEqualTo(OutboundMailboxStore.AddResult.REJECTED_BYTE_QUOTA);
+    // Quota must bite around MAX_MAILBOX_BYTES / itemSize, well below the 500-item cap
+    long approxItems = OutboundMailboxStore.MAX_MAILBOX_BYTES / (63 * 1024);
+    assertThat(accepted)
+        .isLessThan(OutboundMailboxStore.MAX_ITEMS_PER_MAILBOX)
+        .isBetween((int) approxItems - 2, (int) approxItems);
+    assertThat(store.checkAndClearOverflow(ohId)).isTrue();
+
+    // Quota is byte-based: freeing items via ack makes room again
+    store.deleteUpTo(ohId, 2);
+    assertThat(
+            store.addMessage(
+                ohId, MailItem.newBuilder().setPayload(ByteString.copyFrom(payload)).build()))
+        .isEqualTo(OutboundMailboxStore.AddResult.ADDED);
   }
 }

--- a/src/test/java/im/redpanda/outbound/OutboundServiceIntegrationTest.java
+++ b/src/test/java/im/redpanda/outbound/OutboundServiceIntegrationTest.java
@@ -69,8 +69,10 @@ public class OutboundServiceIntegrationTest {
 
     // 2. Deposit a message via depositMessage
     byte[] payload = "Hello from sender!".getBytes(StandardCharsets.UTF_8);
-    boolean deposited = service.depositMessage(ohId, payload);
-    assertThat(deposited).as("Message should be deposited into registered OH").isTrue();
+    OutboundService.DepositResult deposited = service.depositMessage(ohId, payload);
+    assertThat(deposited)
+        .as("Message should be deposited into registered OH")
+        .isEqualTo(OutboundService.DepositResult.DEPOSITED);
 
     // 3. Fetch the deposited message
     FetchRequest fetchReq = createSignedFetchRequest(0);
@@ -94,12 +96,12 @@ public class OutboundServiceIntegrationTest {
   }
 
   @Test
-  public void testDepositMessage_OhNotRegistered_ReturnsFalse() {
+  public void testDepositMessage_OhNotRegistered_ReturnsNotFound() {
     byte[] unknownOhId = new byte[20];
     new SecureRandom().nextBytes(unknownOhId);
-    boolean deposited =
+    OutboundService.DepositResult deposited =
         service.depositMessage(unknownOhId, "test".getBytes(StandardCharsets.UTF_8));
-    assertThat(deposited).isFalse();
+    assertThat(deposited).isEqualTo(OutboundService.DepositResult.NOT_FOUND);
   }
 
   @Test
@@ -139,9 +141,9 @@ public class OutboundServiceIntegrationTest {
     readRevokeResponse();
 
     // Try to deposit after revoke
-    boolean deposited =
+    OutboundService.DepositResult deposited =
         service.depositMessage(ohId, "late message".getBytes(StandardCharsets.UTF_8));
-    assertThat(deposited).isFalse();
+    assertThat(deposited).isEqualTo(OutboundService.DepositResult.NOT_FOUND);
   }
 
   @Test
@@ -323,17 +325,20 @@ public class OutboundServiceIntegrationTest {
     service.handleRegister(peer, createSignedRegisterRequest());
     readRegisterResponse();
 
-    // Fill mailbox to capacity + 1 to trigger eviction
-    for (int i = 0; i <= OutboundMailboxStore.MAX_ITEMS_PER_MAILBOX; i++) {
+    // Fill mailbox to capacity + 1: the last deposit is rejected (MS02b reject-new)
+    for (int i = 0; i < OutboundMailboxStore.MAX_ITEMS_PER_MAILBOX; i++) {
       service.depositMessage(ohId, ("m" + i).getBytes(StandardCharsets.UTF_8));
     }
+    OutboundService.DepositResult rejected =
+        service.depositMessage(ohId, "one too many".getBytes(StandardCharsets.UTF_8));
+    assertThat(rejected).isEqualTo(OutboundService.DepositResult.QUOTA_EXCEEDED);
 
     service.handleFetch(peer, createSignedFetchRequest(0));
     FetchResponse res = readFetchResponse();
 
     assertThat(res.getStatus()).isEqualTo(Status.OK);
     assertThat(res.getMailboxOverflow())
-        .as("overflow flag should be set after FIFO eviction")
+        .as("overflow flag should be set after a rejected deposit")
         .isTrue();
 
     // Second fetch — overflow flag should be cleared
@@ -342,16 +347,59 @@ public class OutboundServiceIntegrationTest {
     assertThat(res2.getMailboxOverflow()).isFalse();
   }
 
+  // --- MS02b AC: per-item size limit surfaces as BAD_REQUEST ---
+
+  @Test
+  public void testDeposit_oversizedItem_returnsBadRequest() throws Exception {
+    byte[] ohId = clientNode.getKademliaId().getBytes();
+    service.handleRegister(peer, createSignedRegisterRequest());
+    readRegisterResponse();
+
+    byte[] oversized = new byte[OutboundMailboxStore.MAX_ITEM_BYTES + 1];
+    assertThat(service.depositMessage(ohId, oversized))
+        .isEqualTo(OutboundService.DepositResult.BAD_REQUEST);
+
+    // Nothing was stored
+    service.handleFetch(peer, createSignedFetchRequest(0));
+    assertThat(readFetchResponse().getItemsCount()).isZero();
+  }
+
+  // --- MS02b AC: register rate limit per connection ---
+
+  @Test
+  public void testRegister_rateLimitPerConnection() throws Exception {
+    for (int i = 0; i < OutboundService.REGISTER_LIMIT_PER_WINDOW; i++) {
+      service.handleRegister(peer, createSignedRegisterRequest());
+      assertThat(readRegisterResponse().getStatus()).isEqualTo(Status.OK);
+    }
+
+    // One register above the per-connection window limit → RATE_LIMIT
+    service.handleRegister(peer, createSignedRegisterRequest());
+    assertThat(readRegisterResponse().getStatus()).isEqualTo(Status.RATE_LIMIT);
+
+    // A different connection is not affected
+    Peer otherPeer = new Peer("127.0.0.1", 23456);
+    otherPeer.writeBuffer = ByteBuffer.allocate(8192);
+    otherPeer.writeBuffer.clear();
+    otherPeer.setConnected(true);
+    service.handleRegister(otherPeer, createSignedRegisterRequest());
+    assertThat(readRegisterResponse(otherPeer).getStatus()).isEqualTo(Status.OK);
+  }
+
   // --- Response readers ---
 
   private RegisterOhResponse readRegisterResponse() throws Exception {
-    peer.writeBuffer.flip();
-    byte cmd = peer.writeBuffer.get();
+    return readRegisterResponse(peer);
+  }
+
+  private RegisterOhResponse readRegisterResponse(Peer fromPeer) throws Exception {
+    fromPeer.writeBuffer.flip();
+    byte cmd = fromPeer.writeBuffer.get();
     assertThat(cmd).isEqualTo(Command.OUTBOUND_REGISTER_OH_RES);
-    int len = peer.writeBuffer.getInt();
+    int len = fromPeer.writeBuffer.getInt();
     byte[] data = new byte[len];
-    peer.writeBuffer.get(data);
-    peer.writeBuffer.compact();
+    fromPeer.writeBuffer.get(data);
+    fromPeer.writeBuffer.compact();
     return RegisterOhResponse.parseFrom(data);
   }
 


### PR DESCRIPTION
## Backend-MS02b (OH Discovery & Forwarding) — Teil 1/3: Deposit-Härtung

Schließt den Mailbox-Flush-Angriff und triviale Erschöpfungsvektoren aus der [MS02b-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms02b_oh_discovery_forwarding.md) (Abschnitt 3).

### Änderungen

**OutboundMailboxStore**
- **Reject-new statt drop-oldest:** Eine volle Mailbox (Item-Cap oder Byte-Quota) lehnt das *neue* Deposit ab; gespeicherte Nachrichten werden nie mehr still verdrängt. Spam kann eine volle Mailbox blockieren, aber keine echten Nachrichten mehr flushen.
- **Per-Item-Größenlimit** (64 KiB serialisiert) → `BAD_REQUEST`.
- **Byte-Quota pro Mailbox** (4 MiB, unabhängig vom Item-Count) → `QUOTA_EXCEEDED`. In-Memory-Byte-Zähler, beim Start aus der persistierten Map rekonstruiert, bei Ack/Revoke/Cleanup dekrementiert.
- Overflow-Flag-Semantik: jetzt „Deposits wurden abgelehnt seit letztem Fetch“ (vorher „älteste Items evicted“) — Client erfährt weiterhin, dass Nachrichten fehlen können.

**OutboundService**
- `depositMessage()` → `DepositResult` (`DEPOSITED`/`NOT_FOUND`/`QUOTA_EXCEEDED`/`BAD_REQUEST`).
- **Register-Rate-Limit pro Verbindung** (Sliding Window, 5/min, vor der teuren Signaturprüfung) → `RATE_LIMIT` in der RegisterOhResponse.

**InboundCommandProcessor**
- Der explizite `oh_id`-Pfad ist jetzt **authoritativ**: abgelehnte/unbekannte Deposits werden gedroppt statt in die Legacy-Garlic-Parsing-Pipeline zu fallen (die rohe Client-Payloads als GarlicMessage fehlinterpretierte und die Verbindung abreißen konnte). Forwarding für `NOT_FOUND` folgt in Teil 3.
- **Opt-in-Deposit-Response:** `FlaschenpostPut.want_response` (neues Feld 3) + `FLASCHENPOST_PUT_RES` (158). Nur direkt verbundene Light Clients, die das Feld setzen, erhalten die Response — Bestandsclients und Full Nodes sehen Command 158 nie (deren Read-Loop würde bei unbekannten Commands desyncen). Damit werden die bisher nie gesendeten Status-Codes `RATE_LIMIT`/`QUOTA_EXCEEDED`/`BAD_REQUEST` erstmals verdrahtet.

### Akzeptanzkriterien (MS02b)
- [x] Volle Mailbox lehnt neue Deposits ab (`QUOTA_EXCEEDED`) statt älteste Items zu droppen
- [x] Deposits über dem Per-Item-Limit → `BAD_REQUEST`
- [x] Byte-Quota pro Mailbox unabhängig vom Item-Count
- [x] Exzessive `RegisterOhRequest` pro Verbindung → `RATE_LIMIT`

### Tests
215 Tests grün (`mvn test`), neu u. a.: reject-new + Overflow-Flag, Ack gibt Quota frei, Größenlimit, Byte-Quota greift vor Item-Cap, Rate-Limit pro Verbindung (andere Verbindung unbeeinflusst), Opt-in-Response-Matrix (Light Client ±want_response, Full Node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)