### PR TITLE
docs: Mirror-Sync MS03b (Backend Done — Verifikation)

### DIFF
--- a/milestones/00_status_overview.md
+++ b/milestones/00_status_overview.md
@@ -20,7 +20,7 @@ Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den
 | [MS02](ms02_reliable_delivery.md) | Reliable Mailbox & Lifecycle | Done | Frontend MS02 kann starten |
 | [MS02b](ms02b_oh_discovery_forwarding.md) | OH Discovery & Forwarding | Done | Frontend MS02b kann starten (Status-Codes, `want_response`) |
 | [MS03](ms03_authenticated_encryption.md) | Crypto Migration (Ed25519/X25519/GCM) | Done | Frontend MS03 kann starten (Handshake v23, Garlic v2, Ed25519 OH-Auth stehen) |
-| [MS03b](ms03b_forward_secrecy.md) | Forward Secrecy | Missing | Minimaler Backend-Anteil — Ratchet ist Ende-zu-Ende zwischen Clients |
+| [MS03b](ms03b_forward_secrecy.md) | Forward Secrecy | Done | Verifiziert 2026-06-12 (keine Code-Änderung): Payloads bleiben opak, 64-KiB-Limit unkritisch — Frontend MS03b Done |
 | [MS04](ms04_multi_hop_garlic.md) | Multi-Hop Relay | Partial | Frontend MS04 blocked — Relay-Peeling muss serverseitig funktionieren |
 | [MS05](ms05_reverse_garlic.md) | Reverse Garlic (Relay-Seite) | Missing | Frontend MS05 blocked — CMD_DELIVER mit session_tag muss funktionieren |
 | [MS06](ms06_two_layer_ack.md) | R-ACK Generation | Missing | Frontend MS06 blocked — OH muss R-ACK erzeugen können |

--- a/milestones/ms03b_forward_secrecy.md
+++ b/milestones/ms03b_forward_secrecy.md
@@ -1,6 +1,6 @@
 # Backend MS03b: Forward Secrecy
 
-## Status: Missing (minimaler Backend-Anteil)
+## Status: Done (2026-06-12 — Verifikation, keine Code-Änderung)
 
 > **Master-Spec**: [Master-Spec im docs-Repo](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms03b_forward_secrecy.md) — der Ratchet
 > läuft Ende-zu-Ende zwischen den Clients; Relays und OH-Mailboxen transportieren weiterhin
@@ -19,4 +19,23 @@
    die Payload — muss innerhalb der Flaschenpost-Limits bleiben (relevant für MS04-Padding,
    2048-Byte-Pakete).
 
-Akzeptanzkriterien und Open Questions: siehe Master-Spec.
+## Verifikationsergebnis (2026-06-12)
+
+Wie erwartet **keine Code-Änderung nötig** (deshalb kein Backend-PR):
+
+1. **Deposit**: `OutboundService.depositMessage(byte[] ohId, byte[] payload)` übernimmt die
+   Payload unverändert als `ByteString` in das `MailItem` — kein Parsen des Inhalts.
+2. **Mailbox**: `OutboundMailboxStore` speichert/liefert serialisierte `MailItem`s; einziges
+   inhaltsunabhängiges Limit ist `MAX_ITEM_BYTES = 64 KiB` pro serialisiertem Item
+   (plus `MAX_ITEMS_PER_MAILBOX = 500` und Byte-Quota, MS02b).
+3. **Forwarding**: `OhForwarder`/`GMParser.sendFpToPeer` reichen `byte[] content` opak weiter
+   (oh_id + hop_count, max. 3 Hops) — keine Annahme über das Payload-Format.
+4. **Größenbudget**: Envelope v4 hat **69 Bytes Festoverhead** (v3: 29; Δ +40 durch
+   `ratchet_pub` 32 + `prev_chain_len` 4 + `chain_counter` 4). Gegen das 64-KiB-Limit
+   irrelevant; für MS04 (2048-Byte-Padding) verbleiben ~1,9 KiB für Content +
+   FlaschenpostPut-Wrapper — Budget dokumentiert in Master-Spec Decision 7.
+
+Die E2E-Suite von redpanda-mobile (Alice→Bob über das Referenz-JAR) läuft mit v4-Payloads
+unverändert grün — bestätigt die Opazität in der Praxis.
+
+Akzeptanzkriterien und Decisions: siehe Master-Spec.


### PR DESCRIPTION
Mirror-Sync aus dem docs-Repo nach Merge von [docs#16](https://github.com/redPanda-project/docs/pull/16): Backend MS03b ist **Done als reine Verifikation** — Deposit/Mailbox/Forwarding behandeln Payloads opak, einziges Limit `MAX_ITEM_BYTES = 64 KiB`; Größenbudget des v4-Envelopes (69 Bytes Festoverhead) dokumentiert. Keine Code-Änderung in diesem Repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)