### PR TITLE
docs: sync milestone mirrors (Backend-MS03 Done)

### DIFF
--- a/milestones/00_status_overview.md
+++ b/milestones/00_status_overview.md
@@ -1,6 +1,6 @@
 # Backend Milestones — Status Overview
 
-> Last updated: 2026-06-11
+> Last updated: 2026-06-12
 
 Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den fertigen Backend-APIs auf.
 
@@ -19,7 +19,7 @@ Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den
 | [MS01](ms01_first_real_message.md) | OH Service Stabilization | Done (PoC) | Frontend MS01 kann starten |
 | [MS02](ms02_reliable_delivery.md) | Reliable Mailbox & Lifecycle | Done | Frontend MS02 kann starten |
 | [MS02b](ms02b_oh_discovery_forwarding.md) | OH Discovery & Forwarding | Done | Frontend MS02b kann starten (Status-Codes, `want_response`) |
-| [MS03](ms03_authenticated_encryption.md) | Crypto Migration (Ed25519/X25519/GCM) | Missing | Frontend MS03 blocked — Handshake-Protokoll muss zuerst stehen |
+| [MS03](ms03_authenticated_encryption.md) | Crypto Migration (Ed25519/X25519/GCM) | Done | Frontend MS03 kann starten (Handshake v23, Garlic v2, Ed25519 OH-Auth stehen) |
 | [MS03b](ms03b_forward_secrecy.md) | Forward Secrecy | Missing | Minimaler Backend-Anteil — Ratchet ist Ende-zu-Ende zwischen Clients |
 | [MS04](ms04_multi_hop_garlic.md) | Multi-Hop Relay | Partial | Frontend MS04 blocked — Relay-Peeling muss serverseitig funktionieren |
 | [MS05](ms05_reverse_garlic.md) | Reverse Garlic (Relay-Seite) | Missing | Frontend MS05 blocked — CMD_DELIVER mit session_tag muss funktionieren |
@@ -37,10 +37,11 @@ Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den
 | OH Mailbox persistence (MapDB) | `OutboundMailboxStore.java` | Done — sequence-based, delete-after-acknowledge, reject-new + Quotas (MS02b) |
 | OH → Node Discovery (DHT) | `OhDht.java`, `OhAnnounceJob.java`, `OhResolveJob.java` | Done — derived announce keys, 256-B-Padding, Jitter |
 | OH Forwarding (Option A) | `OhForwarder.java`, `GMParser.java` | Done — oh_id + hop_count erhalten, max. 3 Hops |
-| OH Auth (ECDSA + replay) | `OutboundAuth.java` | Done (PoC) — in-memory replay cache |
-| Garlic encryption (single layer) | `GarlicMessage.java` | Done |
-| Kademlia DHT | `KadStoreManager.java` | Done (in-memory) |
-| TCP + ECDH handshake | `ConnectionHandler.java` | Done |
+| OH Auth (Ed25519 + replay) | `OutboundAuth.java` | Done — Ed25519 + Signing-Versions-Byte (MS03), Legacy-ECDSA-Fallback bis v22-Removal |
+| Garlic encryption (single layer) | `GarlicMessage.java` | Done — v2: AES-256-GCM + X25519 + HKDF, AAD = Ziel-KademliaId (MS03) |
+| Kademlia DHT | `KadStoreManager.java` | Done (in-memory) — Ed25519-Signaturen (MS03) |
+| TCP handshake + stream encryption | `ConnectionHandler.java`, `GcmFramedStreams.java` | Done — v23: framed AES-256-GCM, Counter-Nonces; v22 nur noch Light Clients (MS03) |
+| Node identity | `NodeId.java` | Done — Ed25519 (sign) + X25519 (encrypt) Dual-Keypair (MS03) |
 | Proto definitions | `commands.proto`, `outbound.proto` | Done |
 
 ## Dependency Graph (Backend only)

--- a/milestones/ms03_authenticated_encryption.md
+++ b/milestones/ms03_authenticated_encryption.md
@@ -1,6 +1,9 @@
 # Backend MS03: Crypto Migration (Ed25519 / X25519 / AES-256-GCM)
 
