### PR TITLE
MS02b: Cross-node OH forwarding (Option A) — preserve oh_id, hop limit, DHT-resolved routing

### DIFF
--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -6,6 +6,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import im.redpanda.crypt.Utils;
 import im.redpanda.flaschenpost.GMParser;
+import im.redpanda.flaschenpost.OhForwarder;
 import im.redpanda.jobs.Job;
 import im.redpanda.jobs.KademliaInsertJob;
 import im.redpanda.jobs.KademliaSearchJob;
@@ -829,8 +830,20 @@ public class InboundCommandProcessor {
         respondToDeposit(peer, putMsg, im.redpanda.outbound.v1.Status.BAD_REQUEST);
         return;
       }
-      OutboundService.DepositResult result =
-          outboundService.depositMessage(ohIdBytes.toByteArray(), content);
+      byte[] ohId = ohIdBytes.toByteArray();
+      OutboundService.DepositResult result = outboundService.depositMessage(ohId, content);
+      if (result == OutboundService.DepositResult.NOT_FOUND) {
+        // MS02b: not our OH — forward toward the host node (resolved via the DHT announce),
+        // preserving the oh_id on every hop. Best-effort: OK means "accepted for forwarding".
+        boolean accepted = OhForwarder.forward(serverContext, ohId, content, putMsg.getHopCount());
+        respondToDeposit(
+            peer,
+            putMsg,
+            accepted
+                ? im.redpanda.outbound.v1.Status.OK
+                : im.redpanda.outbound.v1.Status.NOT_FOUND);
+        return;
+      }
       if (result != OutboundService.DepositResult.DEPOSITED) {
         logger.debug("FlaschenpostPut deposit not stored: {}", result);
       }
