### PR TITLE
docs: sync milestone mirrors (Backend-MS02b Done)

### DIFF
--- a/milestones/00_status_overview.md
+++ b/milestones/00_status_overview.md
@@ -18,7 +18,7 @@ Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den
 |----|-------|--------|----------------------|
 | [MS01](ms01_first_real_message.md) | OH Service Stabilization | Done (PoC) | Frontend MS01 kann starten |
 | [MS02](ms02_reliable_delivery.md) | Reliable Mailbox & Lifecycle | Done | Frontend MS02 kann starten |
-| [MS02b](ms02b_oh_discovery_forwarding.md) | OH Discovery & Forwarding | Missing | Messaging über Node-Grenzen hinweg; Deposit-Härtung |
+| [MS02b](ms02b_oh_discovery_forwarding.md) | OH Discovery & Forwarding | Done | Frontend MS02b kann starten (Status-Codes, `want_response`) |
 | [MS03](ms03_authenticated_encryption.md) | Crypto Migration (Ed25519/X25519/GCM) | Missing | Frontend MS03 blocked — Handshake-Protokoll muss zuerst stehen |
 | [MS03b](ms03b_forward_secrecy.md) | Forward Secrecy | Missing | Minimaler Backend-Anteil — Ratchet ist Ende-zu-Ende zwischen Clients |
 | [MS04](ms04_multi_hop_garlic.md) | Multi-Hop Relay | Partial | Frontend MS04 blocked — Relay-Peeling muss serverseitig funktionieren |
@@ -34,7 +34,9 @@ Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den
 |-----------|------|--------|
 | OH Registration / Fetch / Revoke | `OutboundService.java` | Done (PoC) |
 | OH Handle persistence (MapDB) | `OutboundHandleStore.java` | Done |
-| OH Mailbox persistence (MapDB) | `OutboundMailboxStore.java` | Done — sequence-based, delete-after-acknowledge |
+| OH Mailbox persistence (MapDB) | `OutboundMailboxStore.java` | Done — sequence-based, delete-after-acknowledge, reject-new + Quotas (MS02b) |
+| OH → Node Discovery (DHT) | `OhDht.java`, `OhAnnounceJob.java`, `OhResolveJob.java` | Done — derived announce keys, 256-B-Padding, Jitter |
+| OH Forwarding (Option A) | `OhForwarder.java`, `GMParser.java` | Done — oh_id + hop_count erhalten, max. 3 Hops |
 | OH Auth (ECDSA + replay) | `OutboundAuth.java` | Done (PoC) — in-memory replay cache |
 | Garlic encryption (single layer) | `GarlicMessage.java` | Done |
 | Kademlia DHT | `KadStoreManager.java` | Done (in-memory) |

--- a/milestones/ms02b_oh_discovery_forwarding.md
+++ b/milestones/ms02b_oh_discovery_forwarding.md
@@ -1,6 +1,14 @@
 # Backend MS02b: OH Discovery & Forwarding
 
