### PR TITLE
MS02b: OH→Node DHT discovery — derived announce keys, padded records, jittered announce/resolve

### DIFF
--- a/src/main/java/im/redpanda/App.java
+++ b/src/main/java/im/redpanda/App.java
@@ -13,6 +13,7 @@ import im.redpanda.jobs.GMManagerCleanJobs;
 import im.redpanda.jobs.KadRefreshJob;
 import im.redpanda.jobs.NodeConnectionPointsSeenJob;
 import im.redpanda.jobs.NodeInfoSetRefreshJob;
+import im.redpanda.jobs.OhAnnounceJob;
 import im.redpanda.jobs.OutboundCleanupJob;
 import im.redpanda.jobs.SaveJobs;
 import im.redpanda.jobs.ServerRestartJob;
@@ -165,6 +166,10 @@ public class App {
     new NodeConnectionPointsSeenJob(serverContext).start();
     new UpTimeReporterJob(serverContext).start();
     new OutboundCleanupJob(serverContext).start();
+    new OhAnnounceJob(serverContext).start();
+    serverContext
+        .getOutboundService()
+        .setOhRegisteredListener(ohId -> OhAnnounceJob.announceSoon(serverContext, ohId));
   }
 
   private static void initLogger() {

--- a/src/main/java/im/redpanda/jobs/OhAnnounceJob.java
+++ b/src/main/java/im/redpanda/jobs/OhAnnounceJob.java
@@ -43,7 +43,8 @@ public class OhAnnounceJob extends Job {
 
   @Override
   public void work() {
-    setReRunDelay(BASE_PERIOD_MS + rand.nextLong(PERIOD_JITTER_MS));
+    // symmetric jitter: 30 min ± 5 min
+    setReRunDelay(BASE_PERIOD_MS - PERIOD_JITTER_MS + rand.nextLong(2 * PERIOD_JITTER_MS + 1));
 
     OutboundHandleStore handleStore = serverContext.getOutboundHandleStore();
     if (handleStore == null) {
@@ -73,8 +74,9 @@ public class OhAnnounceJob extends Job {
     private final byte[] ohId;
 
     SingleAnnounceJob(ServerContext serverContext, byte[] ohId) {
-      // skipImminentRun=true → the single work() run happens after the randomized delay
-      super(serverContext, 1 + rand.nextLong(ANNOUNCE_STAGGER_MS), false, true);
+      // skipImminentRun=true → the single work() run happens after the randomized delay,
+      // sampled uniformly from [0, ANNOUNCE_STAGGER_MS]
+      super(serverContext, rand.nextLong(ANNOUNCE_STAGGER_MS + 1), false, true);
       this.ohId = ohId;
     }
 

--- a/src/main/java/im/redpanda/jobs/OhAnnounceJob.java
+++ b/src/main/java/im/redpanda/jobs/OhAnnounceJob.java
@@ -1,0 +1,97 @@
+package im.redpanda.jobs;
+
+import im.redpanda.core.ServerContext;
+import im.redpanda.kademlia.KadContent;
+import im.redpanda.outbound.OhDht;
+import im.redpanda.outbound.OutboundHandleStore;
+import java.time.Duration;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * MS02b: periodically announces {@code H(oh_id) → host node} DHT records for every locally
+ * registered, non-expired Outbound Handle, so senders that are not directly connected to this node
+ * can resolve the OH host (see {@link OhDht}).
+ *
+ * <p>Re-announcing is required because the Kademlia key rotates with the UTC date and stored
+ * content expires. Anti-profiling: every per-OH announce is staggered by a randomized delay so the
+ * announce timing does not reveal a stable fingerprint of this node's registered OHs, and the job
+ * period itself is jittered.
+ */
+public class OhAnnounceJob extends Job {
+
+  private static final Logger logger = LogManager.getLogger();
+
+  static final long BASE_PERIOD_MS = Duration.ofMinutes(30).toMillis();
+  static final long PERIOD_JITTER_MS = Duration.ofMinutes(5).toMillis();
+
+  /** Maximum randomized stagger for a single announce within one job run. */
+  static final long ANNOUNCE_STAGGER_MS = Duration.ofSeconds(30).toMillis();
+
+  /** First run shortly after startup (jobs run immediately otherwise). */
+  private static final long INITIAL_DELAY_MS = Duration.ofSeconds(20).toMillis();
+
+  public OhAnnounceJob(ServerContext serverContext) {
+    super(serverContext, INITIAL_DELAY_MS, true, true);
+  }
+
+  @Override
+  public void init() {
+    // no setup needed
+  }
+
+  @Override
+  public void work() {
+    setReRunDelay(BASE_PERIOD_MS + rand.nextLong(PERIOD_JITTER_MS));
+
+    OutboundHandleStore handleStore = serverContext.getOutboundHandleStore();
+    if (handleStore == null) {
+      return;
+    }
+    List<byte[]> ohIds = handleStore.listActiveOhIds(System.currentTimeMillis());
+    for (byte[] ohId : ohIds) {
+      announceSoon(serverContext, ohId);
+    }
+    if (!ohIds.isEmpty()) {
+      logger.debug("scheduled OH announce for {} handles", ohIds.size());
+    }
+  }
+
+  /**
+   * Schedules a single announce for {@code ohId} after a randomized delay (anti-profiling stagger).
+   * Also used directly after a successful RegisterOh so fresh handles become resolvable without
+   * waiting for the next periodic run.
+   */
+  public static void announceSoon(ServerContext serverContext, byte[] ohId) {
+    new SingleAnnounceJob(serverContext, ohId).start();
+  }
+
+  /** One-shot job that builds and inserts the announce record after its randomized delay. */
+  static class SingleAnnounceJob extends Job {
+
+    private final byte[] ohId;
+
+    SingleAnnounceJob(ServerContext serverContext, byte[] ohId) {
+      // skipImminentRun=true → the single work() run happens after the randomized delay
+      super(serverContext, 1 + rand.nextLong(ANNOUNCE_STAGGER_MS), false, true);
+      this.ohId = ohId;
+    }
+
+    @Override
+    public void init() {
+      // no setup needed
+    }
+
+    @Override
+    public void work() {
+      try {
+        KadContent content =
+            OhDht.buildAnnounceContent(ohId, serverContext.getNonce(), System.currentTimeMillis());
+        new KademliaInsertJob(serverContext, content).start();
+      } finally {
+        done();
+      }
+    }
+  }
+}

--- a/src/main/java/im/redpanda/jobs/OhResolveJob.java
+++ b/src/main/java/im/redpanda/jobs/OhResolveJob.java
@@ -1,0 +1,134 @@
+package im.redpanda.jobs;
+
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.ServerContext;
+import im.redpanda.kademlia.KadContent;
+import im.redpanda.outbound.OhDht;
+import im.redpanda.outbound.v1.OhNodeRecord;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * MS02b: resolves {@code oh_id → host node} via the DHT announce record (see {@link OhDht}).
+ *
+ * <p>Anti-profiling: the network search starts only after a randomized delay, so the timing of a
+ * lookup does not directly correlate with the FlaschenpostPut that triggered it. The local store is
+ * checked without delay (a local read leaks nothing). Records are fixed-size (padded), so the
+ * answer size is uniform as well.
+ */
+public class OhResolveJob extends KademliaSearchJob {
+
+  private static final Logger logger = LogManager.getLogger();
+
+  /** Upper bound for the randomized delay before the DHT search is issued. */
+  static final long LOOKUP_DELAY_JITTER_MS = Duration.ofMillis(1500).toMillis();
+
+  private final byte[] ohId;
+  private final Consumer<OhNodeRecord> onResolved;
+  private final Runnable onFailed;
+  private boolean callbackFired = false;
+
+  OhResolveJob(
+      ServerContext serverContext,
+      byte[] ohId,
+      Consumer<OhNodeRecord> onResolved,
+      Runnable onFailed) {
+    super(serverContext, OhDht.announceKademliaId(ohId, System.currentTimeMillis()));
+    this.ohId = ohId;
+    this.onResolved = onResolved;
+    this.onFailed = onFailed;
+  }
+
+  /**
+   * Resolves the host node for {@code ohId}: local KadStore first (no delay), then a randomized
+   * delayed DHT search. Exactly one of the callbacks fires.
+   */
+  public static void resolve(
+      ServerContext serverContext,
+      byte[] ohId,
+      Consumer<OhNodeRecord> onResolved,
+      Runnable onFailed) {
+    long now = System.currentTimeMillis();
+    KademliaId announceId = OhDht.announceKademliaId(ohId, now);
+
+    KadContent local = serverContext.getKadStoreManager().get(announceId);
+    if (local != null) {
+      OhNodeRecord record = OhDht.extractValidRecord(List.of(local), ohId, now);
+      if (record != null) {
+        onResolved.accept(record);
+        return;
+      }
+    }
+
+    new DelayedSearchJob(serverContext, ohId, onResolved, onFailed).start();
+  }
+
+  @Override
+  protected ArrayList<KadContent> success() {
+    ArrayList<KadContent> contents = super.success();
+    OhNodeRecord record = OhDht.extractValidRecord(contents, ohId, System.currentTimeMillis());
+    if (record != null) {
+      fireResolved(record);
+    } else {
+      fireFailed();
+    }
+    return contents;
+  }
+
+  @Override
+  protected void fail() {
+    fireFailed();
+  }
+
+  private synchronized void fireResolved(OhNodeRecord record) {
+    if (!callbackFired) {
+      callbackFired = true;
+      onResolved.accept(record);
+    }
+  }
+
+  private synchronized void fireFailed() {
+    if (!callbackFired) {
+      callbackFired = true;
+      onFailed.run();
+    }
+  }
+
+  /** One-shot job adding the randomized anti-profiling delay before the actual DHT search. */
+  static class DelayedSearchJob extends Job {
+
+    private final byte[] ohId;
+    private final Consumer<OhNodeRecord> onResolved;
+    private final Runnable onFailed;
+
+    DelayedSearchJob(
+        ServerContext serverContext,
+        byte[] ohId,
+        Consumer<OhNodeRecord> onResolved,
+        Runnable onFailed) {
+      super(serverContext, 1 + rand.nextLong(LOOKUP_DELAY_JITTER_MS), false, true);
+      this.ohId = ohId;
+      this.onResolved = onResolved;
+      this.onFailed = onFailed;
+    }
+
+    @Override
+    public void init() {
+      // no setup needed
+    }
+
+    @Override
+    public void work() {
+      try {
+        new OhResolveJob(serverContext, ohId, onResolved, onFailed).start();
+        logger.debug("started delayed OH resolve search");
+      } finally {
+        done();
+      }
+    }
+  }
+}

--- a/src/main/java/im/redpanda/jobs/OhResolveJob.java
+++ b/src/main/java/im/redpanda/jobs/OhResolveJob.java
@@ -110,7 +110,8 @@ public class OhResolveJob extends KademliaSearchJob {
         byte[] ohId,
         Consumer<OhNodeRecord> onResolved,
         Runnable onFailed) {
-      super(serverContext, 1 + rand.nextLong(LOOKUP_DELAY_JITTER_MS), false, true);
+      // delay sampled uniformly from [0, LOOKUP_DELAY_JITTER_MS]
+      super(serverContext, rand.nextLong(LOOKUP_DELAY_JITTER_MS + 1), false, true);
       this.ohId = ohId;
       this.onResolved = onResolved;
       this.onFailed = onFailed;

--- a/src/main/java/im/redpanda/outbound/OhDht.java
+++ b/src/main/java/im/redpanda/outbound/OhDht.java
@@ -137,8 +137,12 @@ public final class OhDht {
 
   /**
    * Picks the newest valid announce record for {@code ohId} from DHT search results. A result is
-   * valid only if it is signed by the derived announce key (so no foreign content can be smuggled
-   * in under the searched id), carries the matching oh_id_hash, and is not stale.
+   * valid only if it is signed by the derived announce key (so peers cannot smuggle foreign content
+   * into the answer — the pubkey check also pins the self-certifying Kademlia key, which is derived
+   * from pubkey + record date), has exactly the fixed padded size (uniformity is part of the
+   * anti-profiling contract), carries the matching oh_id_hash, and is not stale. Records up to
+   * {@link #MAX_RECORD_AGE_MS} old are accepted deliberately: a record announced yesterday lives
+   * under yesterday's rotated key and stays usable across the midnight-UTC boundary.
    *
    * @return the parsed record, or {@code null} if none qualifies
    */
@@ -157,6 +161,9 @@ public final class OhDht {
         continue;
       }
       if (nowMs - content.getTimestamp() > MAX_RECORD_AGE_MS) {
+        continue;
+      }
+      if (content.getContent() == null || content.getContent().length != RECORD_SIZE_BYTES) {
         continue;
       }
       if (!Arrays.equals(content.getPubkey(), announcePubkey) || !content.verify()) {

--- a/src/main/java/im/redpanda/outbound/OhDht.java
+++ b/src/main/java/im/redpanda/outbound/OhDht.java
@@ -1,0 +1,180 @@
+package im.redpanda.outbound;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.NodeId;
+import im.redpanda.crypt.Sha256Hash;
+import im.redpanda.kademlia.KadContent;
+import im.redpanda.outbound.v1.OhNodeRecord;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.List;
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
+import org.bouncycastle.jce.spec.ECPrivateKeySpec;
+import org.bouncycastle.jce.spec.ECPublicKeySpec;
+import org.bouncycastle.math.ec.ECPoint;
+
+/**
+ * MS02b OH → host-node discovery primitives.
+ *
+ * <p>The DHT only stores self-certifying records: the Kademlia key is {@code H(dateUTC || pubkey)}
+ * and content is signature-checked against the embedded pubkey. To announce {@code oh_id → host
+ * node} without protocol changes, the announce keypair is <em>derived deterministically from the
+ * oh_id</em> (seed = SHA256(domain tag || oh_id) → EC private key on brainpoolp256r1). Everyone who
+ * knows the oh_id — and only they — can compute the same pubkey, hence the same daily-rotating
+ * Kademlia key, and verify the record signature.
+ *
+ * <p>Trade-off (documented in the milestone): knowing an oh_id is already the capability to deposit
+ * into the mailbox; with the derived key it additionally allows publishing/overwriting the announce
+ * record (newest timestamp wins). Authenticated announces (e.g. binding the record to the
+ * registered oh_auth key) are deferred.
+ *
+ * <p>Anti-profiling: records are padded to a fixed {@link #RECORD_SIZE_BYTES} so stored/answered
+ * record sizes do not reveal which OH is being announced or resolved; announce and lookup jobs add
+ * randomized delays (see {@code OhAnnounceJob} / {@code OhResolveJob}).
+ */
+public final class OhDht {
+
+  static {
+    Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+  }
+
+  /** Domain separation tag: announce keys live in their own namespace, distinct from node ids. */
+  private static final byte[] DOMAIN_TAG =
+      "redpanda.oh.announce.v1".getBytes(StandardCharsets.UTF_8);
+
+  /** Fixed serialized size of every {@link OhNodeRecord} (padding field fills the remainder). */
+  public static final int RECORD_SIZE_BYTES = 256;
+
+  /** Maximum age of an announce record before it is considered stale at resolve time. */
+  public static final long MAX_RECORD_AGE_MS = 1000L * 60 * 60 * 26; // 26h: daily rotation + slack
+
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+  private OhDht() {}
+
+  /**
+   * Derives the deterministic announce NodeId for an oh_id: {@code d = (SHA256(tag || oh_id) mod
+   * (n-1)) + 1}, {@code Q = d·G} on brainpoolp256r1. Same oh_id → same keypair on every node.
+   */
+  public static NodeId deriveAnnounceNodeId(byte[] ohId) {
+    ByteBuffer seedInput = ByteBuffer.allocate(DOMAIN_TAG.length + ohId.length);
+    seedInput.put(DOMAIN_TAG).put(ohId);
+    byte[] seed = Sha256Hash.create(seedInput.array()).getBytes();
+
+    ECNamedCurveParameterSpec spec = ECNamedCurveTable.getParameterSpec("brainpoolp256r1");
+    BigInteger n = spec.getN();
+    BigInteger d = new BigInteger(1, seed).mod(n.subtract(BigInteger.ONE)).add(BigInteger.ONE);
+    ECPoint q = spec.getG().multiply(d).normalize();
+
+    try {
+      KeyFactory keyFactory = KeyFactory.getInstance("ECDH", "BC");
+      PrivateKey privateKey = keyFactory.generatePrivate(new ECPrivateKeySpec(d, spec));
+      PublicKey publicKey = keyFactory.generatePublic(new ECPublicKeySpec(q, spec));
+      return new NodeId(new KeyPair(publicKey, privateKey));
+    } catch (GeneralSecurityException e) {
+      throw new IllegalStateException("failed to derive OH announce keypair", e);
+    }
+  }
+
+  /**
+   * The Kademlia key the announce record for this oh_id lives under at {@code timestampMs} (the key
+   * rotates with the UTC date, like all KadContent ids).
+   */
+  public static KademliaId announceKademliaId(byte[] ohId, long timestampMs) {
+    return KadContent.createKademliaId(timestampMs, deriveAnnounceNodeId(ohId).exportPublic());
+  }
+
+  /**
+   * Builds the signed, fixed-size announce KadContent mapping {@code ohId} to {@code hostNodeId}.
+   * Only the node id is stored (no endpoint): a sender resolves the host node's connection points
+   * via the regular NodeInfo lookup, so a single record reveals as little as possible.
+   */
+  public static KadContent buildAnnounceContent(byte[] ohId, KademliaId hostNodeId, long nowMs) {
+    OhNodeRecord.Builder record =
+        OhNodeRecord.newBuilder()
+            .setOhIdHash(ByteString.copyFrom(Sha256Hash.create(ohId).getBytes()))
+            .setNodeId(ByteString.copyFrom(hostNodeId.getBytes()))
+            .setAnnouncedAtMs(nowMs);
+
+    byte[] padded = padToFixedSize(record);
+
+    NodeId announceNodeId = deriveAnnounceNodeId(ohId);
+    KadContent kadContent = new KadContent(nowMs, announceNodeId.exportPublic(), padded);
+    kadContent.signWith(announceNodeId);
+    return kadContent;
+  }
+
+  /** Pads the record with random bytes so the serialized size is exactly RECORD_SIZE_BYTES. */
+  private static byte[] padToFixedSize(OhNodeRecord.Builder record) {
+    int unpadded = record.clearPadding().build().getSerializedSize();
+    // Search the padding length whose field overhead (tag + length varint) lands exactly on the
+    // target; the varint length can shift by one byte around the 127-byte boundary.
+    for (int padLen = Math.max(0, RECORD_SIZE_BYTES - unpadded - 3);
+        padLen <= RECORD_SIZE_BYTES - unpadded;
+        padLen++) {
+      byte[] padding = new byte[padLen];
+      SECURE_RANDOM.nextBytes(padding);
+      byte[] serialized = record.setPadding(ByteString.copyFrom(padding)).build().toByteArray();
+      if (serialized.length == RECORD_SIZE_BYTES) {
+        return serialized;
+      }
+    }
+    throw new IllegalStateException(
+        "OhNodeRecord does not fit RECORD_SIZE_BYTES=" + RECORD_SIZE_BYTES);
+  }
+
+  /**
+   * Picks the newest valid announce record for {@code ohId} from DHT search results. A result is
+   * valid only if it is signed by the derived announce key (so no foreign content can be smuggled
+   * in under the searched id), carries the matching oh_id_hash, and is not stale.
+   *
+   * @return the parsed record, or {@code null} if none qualifies
+   */
+  public static OhNodeRecord extractValidRecord(
+      List<KadContent> contents, byte[] ohId, long nowMs) {
+    if (contents == null || contents.isEmpty()) {
+      return null;
+    }
+    byte[] announcePubkey = deriveAnnounceNodeId(ohId).exportPublic();
+    byte[] expectedHash = Sha256Hash.create(ohId).getBytes();
+
+    OhNodeRecord best = null;
+    long bestTimestamp = Long.MIN_VALUE;
+    for (KadContent content : contents) {
+      if (content == null || content.getTimestamp() <= bestTimestamp) {
+        continue;
+      }
+      if (nowMs - content.getTimestamp() > MAX_RECORD_AGE_MS) {
+        continue;
+      }
+      if (!Arrays.equals(content.getPubkey(), announcePubkey) || !content.verify()) {
+        continue;
+      }
+      OhNodeRecord record;
+      try {
+        record = OhNodeRecord.parseFrom(content.getContent());
+      } catch (InvalidProtocolBufferException e) {
+        continue;
+      }
+      if (!Arrays.equals(record.getOhIdHash().toByteArray(), expectedHash)
+          || record.getNodeId().size() != KademliaId.ID_LENGTH_BYTES) {
+        continue;
+      }
+      best = record;
+      bestTimestamp = content.getTimestamp();
+    }
+    return best;
+  }
+}

--- a/src/main/java/im/redpanda/outbound/OutboundHandleStore.java
+++ b/src/main/java/im/redpanda/outbound/OutboundHandleStore.java
@@ -6,9 +6,12 @@ import im.redpanda.crypt.Utils;
 import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.bouncycastle.util.encoders.Hex;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
 import org.mapdb.Serializer;
@@ -96,6 +99,20 @@ public class OutboundHandleStore {
     String handleKey = Utils.bytesToHexString(ohId);
     handles.remove(handleKey);
     if (db != null) db.commit();
+  }
+
+  /**
+   * Returns the oh_ids of all non-expired handles (MS02b: used by the periodic DHT announce job).
+   */
+  public List<byte[]> listActiveOhIds(long now) {
+    List<byte[]> result = new ArrayList<>();
+    for (Map.Entry<String, HandleRecord> entry : handles.entrySet()) {
+      HandleRecord record = entry.getValue();
+      if (record != null && record.getExpiresAtMs() >= now) {
+        result.add(Hex.decode(entry.getKey()));
+      }
+    }
+    return result;
   }
 
   public void close() {

--- a/src/main/java/im/redpanda/outbound/OutboundService.java
+++ b/src/main/java/im/redpanda/outbound/OutboundService.java
@@ -27,6 +27,9 @@ import java.util.WeakHashMap;
 
 public class OutboundService {
 
+  private static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(OutboundService.class);
+
   /** Result of a deposit attempt (MS02b: callers must distinguish rejection from "not local"). */
   public enum DepositResult {
     /** Stored in a locally registered OH mailbox. */
@@ -134,8 +137,13 @@ public class OutboundService {
 
     handleStore.put(ohId, handleRecord);
 
-    // MS02b: make the fresh handle resolvable via the DHT announce
-    ohRegisteredListener.accept(ohId);
+    // MS02b: make the fresh handle resolvable via the DHT announce. Best-effort — a failing
+    // announce hook must never break the register flow (the handle is already stored).
+    try {
+      ohRegisteredListener.accept(ohId);
+    } catch (RuntimeException e) {
+      logger.warn("OH announce hook failed after register", e);
+    }
 
     // 3. Response
     sendRegisterResponse(peer, Status.OK, validExpiresAt);

--- a/src/main/java/im/redpanda/outbound/OutboundService.java
+++ b/src/main/java/im/redpanda/outbound/OutboundService.java
@@ -50,6 +50,12 @@ public class OutboundService {
   private final OutboundAuth auth;
   private final SecureRandom secureRandom = new SecureRandom();
 
+  /**
+   * MS02b: invoked with the oh_id after every successful register, so the host node can announce
+   * the OH → node mapping to the DHT promptly (wired up in App, no-op by default and in tests).
+   */
+  private volatile java.util.function.Consumer<byte[]> ohRegisteredListener = ohId -> {};
+
   // Configuration (could be in LocalSettings)
   private static final long MAX_TTL_MS = 7L * 24 * 60 * 60 * 1000; // 7 days
   private static final long MIN_TTL_MS = 10L * 60 * 1000; // 10 minutes
@@ -128,8 +134,16 @@ public class OutboundService {
 
     handleStore.put(ohId, handleRecord);
 
+    // MS02b: make the fresh handle resolvable via the DHT announce
+    ohRegisteredListener.accept(ohId);
+
     // 3. Response
     sendRegisterResponse(peer, Status.OK, validExpiresAt);
+  }
+
+  /** Sets the MS02b post-register hook (DHT announce trigger). */
+  public void setOhRegisteredListener(java.util.function.Consumer<byte[]> listener) {
+    this.ohRegisteredListener = listener != null ? listener : ohId -> {};
   }
 
   public void handleFetch(Peer peer, FetchRequest req) {

--- a/src/main/proto/outbound.proto
+++ b/src/main/proto/outbound.proto
@@ -82,6 +82,18 @@ message FlaschenpostPutResponse {
   int64 server_time_ms = 2;
 }
 
+// MS02b: DHT announce record mapping an OH to its host node. Stored as KadContent signed by a
+// keypair deterministically derived from the oh_id (domain tag "redpanda.oh.announce.v1"), so
+// anyone who knows the oh_id can compute the lookup key — and only they can. The serialized
+// record is padded to a fixed size so record size does not reveal which OH is announced.
+message OhNodeRecord {
+  bytes oh_id_hash = 1;     // SHA256(oh_id) — binds the record to the OH
+  bytes node_id = 2;        // 20-byte KademliaId of the host node
+  string endpoint = 3;      // optional "host:port"; empty = resolve node_id via NodeInfo lookup
+  int64 announced_at_ms = 4;
+  bytes padding = 5;        // random bytes padding the record to OhDht.RECORD_SIZE_BYTES
+}
+
 message RevokeOhRequest {
   bytes oh_id = 1;
   int64 timestamp_ms = 2;

--- a/src/test/java/im/redpanda/outbound/OhDhtTest.java
+++ b/src/test/java/im/redpanda/outbound/OhDhtTest.java
@@ -1,0 +1,194 @@
+package im.redpanda.outbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.ByteString;
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.NodeId;
+import im.redpanda.crypt.Sha256Hash;
+import im.redpanda.kademlia.KadContent;
+import im.redpanda.outbound.v1.OhNodeRecord;
+import java.security.SecureRandom;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * MS02b: tests for the OH → host-node DHT discovery primitives — deterministic announce-key
+ * derivation, fixed-size (padded) records, and validation of resolve results.
+ */
+public class OhDhtTest {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private static byte[] randomOhId() {
+    byte[] ohId = new byte[20];
+    RANDOM.nextBytes(ohId);
+    return ohId;
+  }
+
+  private static KademliaId randomNodeKadId() {
+    byte[] bytes = new byte[KademliaId.ID_LENGTH_BYTES];
+    RANDOM.nextBytes(bytes);
+    return new KademliaId(bytes);
+  }
+
+  // --- Announce key derivation ---
+
+  @Test
+  public void deriveAnnounceNodeId_isDeterministic() {
+    byte[] ohId = randomOhId();
+
+    NodeId first = OhDht.deriveAnnounceNodeId(ohId);
+    NodeId second = OhDht.deriveAnnounceNodeId(ohId);
+
+    assertThat(first.exportPublic()).isEqualTo(second.exportPublic());
+    assertThat(first.getKademliaId()).isEqualTo(second.getKademliaId());
+  }
+
+  @Test
+  public void deriveAnnounceNodeId_differsPerOhId() {
+    NodeId first = OhDht.deriveAnnounceNodeId(randomOhId());
+    NodeId second = OhDht.deriveAnnounceNodeId(randomOhId());
+
+    assertThat(first.exportPublic()).isNotEqualTo(second.exportPublic());
+  }
+
+  @Test
+  public void deriveAnnounceNodeId_exportsWireCompatiblePublicKeyAndSigns() {
+    NodeId announceId = OhDht.deriveAnnounceNodeId(randomOhId());
+
+    // Same public key length as regular NodeIds → fits all existing wire formats
+    byte[] publicKey = announceId.exportPublic();
+    assertThat(publicKey).hasSize(NodeId.PUBLIC_KEYLEN);
+
+    // Sign with the derived private key, verify against the re-imported public key
+    byte[] message = "announce-test".getBytes();
+    byte[] signature = announceId.sign(message);
+    NodeId imported = NodeId.importPublic(publicKey);
+    assertThat(imported.verify(message, signature)).isTrue();
+  }
+
+  @Test
+  public void announceKademliaId_sameForEveryoneKnowingOhId() {
+    byte[] ohId = randomOhId();
+    long timestamp = System.currentTimeMillis();
+
+    assertThat(OhDht.announceKademliaId(ohId, timestamp))
+        .isEqualTo(OhDht.announceKademliaId(ohId.clone(), timestamp));
+  }
+
+  // --- Announce record building (padding) ---
+
+  @Test
+  public void buildAnnounceContent_recordsHaveConstantSize() {
+    long now = System.currentTimeMillis();
+    int expectedSize = OhDht.RECORD_SIZE_BYTES;
+
+    for (int i = 0; i < 20; i++) {
+      KadContent content = OhDht.buildAnnounceContent(randomOhId(), randomNodeKadId(), now);
+      assertThat(content.getContent())
+          .as("every announce record must be padded to the same size")
+          .hasSize(expectedSize);
+    }
+  }
+
+  @Test
+  public void buildAnnounceContent_isSignedAndStoredUnderDerivedKey() {
+    byte[] ohId = randomOhId();
+    KademliaId hostNode = randomNodeKadId();
+    long now = System.currentTimeMillis();
+
+    KadContent content = OhDht.buildAnnounceContent(ohId, hostNode, now);
+
+    assertThat(content.verify()).isTrue();
+    assertThat(content.getId()).isEqualTo(OhDht.announceKademliaId(ohId, now));
+    assertThat(content.getPubkey()).isEqualTo(OhDht.deriveAnnounceNodeId(ohId).exportPublic());
+  }
+
+  // --- Resolve-result validation ---
+
+  @Test
+  public void extractValidRecord_returnsRecordWithHostNode() throws Exception {
+    byte[] ohId = randomOhId();
+    KademliaId hostNode = randomNodeKadId();
+    long now = System.currentTimeMillis();
+
+    KadContent content = OhDht.buildAnnounceContent(ohId, hostNode, now);
+    OhNodeRecord record = OhDht.extractValidRecord(List.of(content), ohId, now);
+
+    assertThat(record).isNotNull();
+    assertThat(record.getNodeId().toByteArray()).isEqualTo(hostNode.getBytes());
+    assertThat(record.getOhIdHash().toByteArray()).isEqualTo(Sha256Hash.create(ohId).getBytes());
+  }
+
+  @Test
+  public void extractValidRecord_picksNewestValidRecord() {
+    byte[] ohId = randomOhId();
+    long now = System.currentTimeMillis();
+    KademliaId oldNode = randomNodeKadId();
+    KademliaId newNode = randomNodeKadId();
+
+    KadContent older = OhDht.buildAnnounceContent(ohId, oldNode, now - 10_000);
+    KadContent newer = OhDht.buildAnnounceContent(ohId, newNode, now);
+
+    OhNodeRecord record = OhDht.extractValidRecord(List.of(older, newer), ohId, now);
+
+    assertThat(record).isNotNull();
+    assertThat(record.getNodeId().toByteArray())
+        .as("the record with the newest timestamp wins (OH migration)")
+        .isEqualTo(newNode.getBytes());
+  }
+
+  @Test
+  public void extractValidRecord_rejectsRecordSignedByForeignKey() {
+    byte[] ohId = randomOhId();
+    byte[] otherOhId = randomOhId();
+    long now = System.currentTimeMillis();
+
+    // Record announced for ANOTHER oh_id (signed by a different derived key)
+    KadContent foreign = OhDht.buildAnnounceContent(otherOhId, randomNodeKadId(), now);
+
+    assertThat(OhDht.extractValidRecord(List.of(foreign), ohId, now)).isNull();
+  }
+
+  @Test
+  public void extractValidRecord_rejectsTamperedOhIdHash() throws Exception {
+    byte[] ohId = randomOhId();
+    long now = System.currentTimeMillis();
+
+    // Forge a record claiming the right oh_id_hash is something else; even when signed with the
+    // correct derived key, a mismatching hash must be rejected.
+    NodeId announceNodeId = OhDht.deriveAnnounceNodeId(ohId);
+    OhNodeRecord forgedRecord =
+        OhNodeRecord.newBuilder()
+            .setOhIdHash(ByteString.copyFrom(new byte[32]))
+            .setNodeId(ByteString.copyFrom(randomNodeKadId().getBytes()))
+            .setAnnouncedAtMs(now)
+            .build();
+    KadContent forged =
+        new KadContent(now, announceNodeId.exportPublic(), forgedRecord.toByteArray());
+    forged.signWith(announceNodeId);
+
+    assertThat(OhDht.extractValidRecord(List.of(forged), ohId, now)).isNull();
+  }
+
+  @Test
+  public void extractValidRecord_rejectsStaleRecord() {
+    byte[] ohId = randomOhId();
+    long now = System.currentTimeMillis();
+
+    KadContent stale =
+        OhDht.buildAnnounceContent(ohId, randomNodeKadId(), now - OhDht.MAX_RECORD_AGE_MS - 1);
+
+    assertThat(OhDht.extractValidRecord(List.of(stale), ohId, now)).isNull();
+  }
+
+  @Test
+  public void extractValidRecord_emptyOrNullInput_returnsNull() {
+    byte[] ohId = randomOhId();
+    long now = System.currentTimeMillis();
+
+    assertThat(OhDht.extractValidRecord(List.of(), ohId, now)).isNull();
+    assertThat(OhDht.extractValidRecord(null, ohId, now)).isNull();
+  }
+}

--- a/src/test/java/im/redpanda/outbound/OhDhtTest.java
+++ b/src/test/java/im/redpanda/outbound/OhDhtTest.java
@@ -173,6 +173,26 @@ public class OhDhtTest {
   }
 
   @Test
+  public void extractValidRecord_rejectsNonPaddedRecord() {
+    byte[] ohId = randomOhId();
+    long now = System.currentTimeMillis();
+
+    // Correctly derived key but content without the fixed-size padding — must be rejected
+    // (uniform record size is part of the anti-profiling contract)
+    NodeId announceNodeId = OhDht.deriveAnnounceNodeId(ohId);
+    OhNodeRecord unpadded =
+        OhNodeRecord.newBuilder()
+            .setOhIdHash(ByteString.copyFrom(Sha256Hash.create(ohId).getBytes()))
+            .setNodeId(ByteString.copyFrom(randomNodeKadId().getBytes()))
+            .setAnnouncedAtMs(now)
+            .build();
+    KadContent content = new KadContent(now, announceNodeId.exportPublic(), unpadded.toByteArray());
+    content.signWith(announceNodeId);
+
+    assertThat(OhDht.extractValidRecord(List.of(content), ohId, now)).isNull();
+  }
+
+  @Test
   public void extractValidRecord_rejectsStaleRecord() {
     byte[] ohId = randomOhId();
     long now = System.currentTimeMillis();

--- a/src/test/java/im/redpanda/outbound/OutboundServiceIntegrationTest.java
+++ b/src/test/java/im/redpanda/outbound/OutboundServiceIntegrationTest.java
@@ -386,6 +386,20 @@ public class OutboundServiceIntegrationTest {
     assertThat(announced).hasSize(1);
   }
 
+  /** The announce hook is best-effort: a throwing listener must not break the register flow. */
+  @Test
+  public void testRegister_throwingListenerDoesNotBreakRegister() throws Exception {
+    service.setOhRegisteredListener(
+        ohId -> {
+          throw new IllegalStateException("announce scheduler down");
+        });
+
+    service.handleRegister(peer, createSignedRegisterRequest());
+
+    assertThat(readRegisterResponse().getStatus()).isEqualTo(Status.OK);
+    assertThat(handleStore.get(clientNode.getKademliaId().getBytes())).isNotNull();
+  }
+
   // --- MS02b AC: register rate limit per connection ---
 
   @Test

--- a/src/test/java/im/redpanda/outbound/OutboundServiceIntegrationTest.java
+++ b/src/test/java/im/redpanda/outbound/OutboundServiceIntegrationTest.java
@@ -364,6 +364,28 @@ public class OutboundServiceIntegrationTest {
     assertThat(readFetchResponse().getItemsCount()).isZero();
   }
 
+  // --- MS02b: successful register triggers the OH announce hook ---
+
+  @Test
+  public void testRegister_invokesOhRegisteredListener() throws Exception {
+    java.util.List<byte[]> announced = new java.util.ArrayList<>();
+    service.setOhRegisteredListener(announced::add);
+
+    service.handleRegister(peer, createSignedRegisterRequest());
+    assertThat(readRegisterResponse().getStatus()).isEqualTo(Status.OK);
+
+    assertThat(announced).hasSize(1);
+    assertThat(announced.get(0)).isEqualTo(clientNode.getKademliaId().getBytes());
+
+    // Failed registers (bad signature) must not trigger the announce hook
+    RegisterOhRequest valid = createSignedRegisterRequest();
+    RegisterOhRequest tampered =
+        valid.toBuilder().setSignature(ByteString.copyFrom(new byte[80])).build();
+    service.handleRegister(peer, tampered);
+    readRegisterResponse();
+    assertThat(announced).hasSize(1);
+  }
+
   // --- MS02b AC: register rate limit per connection ---
 
   @Test


### PR DESCRIPTION
## Backend-MS02b (OH Discovery & Forwarding) — Teil 2/3: OH→Node-Discovery

Implementiert den DHT-Announce `H(oh_id) → Host-Node` aus der [MS02b-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms02b_oh_discovery_forwarding.md) (Abschnitt 2). Baut auf #217 auf; Teil 3 (Forwarding) nutzt die Resolution.

### Design: abgeleitete Announce-Keys statt neuem Wire-Format

Die DHT speichert nur selbstzertifizierende Records (Kademlia-Key = `H(dateUTC || pubkey)`, Signaturprüfung gegen den eingebetteten Pubkey). Ein Record unter beliebigem Key `H(oh_id)` passt nicht in dieses Modell. Statt das Wire-Format zu ändern, wird das Announce-Keypair **deterministisch aus der oh_id abgeleitet**: `seed = SHA256("redpanda.oh.announce.v1" || oh_id)` → EC-Private-Key auf brainpoolp256r1. Jeder, der die oh_id kennt — und nur der — kann denselben Pubkey, damit denselben (täglich rotierenden) Lookup-Key berechnen und die Signatur prüfen. Null Protokolländerungen; alte Nodes speichern/servieren die Records wie jeden KadContent.

**Dokumentierter Trade-off:** Wer eine oh_id kennt, kann bereits in die Mailbox einzahlen; mit dem abgeleiteten Key kann er zusätzlich den Announce-Record überschreiben (höchster Timestamp gewinnt). Authentifizierte Announces (Bindung an den registrierten oh_auth-Key) sind bewusst auf später verschoben. Der Domain-Tag trennt den Announce-Namespace von Node-Ids (keine Shadowing-Möglichkeit).

### Anti-Profiling (Akzeptanzkriterium)
- **Padding:** Jeder `OhNodeRecord` (neue Message in outbound.proto) wird auf konstante 256 Bytes gepadded — Record-Größe verrät nicht, welcher OH announced/aufgelöst wird. Es wird nur die Node-Id gespeichert, kein Endpoint (Open Question 2 der Spec → minimale Preisgabe pro Record; Endpoint-Auflösung läuft über den regulären NodeInfo-Lookup).
- **Randomized Delay:** Announces werden pro OH zufällig gestaggert (0–30 s) und die Job-Periode gejittert (30 ± 5 min); der Resolve-Lookup startet erst nach zufälligem Delay (0–1,5 s). Lokale KadStore-Treffer antworten sofort (lokaler Read leakt nichts).

### Änderungen
- **OhDht**: Key-Ableitung, Record-Bau (gepadded, signiert), Validierung von Resolve-Ergebnissen (Pubkey == abgeleiteter Key, oh_id_hash-Bindung, Staleness ≤ 26 h).
- **OhAnnounceJob**: periodischer Announce aller aktiven Handles; sofortiger Announce nach erfolgreichem RegisterOh via Listener-Hook in OutboundService (in App verdrahtet, no-op in Tests).
- **OhResolveJob**: KademliaSearchJob-Subklasse mit Resolved/Failed-Callbacks; `resolve()` prüft erst lokal.
- **OutboundHandleStore.listActiveOhIds()** für den Announce-Job.

### Akzeptanzkriterien (MS02b)
- [x] DHT-Announce `H(oh_id) → NodeInfo` (Host-Node-Id), täglich rotierend, Re-Announce alle ~30 min
- [x] Lookups/Announces mit Padding und randomisiertem Delay
- [x] `oh_id`-Announce-Namespace per Domain-Tag von Node-KademliaIds getrennt

### Tests
232 Tests grün (`mvn test`); neu: Determinismus der Key-Ableitung, Wire-Kompatibilität (65-Byte-Pubkey, Sign/Verify-Roundtrip), konstante Record-Größe über 20 zufällige OHs, newest-wins, Reject von fremd signierten/manipulierten/stale Records, Register-Hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)