@@ -862,7 +875,16 @@ public class InboundCommandProcessor {
    * Attempts to extract the destination KademliaId from a GarlicMessage-formatted payload and
    * deposit it into a locally registered Outbound Handle mailbox.
    *
-   * @return true if the message was deposited into a local OH mailbox
+   * <p><b>Scheduled for removal (MS02b domain-separation decision):</b> this legacy fallback treats
+   * a 20-byte garlic <em>node</em> destination directly as an {@code oh_id}, so OH ids and node
+   * KademliaIds share one undifferentiated namespace (a registered OH can shadow a node id). It
+   * only exists because the explicit {@code oh_id} field was added after the first prototype; the
+   * frontend has sent an explicit {@code oh_id} since Frontend-MS01. Once no legacy traffic
+   * remains, remove this method and the implicit shared-namespace behavior — new code must never
+   * rely on it.
+   *
+   * @return true if the deposit targeted a locally registered OH (stored or rejected by the MS02b
+   *     hardening — in both cases the packet is handled here)
    */
   private boolean tryDepositToLocalOh(byte[] content) {
     if (outboundService == null) {

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -831,6 +831,13 @@ public class InboundCommandProcessor {
         return;
       }
       byte[] ohId = ohIdBytes.toByteArray();
+      // Pre-check the size limit before any deposit/forward decision: an oversized payload is
+      // rejected by every host node anyway, so forwarding it (and answering OK) would only waste
+      // hops and mislead the sender.
+      if (content.length > im.redpanda.outbound.OutboundMailboxStore.MAX_ITEM_BYTES) {
+        respondToDeposit(peer, putMsg, im.redpanda.outbound.v1.Status.BAD_REQUEST);
+        return;
+      }
       OutboundService.DepositResult result = outboundService.depositMessage(ohId, content);
       if (result == OutboundService.DepositResult.NOT_FOUND) {
         // MS02b: not our OH — forward toward the host node (resolved via the DHT announce),

--- a/src/main/java/im/redpanda/flaschenpost/GMParser.java
+++ b/src/main/java/im/redpanda/flaschenpost/GMParser.java
@@ -316,13 +316,28 @@ public class GMParser {
   }
 
   private static void sendFpToPeer(Peer peerToSendFP, byte[] content) {
+    sendFpToPeer(peerToSendFP, content, null, 0);
+  }
+
+  /**
+   * Writes a FlaschenpostPut to the peer. MS02b (Option A): when {@code ohId} is non-null it is
+   * preserved on the forwarded packet, so the destination node can deposit into the correct mailbox
+   * — before MS02b the packet was rebuilt with {@code content} only and the oh_id was lost. {@code
+   * hopCount} carries the forwarding budget (loop protection).
+   */
+  public static void sendFpToPeer(Peer peerToSendFP, byte[] content, byte[] ohId, int hopCount) {
     peerToSendFP.getWriteBufferLock().lock();
     try {
-      var putMsg =
+      var builder =
           im.redpanda.proto.FlaschenpostPut.newBuilder()
-              .setContent(com.google.protobuf.ByteString.copyFrom(content))
-              .build();
-      byte[] data = putMsg.toByteArray();
+              .setContent(com.google.protobuf.ByteString.copyFrom(content));
+      if (ohId != null) {
+        builder.setOhId(com.google.protobuf.ByteString.copyFrom(ohId));
+      }
+      if (hopCount > 0) {
+        builder.setHopCount(hopCount);
+      }
+      byte[] data = builder.build().toByteArray();
 
       peerToSendFP.writeBuffer.put(Command.FLASCHENPOST_PUT);
       peerToSendFP.writeBuffer.putInt(data.length);

--- a/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
+++ b/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
@@ -73,7 +73,11 @@ public final class OhForwarder {
       return;
     }
 
-    TreeSet<Peer> candidates = new TreeSet<>(new PeerComparator(targetNodeId));
+    // tie-break equal XOR distances by KademliaId so the TreeSet never collapses distinct peers
+    TreeSet<Peer> candidates =
+        new TreeSet<>(
+            new PeerComparator(targetNodeId)
+                .thenComparing(peer -> peer.getKademliaId().toString()));
     Lock lock = peerList.getReadWriteLock().readLock();
     lock.lock();
     try {
@@ -97,15 +101,20 @@ public final class OhForwarder {
       return;
     }
 
-    Node targetNode = serverContext.getNodeStore().get(targetNodeId);
-    org.jgrapht.Graph<Node, NodeEdge> graph = serverContext.getNodeStore().getNodeGraph();
-    GMParser.RouteSelection selection =
-        GMParser.selectBestRoutePeer(
-            graph, serverContext.getNode(), candidates, targetNode, GMParser.MAX_ROUTE_WEIGHT);
+    // Graph routing needs our own Node, which is wired late during startup — fall back to the
+    // greedy Kademlia step below until it is available.
+    Node self = serverContext.getNode();
+    if (self != null) {
+      Node targetNode = serverContext.getNodeStore().get(targetNodeId);
+      org.jgrapht.Graph<Node, NodeEdge> graph = serverContext.getNodeStore().getNodeGraph();
+      GMParser.RouteSelection selection =
+          GMParser.selectBestRoutePeer(
+              graph, self, candidates, targetNode, GMParser.MAX_ROUTE_WEIGHT);
 
-    if (selection.peer() != null) {
-      GMParser.sendFpToPeer(selection.peer(), content, ohId, hopCount + 1);
-      return;
+      if (selection.peer() != null) {
+        GMParser.sendFpToPeer(selection.peer(), content, ohId, hopCount + 1);
+        return;
+      }
     }
 
     // No graph route — greedy Kademlia fallback: next hop must be strictly closer to the target

--- a/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
+++ b/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
@@ -1,0 +1,122 @@
+package im.redpanda.flaschenpost;
+
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.Node;
+import im.redpanda.core.Peer;
+import im.redpanda.core.PeerList;
+import im.redpanda.core.ServerContext;
+import im.redpanda.jobs.OhResolveJob;
+import im.redpanda.kademlia.PeerComparator;
+import im.redpanda.store.NodeEdge;
+import java.util.ArrayList;
+import java.util.TreeSet;
+import java.util.concurrent.locks.Lock;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * MS02b cross-node OH delivery (Option A): a FlaschenpostPut whose {@code oh_id} is not registered
+ * locally is forwarded toward the OH host node — resolved via the DHT announce record (see {@code
+ * OhDht}) — with the {@code oh_id} preserved on every hop, so the destination node deposits into
+ * the correct mailbox exactly as for a directly connected sender.
+ *
+ * <p>Loop protection: every forward increments {@code hop_count}; packets that arrive at the hop
+ * limit are dropped. Delivery is best-effort (like the rest of the flaschenpost layer).
+ */
+@Slf4j
+public final class OhForwarder {
+
+  /** Maximum number of node-to-node forwards before a packet is dropped. */
+  public static final int MAX_HOPS = 3;
+
+  private OhForwarder() {}
+
+  /**
+   * Forwards a deposit for a non-local OH toward its host node. Resolution result and routing
+   * happen asynchronously (the DHT lookup is randomized-delayed against profiling).
+   *
+   * @param hopCount the hop count the packet arrived with
+   * @return {@code true} if forwarding was initiated (hop budget available), {@code false} if the
+   *     packet was dropped at the hop limit
+   */
+  public static boolean forward(
+      ServerContext serverContext, byte[] ohId, byte[] content, int hopCount) {
+    if (hopCount >= MAX_HOPS) {
+      log.debug("dropping FlaschenpostPut for unknown OH at hop limit {}", hopCount);
+      return false;
+    }
+    OhResolveJob.resolve(
+        serverContext,
+        ohId,
+        record -> {
+          byte[] nodeIdBytes = record.getNodeId().toByteArray();
+          routeToNode(serverContext, new KademliaId(nodeIdBytes), ohId, content, hopCount);
+        },
+        () -> log.debug("OH host resolution failed, dropping forwarded deposit"));
+    return true;
+  }
+
+  /**
+   * Routes the packet toward {@code targetNodeId}: directly if connected, otherwise via the
+   * cheapest next hop in the weighted node graph (same selection as garlic routing).
+   */
+  static void routeToNode(
+      ServerContext serverContext,
+      KademliaId targetNodeId,
+      byte[] ohId,
+      byte[] content,
+      int hopCount) {
+    PeerList peerList = serverContext.getPeerList();
+
+    Peer direct = peerList.get(targetNodeId);
+    if (direct != null && direct.isConnected()) {
+      GMParser.sendFpToPeer(direct, content, ohId, hopCount + 1);
+      return;
+    }
+
+    TreeSet<Peer> candidates = new TreeSet<>(new PeerComparator(targetNodeId));
+    Lock lock = peerList.getReadWriteLock().readLock();
+    lock.lock();
+    try {
+      ArrayList<Peer> peerArrayList = peerList.getPeerArrayList();
+      if (peerArrayList == null) {
+        return;
+      }
+      for (Peer p : peerArrayList) {
+        // same candidate filter as garlic routing: connected full nodes with known node id
+        if (p.getNodeId() == null || !p.isConnected() || !p.hasNode() || p.isLightClient()) {
+          continue;
+        }
+        candidates.add(p);
+      }
+    } finally {
+      lock.unlock();
+    }
+
+    if (candidates.isEmpty()) {
+      log.debug("no candidate peer to forward OH deposit toward {}", targetNodeId);
+      return;
+    }
+
+    Node targetNode = serverContext.getNodeStore().get(targetNodeId);
+    org.jgrapht.Graph<Node, NodeEdge> graph = serverContext.getNodeStore().getNodeGraph();
+    GMParser.RouteSelection selection =
+        GMParser.selectBestRoutePeer(
+            graph, serverContext.getNode(), candidates, targetNode, GMParser.MAX_ROUTE_WEIGHT);
+
+    if (selection.peer() != null) {
+      GMParser.sendFpToPeer(selection.peer(), content, ohId, hopCount + 1);
+      return;
+    }
+
+    // No graph route — greedy Kademlia fallback: next hop must be strictly closer to the target
+    // than we are (forward progress), the hop limit bounds the worst case.
+    Peer nearest = candidates.first();
+    int ourDistance = targetNodeId.getDistance(serverContext.getNonce());
+    int nearestDistance = targetNodeId.getDistance(nearest.getKademliaId());
+    if (nearestDistance < ourDistance) {
+      GMParser.sendFpToPeer(nearest, content, ohId, hopCount + 1);
+    } else {
+      log.debug("no peer closer to OH host {} than ourselves, dropping", targetNodeId);
+    }
+  }
+}

--- a/src/main/java/im/redpanda/outbound/OutboundMailboxStore.java
+++ b/src/main/java/im/redpanda/outbound/OutboundMailboxStore.java
@@ -62,7 +62,7 @@ public class OutboundMailboxStore {
    * (BAD_REQUEST): the 500-item cap alone counts items, not bytes, so a single item could otherwise
    * be arbitrarily large.
    */
-  static final int MAX_ITEM_BYTES = 64 * 1024;
+  public static final int MAX_ITEM_BYTES = 64 * 1024;
 
   /**
    * Byte quota per mailbox, independent of the item count. Deposits that would exceed it are

--- a/src/main/proto/commands.proto
+++ b/src/main/proto/commands.proto
@@ -63,6 +63,9 @@ message FlaschenpostPut {
     // MS02b: if set by a directly connected light client, the node answers with
     // FlaschenpostPutResponse (command 158). Full nodes never set this.
     bool want_response = 3;
+    // MS02b: number of node-to-node forwards this packet has taken. Incremented on every
+    // forward; packets at the hop limit are dropped instead of forwarded (loop protection).
+    uint32 hop_count = 4;
 }
 
 // Unified envelope for future-proofing or batching, 

--- a/src/main/proto/outbound.proto
+++ b/src/main/proto/outbound.proto
@@ -73,8 +73,9 @@ message AckFetchResponse {
 
 // MS02b: optional response to a FlaschenpostPut deposit (command 158). Only sent to light
 // clients that set FlaschenpostPut.want_response, so existing clients never see it.
-//   OK             — deposited into a locally registered OH
-//   NOT_FOUND      — oh_id not registered here
+//   OK             — deposited into a locally registered OH, or accepted for best-effort
+//                    forwarding toward the OH host node (MS02b)
+//   NOT_FOUND      — oh_id not registered here and forwarding not possible (hop limit)
 //   QUOTA_EXCEEDED — mailbox full (item cap or byte quota); deposit rejected, nothing displaced
 //   BAD_REQUEST    — item exceeds the per-item size limit
 message FlaschenpostPutResponse {

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
@@ -384,14 +384,53 @@ public class InboundCommandProcessorFlaschenpostPutTest {
     assertEquals(im.redpanda.outbound.v1.Status.OK, res.getStatus());
   }
 
-  /** Light client with want_response gets NOT_FOUND when the OH is not registered here. */
+  /**
+   * Light client with want_response gets OK when the OH is unknown here but forwarding toward the
+   * host node was accepted (MS02b best-effort forwarding).
+   */
   @Test
-  public void flaschenpostPut_lightClientWantResponse_receivesNotFoundForUnknownOh() {
+  public void flaschenpostPut_lightClientWantResponse_unknownOhAcceptedForForwarding() {
     byte[] ohId = sampleOhId(); // not registered
 
     im.redpanda.outbound.v1.FlaschenpostPutResponse res =
         depositAndReadResponse(ohId, new byte[32], true, true);
-    assertEquals(im.redpanda.outbound.v1.Status.NOT_FOUND, res.getStatus());
+    assertEquals(im.redpanda.outbound.v1.Status.OK, res.getStatus());
+  }
+
+  /** At the hop limit an unknown OH is NOT forwarded again — the client sees NOT_FOUND. */
+  @Test
+  public void flaschenpostPut_lightClientWantResponse_unknownOhAtHopLimitIsNotFound() {
+    byte[] ohId = sampleOhId(); // not registered
+
+    FlaschenpostPut putMsg =
+        FlaschenpostPut.newBuilder()
+            .setContent(copyFrom(new byte[32]))
+            .setOhId(ByteString.copyFrom(ohId))
+            .setWantResponse(true)
+            .setHopCount(im.redpanda.flaschenpost.OhForwarder.MAX_HOPS)
+            .build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9101, ctx.getNodeId());
+    peer.setConnected(true);
+    peer.setLightClient(true);
+    peer.writeBuffer = ByteBuffer.allocate(8192);
+    ctx.getPeerList().add(peer);
+    proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+
+    ByteBuffer buf = peer.writeBuffer;
+    buf.flip();
+    assertEquals(Command.FLASCHENPOST_PUT_RES, buf.get());
+    int len = buf.getInt();
+    byte[] payload = new byte[len];
+    buf.get(payload);
+    try {
+      assertEquals(
+          im.redpanda.outbound.v1.Status.NOT_FOUND,
+          im.redpanda.outbound.v1.FlaschenpostPutResponse.parseFrom(payload).getStatus());
+    } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+      throw new AssertionError(e);
+    }
   }
 
   /** Full nodes never receive command 158, even if they set want_response. */

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
@@ -397,6 +397,20 @@ public class InboundCommandProcessorFlaschenpostPutTest {
     assertEquals(im.redpanda.outbound.v1.Status.OK, res.getStatus());
   }
 
+  /**
+   * Oversized payloads are rejected up front with BAD_REQUEST — even for unknown OHs — instead of
+   * being forwarded through the network only to be rejected by the host node.
+   */
+  @Test
+  public void flaschenpostPut_oversizedPayloadToUnknownOh_isRejectedNotForwarded() {
+    byte[] ohId = sampleOhId(); // not registered
+    byte[] oversized = new byte[OutboundMailboxStore.MAX_ITEM_BYTES + 1];
+
+    im.redpanda.outbound.v1.FlaschenpostPutResponse res =
+        depositAndReadResponse(ohId, oversized, true, true);
+    assertEquals(im.redpanda.outbound.v1.Status.BAD_REQUEST, res.getStatus());
+  }
+
   /** At the hop limit an unknown OH is NOT forwarded again — the client sees NOT_FOUND. */
   @Test
   public void flaschenpostPut_lightClientWantResponse_unknownOhAtHopLimitIsNotFound() {

--- a/src/test/java/im/redpanda/flaschenpost/OhForwarderTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/OhForwarderTest.java
@@ -1,0 +1,174 @@
+package im.redpanda.flaschenpost;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.ByteString;
+import im.redpanda.core.Command;
+import im.redpanda.core.InboundCommandProcessor;
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.NodeId;
+import im.redpanda.core.Peer;
+import im.redpanda.core.ServerContext;
+import im.redpanda.outbound.OhDht;
+import im.redpanda.outbound.OutboundHandleStore;
+import im.redpanda.outbound.OutboundMailboxStore;
+import im.redpanda.outbound.OutboundService;
+import im.redpanda.outbound.v1.MailItem;
+import im.redpanda.proto.FlaschenpostPut;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * MS02b acceptance: a FlaschenpostPut whose OH is not registered locally is forwarded across an
+ * intermediate node with the {@code oh_id} preserved and deposited into the correct mailbox on the
+ * host node.
+ */
+public class OhForwarderTest {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  /** Intermediate node A — receives the deposit but does not host the OH. */
+  private ServerContext nodeA;
+
+  private InboundCommandProcessor processorA;
+
+  /** Host node B — hosts the OH mailbox. */
+  private ServerContext nodeB;
+
+  private InboundCommandProcessor processorB;
+  private OutboundMailboxStore mailboxB;
+  private OutboundHandleStore handleStoreB;
+
+  private byte[] ohId;
+
+  @Before
+  public void setUp() {
+    nodeA = ServerContext.buildDefaultServerContext();
+    nodeA.setOutboundService(
+        new OutboundService(new OutboundHandleStore(), new OutboundMailboxStore()));
+    processorA = new InboundCommandProcessor(nodeA);
+
+    nodeB = ServerContext.buildDefaultServerContext();
+    handleStoreB = new OutboundHandleStore();
+    mailboxB = new OutboundMailboxStore();
+    nodeB.setOutboundService(new OutboundService(handleStoreB, mailboxB));
+    processorB = new InboundCommandProcessor(nodeB);
+
+    ohId = new byte[KademliaId.ID_LENGTH_BYTES];
+    RANDOM.nextBytes(ohId);
+
+    // OH registered on node B only
+    long now = System.currentTimeMillis();
+    handleStoreB.put(ohId, new OutboundHandleStore.HandleRecord(new byte[65], now, now + 60_000));
+  }
+
+  /** Builds a [4-byte len][payload] frame as expected by {@code parseCommand}. */
+  private static ByteBuffer buildFrame(byte[] payload) {
+    ByteBuffer buf = ByteBuffer.allocate(4 + payload.length);
+    buf.putInt(payload.length);
+    buf.put(payload);
+    buf.flip();
+    return buf;
+  }
+
+  /** Connects a peer object representing node B to node A's peer list. */
+  private Peer connectPeerForNodeB() {
+    Peer peerB = new Peer("127.0.0.1", 9301, nodeB.getNodeId());
+    peerB.setConnected(true);
+    peerB.writeBuffer = ByteBuffer.allocate(65536);
+    nodeA.getPeerList().add(peerB);
+    return peerB;
+  }
+
+  @Test
+  public void forwardedDeposit_acrossIntermediateNode_keepsOhIdAndLandsInMailbox()
+      throws Exception {
+    // Node B has announced its OH in the DHT; node A has the (padded, signed) record locally.
+    nodeA
+        .getKadStoreManager()
+        .put(
+            OhDht.buildAnnounceContent(
+                ohId, nodeB.getNodeId().getKademliaId(), System.currentTimeMillis()));
+
+    Peer peerB = connectPeerForNodeB();
+
+    // A light client deposits at node A (which does NOT host the OH)
+    byte[] payload = "cross-node message".getBytes(StandardCharsets.UTF_8);
+    FlaschenpostPut put =
+        FlaschenpostPut.newBuilder()
+            .setContent(ByteString.copyFrom(payload))
+            .setOhId(ByteString.copyFrom(ohId))
+            .build();
+    Peer lightClient = new Peer("127.0.0.1", 9300, nodeA.getNodeId());
+    lightClient.setConnected(true);
+    nodeA.getPeerList().add(lightClient);
+
+    processorA.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(put.toByteArray()), lightClient);
+
+    // Node A must have forwarded a FLASCHENPOST_PUT to peer B with the oh_id preserved
+    ByteBuffer outA = peerB.writeBuffer;
+    outA.flip();
+    assertThat(outA.hasRemaining()).as("node A must forward to the resolved host node").isTrue();
+    assertThat(outA.get()).isEqualTo(Command.FLASCHENPOST_PUT);
+    byte[] forwardedBytes = new byte[outA.getInt()];
+    outA.get(forwardedBytes);
+
+    FlaschenpostPut forwarded = FlaschenpostPut.parseFrom(forwardedBytes);
+    assertThat(forwarded.getOhId().toByteArray())
+        .as("Option A: oh_id must survive the forward hop")
+        .isEqualTo(ohId);
+    assertThat(forwarded.getContent().toByteArray()).isEqualTo(payload);
+    assertThat(forwarded.getHopCount()).isEqualTo(1);
+    assertThat(forwarded.getWantResponse())
+        .as("hop-local response flag must not propagate")
+        .isFalse();
+
+    // Node B processes the forwarded packet — the message lands in the correct mailbox
+    Peer peerA = new Peer("127.0.0.1", 9302, nodeA.getNodeId());
+    peerA.setConnected(true);
+    nodeB.getPeerList().add(peerA);
+    processorB.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(forwardedBytes), peerA);
+
+    List<MailItem> items = mailboxB.fetchMessages(ohId, 10, 0);
+    assertThat(items).hasSize(1);
+    assertThat(items.get(0).getPayload().toByteArray()).isEqualTo(payload);
+  }
+
+  @Test
+  public void forwardedDeposit_atHopLimit_isDroppedNotForwarded() {
+    nodeA
+        .getKadStoreManager()
+        .put(
+            OhDht.buildAnnounceContent(
+                ohId, nodeB.getNodeId().getKademliaId(), System.currentTimeMillis()));
+    Peer peerB = connectPeerForNodeB();
+
+    FlaschenpostPut put =
+        FlaschenpostPut.newBuilder()
+            .setContent(ByteString.copyFrom(new byte[16]))
+            .setOhId(ByteString.copyFrom(ohId))
+            .setHopCount(OhForwarder.MAX_HOPS)
+            .build();
+    Peer sender = new Peer("127.0.0.1", 9303, nodeA.getNodeId());
+    sender.setConnected(true);
+    nodeA.getPeerList().add(sender);
+
+    processorA.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(put.toByteArray()), sender);
+
+    peerB.writeBuffer.flip();
+    assertThat(peerB.writeBuffer.hasRemaining())
+        .as("a packet at the hop limit must not be forwarded")
+        .isFalse();
+  }
+
+  @Test
+  public void routeToNode_withoutDirectPeer_dropsWhenNoCloserCandidate() {
+    // No peers at all — routing must simply drop without throwing
+    OhForwarder.routeToNode(
+        nodeA, NodeId.generateWithSimpleKey().getKademliaId(), ohId, new byte[8], 0);
+  }
+}


### PR DESCRIPTION
## Backend-MS02b (OH Discovery & Forwarding) — Teil 3/3: Forwarding

Schließt die Kernlücke der [MS02b-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms02b_oh_discovery_forwarding.md) (Abschnitt 1, **Option A** wie empfohlen): Zustellung funktionierte bisher nur, wenn der Sender direkt mit dem OH-Host verbunden war — `sendFpToPeer()` baute die weitergeleitete `FlaschenpostPut` ohne `oh_id` neu, und der Mobile-Client deposited bei *irgendeinem* verbundenen Full Node. Baut auf #217 und #218 auf.

### Änderungen

- **`GMParser.sendFpToPeer()`**: neuer Overload trägt `oh_id` und `hop_count` (neues Feld 4 in `FlaschenpostPut`) auf dem weitergeleiteten Paket — die oh_id überlebt jetzt jeden Hop (Option A).
- **`OhForwarder`** (neu): Deposits für nicht-lokale OHs werden zum Host-Node geroutet, der via DHT-Announce-Record aufgelöst wird (#218; lokaler Cache-Hit synchron, Netz-Lookup mit Anti-Profiling-Delay). Routing: direkter Peer → günstigste Route im gewichteten Node-Graph (`selectBestRoutePeer`, wie Garlic-Routing) → greedy Kademlia-Fallback nur bei striktem Fortschritt zum Ziel. **Hop-Limit 3** als Loop-Schutz.
- **`InboundCommandProcessor`**: `NOT_FOUND`-Deposits gehen in den Forwarding-Pfad; Light Clients mit `want_response` erhalten `OK` (= deposited **oder** zum Forwarding angenommen, best-effort) bzw. `NOT_FOUND` am Hop-Limit. `want_response` propagiert nicht auf weitergeleitete Pakete (hop-lokal).
- **Domänentrennungs-Entscheidung (MS02b Abschnitt 4)**: Der Legacy-Garlic-Header-Fallback `tryDepositToLocalOh()` ist als **scheduled for removal** dokumentiert (oh_id/Node-Id teilen dort einen Namespace; das Frontend sendet seit MS01 immer ein explizites oh_id).

### Akzeptanzkriterien (MS02b)
- [x] Eine über mindestens einen Zwischen-Node weitergeleitete `FlaschenpostPut` trägt weiterhin `oh_id` und landet in der richtigen Mailbox (Akzeptanztest `OhForwarderTest#forwardedDeposit_acrossIntermediateNode_keepsOhIdAndLandsInMailbox`: Light Client → Node A → Node B → Mailbox)
- [x] Ein Sender ohne Direktverbindung zum OH-Host kann zustellen (Node A löst den Host via DHT-Record auf und forwarded)
- [x] Legacy-Fallback zur Entfernung eingeplant und dokumentiert (Domänentrennung)

### Tests
234 Tests grün (`mvn test`); neu: Cross-Node-Akzeptanztest (oh_id/Content/hop_count auf dem Draht geprüft, want_response propagiert nicht), Hop-Limit-Drop, Routing ohne Kandidaten wirft nicht, Response-Matrix-Update (OK bei angenommenem Forwarding, NOT_FOUND am Hop-Limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)