-## Status: Missing
+## Status: Done (2026-06-11)
+
+Umgesetzt in redpandaj [#217](https://github.com/redPanda-project/redpandaj/pull/217) (Deposit-Härtung), [#218](https://github.com/redPanda-project/redpandaj/pull/218) (OH→Node-Discovery) und [#219](https://github.com/redPanda-project/redpandaj/pull/219) (Forwarding Option A). Entscheidungen und beantwortete Open Questions: siehe [Decisions in der Master-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms02b_oh_discovery_forwarding.md#decisions-backend-2026-06-11).
+
+**Implementiert:**
+- **Forwarding (Option A):** `sendFpToPeer()` trägt `oh_id` + `hop_count` (max. 3); nicht-lokale Deposits werden via DHT-Record zum Host-Node geroutet (`OhForwarder`); expliziter `oh_id`-Pfad ist authoritativ (kein Legacy-Fallthrough mehr).
+- **Discovery:** Announce-Keypair deterministisch aus oh_id abgeleitet (`OhDht`, Domain-Tag `redpanda.oh.announce.v1`), `OhNodeRecord` fix 256 Bytes gepadded, nur Node-Id im Record; `OhAnnounceJob` (30 ± 5 min + Stagger, Announce direkt nach Register), `OhResolveJob` (Lookup mit 0–1,5 s Zufallsdelay).
+- **Deposit-Härtung:** reject-new statt drop-oldest, 64 KiB Per-Item-Limit, 4 MiB Byte-Quota pro Mailbox, Register-Rate-Limit 5/min pro Verbindung; Status-Codes `RATE_LIMIT`/`QUOTA_EXCEEDED`/`BAD_REQUEST` erstmals verdrahtet via Opt-in-Response (`want_response`, Command 158, nur Light Clients).
+- **Domänentrennung:** Legacy-Garlic-Header-Fallback (`tryDepositToLocalOh`) als *scheduled for removal* dokumentiert.
 
 > **Master-Spec**: [Master-Spec im docs-Repo](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms02b_oh_discovery_forwarding.md) — MS02b ist fast vollständig Backend-Arbeit; dies ist die Backend-Sicht.
 > **Frontend-Alignment**: [Frontend MS02b](https://github.com/redPanda-project/docs/blob/main/docs/milestones/frontend/ms02b_oh_discovery_forwarding.md) (kleiner Anteil).

--- a/milestones/ms02b_oh_discovery_forwarding.md
+++ b/milestones/ms02b_oh_discovery_forwarding.md
@@ -5,7 +5,7 @@
 Umgesetzt in redpandaj [#217](https://github.com/redPanda-project/redpandaj/pull/217) (Deposit-Härtung), [#218](https://github.com/redPanda-project/redpandaj/pull/218) (OH→Node-Discovery) und [#219](https://github.com/redPanda-project/redpandaj/pull/219) (Forwarding Option A). Entscheidungen und beantwortete Open Questions: siehe [Decisions in der Master-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms02b_oh_discovery_forwarding.md#decisions-backend-2026-06-11).
 
 **Implementiert:**
-- **Forwarding (Option A):** `sendFpToPeer()` trägt `oh_id` + `hop_count` (max. 3); nicht-lokale Deposits werden via DHT-Record zum Host-Node geroutet (`OhForwarder`); expliziter `oh_id`-Pfad ist authoritativ (kein Legacy-Fallthrough mehr).
+- **Forwarding (Option A):** `sendFpToPeer()` trägt `oh_id` + `hop_count` (max. 3); nicht-lokale Deposits werden via DHT-Record zum Host-Node geroutet (`OhForwarder`); expliziter `oh_id`-Pfad ist autoritativ (kein Legacy-Fallthrough mehr).
 - **Discovery:** Announce-Keypair deterministisch aus oh_id abgeleitet (`OhDht`, Domain-Tag `redpanda.oh.announce.v1`), `OhNodeRecord` fix 256 Bytes gepadded, nur Node-Id im Record; `OhAnnounceJob` (30 ± 5 min + Stagger, Announce direkt nach Register), `OhResolveJob` (Lookup mit 0–1,5 s Zufallsdelay).
 - **Deposit-Härtung:** reject-new statt drop-oldest, 64 KiB Per-Item-Limit, 4 MiB Byte-Quota pro Mailbox, Register-Rate-Limit 5/min pro Verbindung; Status-Codes `RATE_LIMIT`/`QUOTA_EXCEEDED`/`BAD_REQUEST` erstmals verdrahtet via Opt-in-Response (`want_response`, Command 158, nur Light Clients).
 - **Domänentrennung:** Legacy-Garlic-Header-Fallback (`tryDepositToLocalOh`) als *scheduled for removal* dokumentiert.


### PR DESCRIPTION
Mirror-Sync aus dem docs-Repo (Source of Truth, [docs#8](https://github.com/redPanda-project/docs/pull/8)) via `scripts/sync_milestones.sh`: Backend-MS02b → **Done** (#217, #218, #219), Statusmatrix und Component Readiness aktualisiert, Verweis auf die Decisions in der Master-Spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)