-## Status: Missing
+## Status: Done
+
+> **Backend umgesetzt in redpandaj [#221](https://github.com/redPanda-project/redpandaj/pull/221)** (2026-06-12).
+> Entscheidungen und beantwortete Open Questions: siehe [Decisions in der Master-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms03_authenticated_encryption.md#decisions-backend-2026-06-12).
 
 > **Update 2026-06-11**: Die Master-Spec wurde um das **Message-Format v2**
 > (HKDF-Schlüsseltrennung, Version-Byte, inneres `ChannelMessage`) und das
@@ -11,7 +14,8 @@
 > Backend-Milestones.
 
 > **Frontend-Alignment**: Backend MS03 ist Voraussetzung für [Frontend MS03](../frontend/ms03_authenticated_encryption.md).
-> Das neue Handshake-Protokoll (v23) und das Garlic-Wire-Format müssen zuerst auf dem Server stehen.
+> Das neue Handshake-Protokoll (v23) und das Garlic-Wire-Format stehen jetzt auf dem Server —
+> Frontend MS03 kann starten.
 
 ## Goal
 
@@ -22,6 +26,9 @@ Gesamte Kryptographie von brainpoolp256r1 + AES-CTR auf Ed25519 + X25519 + AES-2
 - Backend MS02 (Reliable Mailbox) — stabile Basis vor Breaking Changes
 
 ## Current State
+
+> Historischer Stand **vor** der Umsetzung (2026-06-12) — alle Zeilen sind migriert,
+> siehe [Decisions in der Master-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms03_authenticated_encryption.md#decisions-backend-2026-06-12).
 
 | Component | File | Status |
 |-----------|------|--------|
@@ -158,17 +165,19 @@ Keine strukturellen Änderungen. `bytes`-Felder für Keys und Signaturen passen 
 
 ## Acceptance Criteria
 
-- [ ] `NodeId` verwendet Ed25519 (sign) + X25519 (encrypt) — kein brainpoolp256r1 mehr
-- [ ] GarlicMessage v2 nutzt AES-256-GCM; manipulierter Ciphertext → `AEADBadTagException`
-- [ ] TCP v23 Handshake funktioniert mit 32-byte Keys und framed GCM
-- [ ] TCP v22 Handshake wird noch akzeptiert (Übergangsphase)
-- [ ] OH-Auth nutzt Ed25519 Signaturen (64 bytes)
-- [ ] Keine `RC4`, `ARCFOUR`, `AES/CTR`, `brainpool` Referenzen im Backend-Code
-- [ ] Alle bestehenden Unit-Tests passen mit neuem Crypto-Stack
-- [ ] Wire-Formate (v2 Garlic, v23 Handshake) sind dokumentiert für Frontend-Team
+- [x] `NodeId` verwendet Ed25519 (sign) + X25519 (encrypt) — kein brainpoolp256r1 mehr
+- [x] GarlicMessage v2 nutzt AES-256-GCM; manipulierter Ciphertext → `AEADBadTagException`
+- [x] TCP v23 Handshake funktioniert mit 32-byte Keys und framed GCM
+- [x] TCP v22 Handshake wird noch akzeptiert (Übergangsphase) — nur für Light Clients, siehe Decisions
+- [x] OH-Auth nutzt Ed25519 Signaturen (64 bytes)
+- [x] Keine `RC4`, `ARCFOUR`, `AES/CTR`, `brainpool` Referenzen im Backend-Code — außer dem isolierten, deprecated v22-Legacy-Pfad (`crypt/legacy`), siehe Decisions
+- [x] Alle bestehenden Unit-Tests passen mit neuem Crypto-Stack
+- [x] Wire-Formate (v2 Garlic, v23 Handshake) sind dokumentiert für Frontend-Team
 
 ## Open Questions
 
-1. HKDF vs. einfaches SHA-256 vom shared secret?
-2. Wie lange Dual-Version Support (v22/v23)?
-3. Sollen bestehende NodeIds migriert werden, oder müssen alle Nodes neue Identitäten erzeugen?
+Alle drei ursprünglichen Open Questions sind durch die [Decisions in der Master-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms03_authenticated_encryption.md#decisions-backend-2026-06-12) beantwortet:
+
+1. ~~HKDF vs. einfaches SHA-256 vom shared secret?~~ → HKDF-SHA256 (Decision 1).
+2. ~~Wie lange Dual-Version Support (v22/v23)?~~ → Betriebsentscheidung, technisch per Konstante entfernbar (Decision 4).
+3. ~~Sollen bestehende NodeIds migriert werden?~~ → Nein, neue Identitäten (Decision 3).

--- a/milestones/ms03_authenticated_encryption.md
+++ b/milestones/ms03_authenticated_encryption.md
@@ -13,7 +13,7 @@
 > opak — keine Backend-Änderung); das Signing-Versions-Byte ist Teil dieses
 > Backend-Milestones.
 
-> **Frontend-Alignment**: Backend MS03 ist Voraussetzung für [Frontend MS03](../frontend/ms03_authenticated_encryption.md).
+> **Frontend-Alignment**: Backend MS03 ist Voraussetzung für [Frontend MS03](https://github.com/redPanda-project/docs/blob/main/docs/milestones/frontend/ms03_authenticated_encryption.md).
 > Das neue Handshake-Protokoll (v23) und das Garlic-Wire-Format stehen jetzt auf dem Server —
 > Frontend MS03 kann starten.
 


### PR DESCRIPTION
Mirror-Sync aus dem docs-Repo nach Backend-MS03 (docs#11, redpandaj#221): Backend-View MS03 Done, Status-Overview aktualisiert. Quelle: `docs/scripts/sync_milestones.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)