### PR TITLE
MS04: Multi-Hop Garlic Relay (Flaschenpost v2)

### DIFF
--- a/src/main/java/im/redpanda/core/Command.java
+++ b/src/main/java/im/redpanda/core/Command.java
@@ -31,6 +31,13 @@ public final class Command {
   // flaschenpost
   public static final byte FLASCHENPOST_PUT = (byte) 141;
 
+  /**
+   * MS04: fixed-size (2048 byte) multi-hop garlic packet, see {@link
+   * im.redpanda.flaschenpost.FlaschenpostV2}. Framed like every payload command: {@code
+   * [cmd][len:4][packet]}.
+   */
+  public static final byte FLASCHENPOST_V2 = (byte) 142;
+
   // outbound
   public static final byte OUTBOUND_REGISTER_OH_REQ = (byte) 150;
   public static final byte OUTBOUND_REGISTER_OH_RES = (byte) 151;

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -5,6 +5,7 @@ import static com.google.protobuf.ByteString.copyFrom;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import im.redpanda.flaschenpost.GMParser;
+import im.redpanda.flaschenpost.GarlicRouter;
 import im.redpanda.flaschenpost.OhForwarder;
 import im.redpanda.jobs.Job;
 import im.redpanda.jobs.KademliaInsertJob;
@@ -152,6 +153,13 @@ public class InboundCommandProcessor {
           handleFlaschenpostPut(payload, peer);
           return 1 + 4 + payload.length;
         });
+    commandHandlers.put(
+        Command.FLASCHENPOST_V2,
+        (peer, buf, payload) -> {
+          // MS04 multi-hop garlic relay: dedup, peel own layer or route toward next_hop
+          GarlicRouter.handle(serverContext, payload);
+          return 1 + 4 + payload.length;
+        });
   }
 
   public void loopCommands(Peer peer, ByteBuffer readBuffer) {
@@ -232,6 +240,7 @@ public class InboundCommandProcessor {
         || command == Command.KADEMLIA_STORE
         || command == Command.KADEMLIA_GET_ANSWER
         || command == Command.FLASCHENPOST_PUT
+        || command == Command.FLASCHENPOST_V2
         || command == Command.OUTBOUND_REGISTER_OH_REQ
         || command == Command.OUTBOUND_FETCH_REQ
         || command == Command.OUTBOUND_REVOKE_OH_REQ
@@ -293,6 +302,9 @@ public class InboundCommandProcessor {
               NodeIdProto.newBuilder()
                   .setPublicKeyBytes(copyFrom(peerToCheck.getNodeId().exportPublic()))
                   .build());
+          // MS04: explicit X25519 key so light clients can pick garlic hops directly
+          peerBuilder.setEncryptionPublicKey(
+              copyFrom(peerToCheck.getNodeId().getEncryptionPubKey().getEncoded()));
         }
         builder.addPeers(peerBuilder.build());
       }

--- a/src/main/java/im/redpanda/flaschenpost/FlaschenpostV2.java
+++ b/src/main/java/im/redpanda/flaschenpost/FlaschenpostV2.java
@@ -1,0 +1,199 @@
+package im.redpanda.flaschenpost;
+
+import im.redpanda.core.KademliaId;
+import im.redpanda.crypt.CryptoUtils;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import org.bouncycastle.crypto.params.X25519PrivateKeyParameters;
+import org.bouncycastle.crypto.params.X25519PublicKeyParameters;
+
+/**
+ * Flaschenpost v2 (MS04): fixed-size multi-hop garlic packet.
+ *
+ * <p>Wire format — every packet is exactly {@link #PACKET_SIZE} (2048) bytes:
+ *
+ * <pre>
+ * [1  version = 0x02]
+ * [4  packet_id]          // random int, dedup + loop protection
+ * [20 next_hop]           // KademliaId of the relay that can peel this layer
+ * [12 nonce]              // AES-256-GCM nonce
+ * [32 ephemeral_pub]      // X25519 ephemeral public key for this layer
+ * [4  ciphertext_len]
+ * [N  ciphertext + 16-byte GCM tag]
+ * [P  random padding]     // fill to 2048 bytes total
+ * </pre>
+ *
+ * <p>Key derivation: {@code key = HKDF-SHA256(ikm = X25519(ephemeralPriv, hopEncPub), salt =
+ * ephemeralPub, info = "flaschenpost-v2")}. The AAD is the 20-byte {@code next_hop} KademliaId,
+ * binding each layer to the relay that is meant to peel it. A relay that cannot authenticate the
+ * layer drops the packet silently.
+ *
+ * <p>Layer plaintexts start with a command byte:
+ *
+ * <pre>
+ * CMD_FORWARD (0x01): [1 cmd][20 inner next_hop][12 nonce][32 ephemeral_pub][4 ct_len][ct + tag]
+ * CMD_DELIVER (0x02): [1 cmd][20 oh_id][4 payload_len][payload][optional padding]
+ * </pre>
+ *
+ * After peeling a {@code CMD_FORWARD} layer, the relay rebuilds a fresh 2048-byte packet with a new
+ * random {@code packet_id}, the inner {@code next_hop} and the remaining plaintext as body, padded
+ * with random bytes (see {@link #buildPacket}).
+ */
+public final class FlaschenpostV2 {
+
+  /** Version byte of the fixed-size garlic packet format. */
+  public static final byte VERSION = 0x02;
+
+  /** Every Flaschenpost v2 packet is exactly this many bytes. */
+  public static final int PACKET_SIZE = 2048;
+
+  /** HKDF info string for the per-layer key derivation (domain-separated from "garlic-v2"). */
+  public static final byte[] HKDF_INFO = "flaschenpost-v2".getBytes(StandardCharsets.US_ASCII);
+
+  /** Layer command: peel and forward the inner packet to the contained next hop. */
+  public static final byte CMD_FORWARD = 0x01;
+
+  /** Layer command: final hop — deposit the payload into the OH mailbox. */
+  public static final byte CMD_DELIVER = 0x02;
+
+  /** Length of a layer body prefix: [12 nonce][32 ephemeral_pub][4 ciphertext_len] (48). */
+  public static final int BODY_HEADER_LEN =
+      CryptoUtils.GCM_NONCE_LEN + CryptoUtils.X25519_KEY_LEN + 4;
+
+  /** Header length before the ciphertext: version + packet_id + next_hop + body header (73). */
+  public static final int HEADER_LEN = 1 + 4 + KademliaId.ID_LENGTH_BYTES + BODY_HEADER_LEN;
+
+  /** Maximum ciphertext length (including tag) that fits into a packet (1975). */
+  public static final int MAX_CIPHERTEXT_LEN = PACKET_SIZE - HEADER_LEN;
+
+  /** Minimum ciphertext length: GCM tag + at least the 1-byte layer command (17). */
+  public static final int MIN_CIPHERTEXT_LEN = CryptoUtils.GCM_TAG_LEN + 1;
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private final int packetId;
+  private final KademliaId nextHop;
+  private final byte[] nonce;
+  private final byte[] ephemeralPub;
+  private final byte[] ciphertext;
+
+  private FlaschenpostV2(
+      int packetId, KademliaId nextHop, byte[] nonce, byte[] ephemeralPub, byte[] ciphertext) {
+    this.packetId = packetId;
+    this.nextHop = nextHop;
+    this.nonce = nonce;
+    this.ephemeralPub = ephemeralPub;
+    this.ciphertext = ciphertext;
+  }
+
+  /**
+   * Parses a Flaschenpost v2 packet.
+   *
+   * @return the parsed packet or {@code null} if the packet is malformed (wrong size, wrong
+   *     version, ciphertext length out of bounds)
+   */
+  public static FlaschenpostV2 parse(byte[] packet) {
+    if (packet == null || packet.length != PACKET_SIZE) {
+      return null;
+    }
+    ByteBuffer buffer = ByteBuffer.wrap(packet);
+    if (buffer.get() != VERSION) {
+      return null;
+    }
+    int packetId = buffer.getInt();
+    KademliaId nextHop = KademliaId.fromBuffer(buffer);
+    byte[] nonce = new byte[CryptoUtils.GCM_NONCE_LEN];
+    buffer.get(nonce);
+    byte[] ephemeralPub = new byte[CryptoUtils.X25519_KEY_LEN];
+    buffer.get(ephemeralPub);
+    int ciphertextLen = buffer.getInt();
+    if (ciphertextLen < MIN_CIPHERTEXT_LEN || ciphertextLen > MAX_CIPHERTEXT_LEN) {
+      return null;
+    }
+    byte[] ciphertext = new byte[ciphertextLen];
+    buffer.get(ciphertext);
+    // remaining bytes are padding and are ignored
+    return new FlaschenpostV2(packetId, nextHop, nonce, ephemeralPub, ciphertext);
+  }
+
+  /**
+   * Assembles a 2048-byte packet from a layer body ({@code [nonce][ephemeral_pub][ct_len][ct]} as
+   * produced by {@link #encryptLayer} or carried inside a peeled {@code CMD_FORWARD} plaintext) and
+   * fills the rest with random padding.
+   *
+   * @throws IllegalArgumentException if the body does not fit or is too short
+   */
+  public static byte[] buildPacket(int packetId, KademliaId nextHop, byte[] body) {
+    int minBodyLen = BODY_HEADER_LEN + MIN_CIPHERTEXT_LEN;
+    int maxBodyLen = PACKET_SIZE - 1 - 4 - KademliaId.ID_LENGTH_BYTES;
+    if (body.length < minBodyLen || body.length > maxBodyLen) {
+      throw new IllegalArgumentException("invalid flaschenpost v2 body length: " + body.length);
+    }
+    ByteBuffer buffer = ByteBuffer.allocate(PACKET_SIZE);
+    buffer.put(VERSION);
+    buffer.putInt(packetId);
+    buffer.put(nextHop.getBytes());
+    buffer.put(body);
+    byte[] padding = new byte[buffer.remaining()];
+    RANDOM.nextBytes(padding);
+    buffer.put(padding);
+    return buffer.array();
+  }
+
+  /**
+   * Encrypts one garlic layer for the given hop: generates a fresh ephemeral X25519 key and a
+   * random nonce, derives the AES-256-GCM key via HKDF and authenticates the hop's KademliaId as
+   * AAD. Reference implementation for the client-side layer construction.
+   *
+   * @return the layer body {@code [12 nonce][32 ephemeral_pub][4 ct_len][ciphertext + tag]}
+   */
+  public static byte[] encryptLayer(
+      X25519PublicKeyParameters hopEncryptionKey, KademliaId hopId, byte[] plaintext)
+      throws GeneralSecurityException {
+    byte[] nonce = new byte[CryptoUtils.GCM_NONCE_LEN];
+    RANDOM.nextBytes(nonce);
+    X25519PrivateKeyParameters ephemeralKey = new X25519PrivateKeyParameters(RANDOM);
+    byte[] ephemeralPub = ephemeralKey.generatePublicKey().getEncoded();
+
+    byte[] key = deriveKey(CryptoUtils.x25519(ephemeralKey, hopEncryptionKey), ephemeralPub);
+    byte[] ciphertext = CryptoUtils.encryptGcm(key, nonce, plaintext, hopId.getBytes());
+
+    ByteBuffer body = ByteBuffer.allocate(BODY_HEADER_LEN + ciphertext.length);
+    body.put(nonce);
+    body.put(ephemeralPub);
+    body.putInt(ciphertext.length);
+    body.put(ciphertext);
+    return body.array();
+  }
+
+  /**
+   * Decrypts this packet's layer with our X25519 encryption key. The AAD is the packet's {@code
+   * next_hop}, so this only succeeds on the relay the layer was encrypted for.
+   *
+   * @throws javax.crypto.AEADBadTagException if the layer is not encrypted to us or was tampered
+   *     with — the caller must drop the packet silently
+   */
+  public byte[] decryptLayer(X25519PrivateKeyParameters encryptionKey)
+      throws GeneralSecurityException {
+    byte[] key =
+        deriveKey(
+            CryptoUtils.x25519(encryptionKey, new X25519PublicKeyParameters(ephemeralPub, 0)),
+            ephemeralPub);
+    return CryptoUtils.decryptGcm(key, nonce, ciphertext, nextHop.getBytes());
+  }
+
+  private static byte[] deriveKey(byte[] sharedSecret, byte[] ephemeralPublicKey) {
+    return CryptoUtils.hkdfSha256(
+        sharedSecret, ephemeralPublicKey, HKDF_INFO, CryptoUtils.AES_KEY_LEN);
+  }
+
+  public int getPacketId() {
+    return packetId;
+  }
+
+  public KademliaId getNextHop() {
+    return nextHop;
+  }
+}

--- a/src/main/java/im/redpanda/flaschenpost/GMStoreManager.java
+++ b/src/main/java/im/redpanda/flaschenpost/GMStoreManager.java
@@ -11,7 +11,11 @@ public class GMStoreManager {
   public static final long REMOVE_AFTER_MILLISECONDS = 1000L * 60L * 5L;
   private static final HashMap<GarlicMessage, Long> entries = new HashMap<>();
 
-  /** MS04: seen Flaschenpost v2 packet ids (dedup and loop protection), same 5-minute window. */
+  /**
+   * MS04: seen Flaschenpost v2 packet ids, same 5-minute window. A pure dedup cache for identical
+   * packets — it stops replays and routing loops of the unchanged packet; peeled forwards carry a
+   * fresh packet_id and are bounded by the layer count instead (see {@code GarlicRouter}).
+   */
   private static final HashMap<Integer, Long> v2Entries = new HashMap<>();
 
   private static final ReentrantLock lock = new ReentrantLock();

--- a/src/main/java/im/redpanda/flaschenpost/GMStoreManager.java
+++ b/src/main/java/im/redpanda/flaschenpost/GMStoreManager.java
@@ -10,6 +10,10 @@ public class GMStoreManager {
 
   public static final long REMOVE_AFTER_MILLISECONDS = 1000L * 60L * 5L;
   private static final HashMap<GarlicMessage, Long> entries = new HashMap<>();
+
+  /** MS04: seen Flaschenpost v2 packet ids (dedup and loop protection), same 5-minute window. */
+  private static final HashMap<Integer, Long> v2Entries = new HashMap<>();
+
   private static final ReentrantLock lock = new ReentrantLock();
 
   public static boolean put(GarlicMessage gm) {
@@ -22,21 +26,44 @@ public class GMStoreManager {
     }
   }
 
+  /**
+   * Marks a Flaschenpost v2 {@code packet_id} as seen.
+   *
+   * @return {@code true} if the packet id was already present (duplicate — drop the packet)
+   */
+  public static boolean putV2(int packetId) {
+    lock.lock();
+    try {
+      Long put = v2Entries.put(packetId, System.currentTimeMillis());
+      return put != null;
+    } finally {
+      lock.unlock();
+    }
+  }
+
   public static void cleanUp() {
     long currentTimeMillis = System.currentTimeMillis();
     lock.lock();
     try {
 
-      Iterator<Map.Entry<GarlicMessage, Long>> iterator = entries.entrySet().iterator();
-      while (iterator.hasNext()) {
-        if (currentTimeMillis - iterator.next().getValue() > REMOVE_AFTER_MILLISECONDS) {
-          iterator.remove();
-        }
-      }
+      removeExpired(entries, currentTimeMillis);
+      removeExpired(v2Entries, currentTimeMillis);
 
-      Log.put("remaining entries in GMStoreManager after cleanup: %d".formatted(entries.size()), 0);
+      Log.put(
+          "remaining entries in GMStoreManager after cleanup: %d v2: %d"
+              .formatted(entries.size(), v2Entries.size()),
+          0);
     } finally {
       lock.unlock();
+    }
+  }
+
+  private static void removeExpired(HashMap<?, Long> map, long currentTimeMillis) {
+    Iterator<? extends Map.Entry<?, Long>> iterator = map.entrySet().iterator();
+    while (iterator.hasNext()) {
+      if (currentTimeMillis - iterator.next().getValue() > REMOVE_AFTER_MILLISECONDS) {
+        iterator.remove();
+      }
     }
   }
 }

--- a/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
+++ b/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
@@ -1,0 +1,158 @@
+package im.redpanda.flaschenpost;
+
+import im.redpanda.core.Command;
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.Peer;
+import im.redpanda.core.ServerContext;
+import im.redpanda.outbound.OutboundService;
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * MS04 stateless garlic relay: handles inbound {@link Command#FLASCHENPOST_V2} packets.
+ *
+ * <ul>
+ *   <li>Dedup: a {@code packet_id} is processed at most once per node (5-minute window) — this is
+ *       also the loop protection, the packet intentionally carries no hop counter (it would leak
+ *       the position in the path).
+ *   <li>If {@code next_hop} is not us, the packet is routed unchanged toward {@code next_hop}
+ *       (Kademlia step between garlic hops).
+ *   <li>If it is us, the layer is peeled: {@code CMD_FORWARD} rebuilds a fresh 2048-byte packet
+ *       (new random packet_id, new random padding) and routes it to the inner next hop; {@code
+ *       CMD_DELIVER} deposits the payload into the local OH mailbox (falling back to the MS02b
+ *       {@link OhForwarder} if the OH is hosted on another node).
+ *   <li>Any malformed or unauthenticated packet is dropped silently (best-effort layer, no error
+ *       responses).
+ * </ul>
+ */
+@Slf4j
+public final class GarlicRouter {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private GarlicRouter() {}
+
+  /** Entry point for a received FLASCHENPOST_V2 payload (the raw 2048-byte packet). */
+  public static void handle(ServerContext serverContext, byte[] packet) {
+    FlaschenpostV2 fp = FlaschenpostV2.parse(packet);
+    if (fp == null) {
+      log.debug("dropping malformed flaschenpost v2 packet");
+      return;
+    }
+    if (GMStoreManager.putV2(fp.getPacketId())) {
+      log.debug("dropping duplicate flaschenpost v2 packet {}", fp.getPacketId());
+      return;
+    }
+    if (!fp.getNextHop().equals(serverContext.getNonce())) {
+      routeToNextHop(serverContext, fp.getNextHop(), packet);
+      return;
+    }
+
+    byte[] plaintext;
+    try {
+      plaintext = fp.decryptLayer(serverContext.getNodeId().getEncryptionKey());
+    } catch (GeneralSecurityException e) {
+      // not encrypted to us or tampered with — drop silently, never flood-forward
+      log.debug("flaschenpost v2 layer authentication failed, dropping packet");
+      return;
+    }
+
+    byte cmd = plaintext[0]; // MIN_CIPHERTEXT_LEN guarantees at least one plaintext byte
+    switch (cmd) {
+      case FlaschenpostV2.CMD_FORWARD -> handleForward(serverContext, plaintext);
+      case FlaschenpostV2.CMD_DELIVER -> handleDeliver(serverContext, plaintext);
+      default -> log.debug("unknown flaschenpost v2 layer command {}, dropping", cmd);
+    }
+  }
+
+  /** CMD_FORWARD: [1 cmd][20 next_hop][body = nonce|ephemeral_pub|ct_len|ct]. */
+  private static void handleForward(ServerContext serverContext, byte[] plaintext) {
+    int minLen =
+        1
+            + KademliaId.ID_LENGTH_BYTES
+            + FlaschenpostV2.BODY_HEADER_LEN
+            + FlaschenpostV2.MIN_CIPHERTEXT_LEN;
+    if (plaintext.length < minLen) {
+      log.debug("flaschenpost v2 forward layer too short, dropping");
+      return;
+    }
+    KademliaId innerNextHop =
+        KademliaId.fromBuffer(ByteBuffer.wrap(plaintext, 1, KademliaId.ID_LENGTH_BYTES));
+    byte[] body = Arrays.copyOfRange(plaintext, 1 + KademliaId.ID_LENGTH_BYTES, plaintext.length);
+
+    byte[] rebuilt;
+    try {
+      // fresh random packet_id so the dedup caches on the next hops never collide
+      rebuilt = FlaschenpostV2.buildPacket(RANDOM.nextInt(), innerNextHop, body);
+    } catch (IllegalArgumentException e) {
+      log.debug("flaschenpost v2 inner packet invalid, dropping: {}", e.getMessage());
+      return;
+    }
+    if (FlaschenpostV2.parse(rebuilt) == null) {
+      log.debug("rebuilt flaschenpost v2 packet invalid, dropping");
+      return;
+    }
+    routeToNextHop(serverContext, innerNextHop, rebuilt);
+  }
+
+  /** CMD_DELIVER: [1 cmd][20 oh_id][4 payload_len][payload][ignored padding]. */
+  private static void handleDeliver(ServerContext serverContext, byte[] plaintext) {
+    if (plaintext.length < 1 + KademliaId.ID_LENGTH_BYTES + 4) {
+      log.debug("flaschenpost v2 deliver layer too short, dropping");
+      return;
+    }
+    ByteBuffer buffer = ByteBuffer.wrap(plaintext);
+    buffer.get(); // command byte
+    byte[] ohId = new byte[KademliaId.ID_LENGTH_BYTES];
+    buffer.get(ohId);
+    int payloadLen = buffer.getInt();
+    if (payloadLen < 0 || payloadLen > buffer.remaining()) {
+      log.debug("flaschenpost v2 deliver payload length invalid, dropping");
+      return;
+    }
+    byte[] payload = new byte[payloadLen];
+    buffer.get(payload);
+
+    OutboundService outboundService = serverContext.getOutboundService();
+    if (outboundService == null) {
+      return;
+    }
+    OutboundService.DepositResult result = outboundService.depositMessage(ohId, payload);
+    if (result == OutboundService.DepositResult.NOT_FOUND) {
+      // the final garlic hop does not have to be the OH host — reuse the MS02b forwarding
+      OhForwarder.forward(serverContext, ohId, payload, 0);
+    } else if (result != OutboundService.DepositResult.DEPOSITED) {
+      log.debug("flaschenpost v2 deliver not stored: {}", result);
+    }
+  }
+
+  /**
+   * Routes a (raw, still 2048-byte) packet toward {@code nextHop} using the shared next-peer
+   * selection: direct connection, weighted graph route or greedy Kademlia step. Best-effort —
+   * without a route the packet is dropped silently.
+   */
+  static void routeToNextHop(ServerContext serverContext, KademliaId nextHop, byte[] packet) {
+    Peer peer = OhForwarder.selectNextPeer(serverContext, nextHop);
+    if (peer == null) {
+      log.debug("no route toward flaschenpost v2 next hop {}, dropping", nextHop);
+      return;
+    }
+    sendToPeer(peer, packet);
+  }
+
+  /** Writes a FLASCHENPOST_V2 frame ([cmd][len:4][packet]) to the peer. */
+  public static void sendToPeer(Peer peer, byte[] packet) {
+    peer.getWriteBufferLock().lock();
+    try {
+      peer.writeBuffer.put(Command.FLASCHENPOST_V2);
+      peer.writeBuffer.putInt(packet.length);
+      peer.writeBuffer.put(packet);
+      peer.setWriteBufferFilled();
+    } finally {
+      peer.getWriteBufferLock().unlock();
+    }
+  }
+}

--- a/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
+++ b/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
@@ -15,9 +15,12 @@ import lombok.extern.slf4j.Slf4j;
  * MS04 stateless garlic relay: handles inbound {@link Command#FLASCHENPOST_V2} packets.
  *
  * <ul>
- *   <li>Dedup: a {@code packet_id} is processed at most once per node (5-minute window) — this is
- *       also the loop protection, the packet intentionally carries no hop counter (it would leak
- *       the position in the path).
+ *   <li>Dedup: a {@code packet_id} is processed at most once per node (5-minute window). This stops
+ *       replays and routing loops of the <em>unchanged</em> packet (the Kademlia steps between
+ *       garlic hops keep the packet_id). Peeled {@code CMD_FORWARD} chains rebuild with a fresh
+ *       packet_id, but their length is physically bounded by the layer count: every layer costs 85
+ *       bytes of the fixed 2048-byte packet, so a sender cannot construct unbounded relay loops.
+ *       The packet intentionally carries no hop counter (it would leak the position in the path).
  *   <li>If {@code next_hop} is not us, the packet is routed unchanged toward {@code next_hop}
  *       (Kademlia step between garlic hops).
  *   <li>If it is us, the layer is peeled: {@code CMD_FORWARD} rebuilds a fresh 2048-byte packet

--- a/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
+++ b/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
@@ -65,12 +65,26 @@ public final class OhForwarder {
       byte[] ohId,
       byte[] content,
       int hopCount) {
+    Peer nextPeer = selectNextPeer(serverContext, targetNodeId);
+    if (nextPeer != null) {
+      GMParser.sendFpToPeer(nextPeer, content, ohId, hopCount + 1);
+    }
+  }
+
+  /**
+   * Selects the next peer toward {@code targetNodeId}: the target itself if directly connected,
+   * otherwise the cheapest next hop in the weighted node graph, otherwise the greedy Kademlia step
+   * (only if it makes strict forward progress). Shared by the MS02b OH forwarding and the MS04
+   * Flaschenpost v2 relay routing.
+   *
+   * @return the selected peer or {@code null} if no usable route exists (best-effort drop)
+   */
+  static Peer selectNextPeer(ServerContext serverContext, KademliaId targetNodeId) {
     PeerList peerList = serverContext.getPeerList();
 
     Peer direct = peerList.get(targetNodeId);
     if (direct != null && direct.isConnected()) {
-      GMParser.sendFpToPeer(direct, content, ohId, hopCount + 1);
-      return;
+      return direct;
     }
 
     // tie-break equal XOR distances by KademliaId so the TreeSet never collapses distinct peers
@@ -83,7 +97,7 @@ public final class OhForwarder {
     try {
       ArrayList<Peer> peerArrayList = peerList.getPeerArrayList();
       if (peerArrayList == null) {
-        return;
+        return null;
       }
       for (Peer p : peerArrayList) {
         // same candidate filter as garlic routing: connected full nodes with known node id
@@ -97,8 +111,8 @@ public final class OhForwarder {
     }
 
     if (candidates.isEmpty()) {
-      log.debug("no candidate peer to forward OH deposit toward {}", targetNodeId);
-      return;
+      log.debug("no candidate peer to forward toward {}", targetNodeId);
+      return null;
     }
 
     // Graph routing needs our own Node, which is wired late during startup — fall back to the
@@ -112,20 +126,19 @@ public final class OhForwarder {
               graph, self, candidates, targetNode, GMParser.MAX_ROUTE_WEIGHT);
 
       if (selection.peer() != null) {
-        GMParser.sendFpToPeer(selection.peer(), content, ohId, hopCount + 1);
-        return;
+        return selection.peer();
       }
     }
 
     // No graph route — greedy Kademlia fallback: next hop must be strictly closer to the target
-    // than we are (forward progress), the hop limit bounds the worst case.
+    // than we are (forward progress), dedup/hop limits bound the worst case.
     Peer nearest = candidates.first();
     int ourDistance = targetNodeId.getDistance(serverContext.getNonce());
     int nearestDistance = targetNodeId.getDistance(nearest.getKademliaId());
     if (nearestDistance < ourDistance) {
-      GMParser.sendFpToPeer(nearest, content, ohId, hopCount + 1);
-    } else {
-      log.debug("no peer closer to OH host {} than ourselves, dropping", targetNodeId);
+      return nearest;
     }
+    log.debug("no peer closer to {} than ourselves, dropping", targetNodeId);
+    return null;
   }
 }

--- a/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
+++ b/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
@@ -131,7 +131,8 @@ public final class OhForwarder {
     }
 
     // No graph route — greedy Kademlia fallback: next hop must be strictly closer to the target
-    // than we are (forward progress), dedup/hop limits bound the worst case.
+    // than we are (forward progress). Loop protection is the caller's job: the hop limit for the
+    // MS02b OH forwarding, the packet_id dedup for Flaschenpost v2 routing.
     Peer nearest = candidates.first();
     int ourDistance = targetNodeId.getDistance(serverContext.getNonce());
     int nearestDistance = targetNodeId.getDistance(nearest.getKademliaId());

--- a/src/main/proto/commands.proto
+++ b/src/main/proto/commands.proto
@@ -17,6 +17,10 @@ message PeerInfoProto {
     string ip = 1;
     int32 port = 2;
     NodeIdProto node_id = 3; // optional if not known
+    // MS04: 32-byte X25519 encryption public key of the node, so clients can pick
+    // garlic hops without importing the full 64-byte node_id export (it duplicates
+    // bytes 32..63 of node_id and is only set when node_id is known).
+    bytes encryption_public_key = 4;
 }
 
 message SendPeerList {

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorTest.java
@@ -205,4 +205,41 @@ public class InboundCommandProcessorTest {
     assertFalse("Peer with null IP should be skipped", foundInvalid);
     assertTrue(sendPeerList.getPeersCount() >= 1);
   }
+
+  @Test
+  public void parseCommand_requestPeerList_includesEncryptionPublicKey()
+      throws InvalidProtocolBufferException {
+    // MS04: peers with a known NodeId must expose their X25519 encryption public key so
+    // clients can select garlic hops
+    ServerContext ctx = ServerContext.buildDefaultServerContext();
+    InboundCommandProcessor proc = newProcessor(ctx);
+
+    NodeId knownNodeId = NodeId.generateWithSimpleKey();
+    Peer knownPeer = new Peer("127.0.0.1", 44444, knownNodeId);
+    ctx.getPeerList().add(knownPeer);
+
+    Peer requestingPeer = new Peer("10.0.0.1", 33333, ctx.getNodeId());
+    requestingPeer.setConnected(true);
+    requestingPeer.writeBuffer = ByteBuffer.allocate(4096);
+
+    proc.parseCommand(Command.REQUEST_PEERLIST, ByteBuffer.allocate(0), requestingPeer);
+
+    requestingPeer.writeBuffer.flip();
+    assertEquals(Command.SEND_PEERLIST, requestingPeer.writeBuffer.get());
+    int len = requestingPeer.writeBuffer.getInt();
+    byte[] data = new byte[len];
+    requestingPeer.writeBuffer.get(data);
+
+    im.redpanda.proto.SendPeerList sendPeerList = im.redpanda.proto.SendPeerList.parseFrom(data);
+    boolean found = false;
+    for (im.redpanda.proto.PeerInfoProto p : sendPeerList.getPeersList()) {
+      if (p.getPort() == 44444) {
+        found = true;
+        org.junit.Assert.assertArrayEquals(
+            knownNodeId.getEncryptionPubKey().getEncoded(),
+            p.getEncryptionPublicKey().toByteArray());
+      }
+    }
+    assertTrue("peer with known NodeId must be in the list", found);
+  }
 }

--- a/src/test/java/im/redpanda/flaschenpost/FlaschenpostV2Test.java
+++ b/src/test/java/im/redpanda/flaschenpost/FlaschenpostV2Test.java
@@ -1,0 +1,139 @@
+package im.redpanda.flaschenpost;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.NodeId;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import javax.crypto.AEADBadTagException;
+import org.junit.Test;
+
+/** MS04: Flaschenpost v2 packet format — fixed 2048-byte size, layer crypto, validation. */
+public class FlaschenpostV2Test {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  @Test
+  public void wireFormatConstants_areLocked() {
+    // these constants are the wire format — changing them breaks frontend interop
+    assertThat(FlaschenpostV2.PACKET_SIZE).isEqualTo(2048);
+    assertThat(FlaschenpostV2.HEADER_LEN).isEqualTo(73);
+    assertThat(FlaschenpostV2.BODY_HEADER_LEN).isEqualTo(48);
+    assertThat(FlaschenpostV2.MAX_CIPHERTEXT_LEN).isEqualTo(1975);
+    assertThat(FlaschenpostV2.MIN_CIPHERTEXT_LEN).isEqualTo(17);
+    assertThat(FlaschenpostV2.HKDF_INFO)
+        .isEqualTo("flaschenpost-v2".getBytes(StandardCharsets.US_ASCII));
+  }
+
+  @Test
+  public void encryptBuildParseDecrypt_roundTrip() throws Exception {
+    NodeId hop = NodeId.generateWithSimpleKey();
+    byte[] plaintext = "layer plaintext".getBytes(StandardCharsets.UTF_8);
+
+    byte[] body =
+        FlaschenpostV2.encryptLayer(hop.getEncryptionPubKey(), hop.getKademliaId(), plaintext);
+    int packetId = RANDOM.nextInt();
+    byte[] packet = FlaschenpostV2.buildPacket(packetId, hop.getKademliaId(), body);
+
+    assertThat(packet).hasSize(FlaschenpostV2.PACKET_SIZE);
+
+    FlaschenpostV2 parsed = FlaschenpostV2.parse(packet);
+    assertThat(parsed).isNotNull();
+    assertThat(parsed.getPacketId()).isEqualTo(packetId);
+    assertThat(parsed.getNextHop()).isEqualTo(hop.getKademliaId());
+    assertThat(parsed.decryptLayer(hop.getEncryptionKey())).isEqualTo(plaintext);
+  }
+
+  @Test
+  public void decryptLayer_withWrongKey_throwsAeadBadTag() throws Exception {
+    NodeId hop = NodeId.generateWithSimpleKey();
+    NodeId other = NodeId.generateWithSimpleKey();
+    byte[] body =
+        FlaschenpostV2.encryptLayer(hop.getEncryptionPubKey(), hop.getKademliaId(), new byte[32]);
+    FlaschenpostV2 parsed =
+        FlaschenpostV2.parse(FlaschenpostV2.buildPacket(1, hop.getKademliaId(), body));
+
+    assertThatThrownBy(() -> parsed.decryptLayer(other.getEncryptionKey()))
+        .isInstanceOf(AEADBadTagException.class);
+  }
+
+  @Test
+  public void decryptLayer_withTamperedNextHop_throwsAeadBadTag() throws Exception {
+    // the next_hop is the AAD: redirecting a packet to another relay must break authentication
+    NodeId hop = NodeId.generateWithSimpleKey();
+    byte[] body =
+        FlaschenpostV2.encryptLayer(hop.getEncryptionPubKey(), hop.getKademliaId(), new byte[32]);
+    KademliaId otherId = NodeId.generateWithSimpleKey().getKademliaId();
+    FlaschenpostV2 redirected = FlaschenpostV2.parse(FlaschenpostV2.buildPacket(1, otherId, body));
+
+    assertThatThrownBy(() -> redirected.decryptLayer(hop.getEncryptionKey()))
+        .isInstanceOf(AEADBadTagException.class);
+  }
+
+  @Test
+  public void parse_rejectsMalformedPackets() {
+    NodeId hop = NodeId.generateWithSimpleKey();
+
+    // wrong total size
+    assertThat(FlaschenpostV2.parse(new byte[100])).isNull();
+    assertThat(FlaschenpostV2.parse(new byte[FlaschenpostV2.PACKET_SIZE + 1])).isNull();
+    assertThat(FlaschenpostV2.parse(null)).isNull();
+
+    // wrong version byte
+    byte[] packet = validPacket(hop);
+    packet[0] = 0x01;
+    assertThat(FlaschenpostV2.parse(packet)).isNull();
+
+    // ciphertext length out of bounds
+    packet = validPacket(hop);
+    java.nio.ByteBuffer.wrap(packet).putInt(69, FlaschenpostV2.MAX_CIPHERTEXT_LEN + 1);
+    assertThat(FlaschenpostV2.parse(packet)).isNull();
+    java.nio.ByteBuffer.wrap(packet).putInt(69, FlaschenpostV2.MIN_CIPHERTEXT_LEN - 1);
+    assertThat(FlaschenpostV2.parse(packet)).isNull();
+  }
+
+  @Test
+  public void buildPacket_rejectsInvalidBodyLength() {
+    KademliaId nextHop = NodeId.generateWithSimpleKey().getKademliaId();
+    int maxBody = FlaschenpostV2.PACKET_SIZE - 1 - 4 - KademliaId.ID_LENGTH_BYTES;
+
+    assertThatThrownBy(() -> FlaschenpostV2.buildPacket(1, nextHop, new byte[maxBody + 1]))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () ->
+                FlaschenpostV2.buildPacket(
+                    1,
+                    nextHop,
+                    new byte
+                        [FlaschenpostV2.BODY_HEADER_LEN + FlaschenpostV2.MIN_CIPHERTEXT_LEN - 1]))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void buildPacket_withMaximumBody_isExactlyPacketSize() throws Exception {
+    // a full-size layer: ciphertext fills the packet completely, zero padding
+    NodeId hop = NodeId.generateWithSimpleKey();
+    byte[] plaintext =
+        new byte[FlaschenpostV2.MAX_CIPHERTEXT_LEN - 16]; // max ct minus GCM tag = 1959
+    byte[] body =
+        FlaschenpostV2.encryptLayer(hop.getEncryptionPubKey(), hop.getKademliaId(), plaintext);
+    byte[] packet = FlaschenpostV2.buildPacket(7, hop.getKademliaId(), body);
+
+    assertThat(packet).hasSize(FlaschenpostV2.PACKET_SIZE);
+    FlaschenpostV2 parsed = FlaschenpostV2.parse(packet);
+    assertThat(parsed).isNotNull();
+    assertThat(parsed.decryptLayer(hop.getEncryptionKey())).isEqualTo(plaintext);
+  }
+
+  private static byte[] validPacket(NodeId hop) {
+    try {
+      byte[] body =
+          FlaschenpostV2.encryptLayer(hop.getEncryptionPubKey(), hop.getKademliaId(), new byte[32]);
+      return FlaschenpostV2.buildPacket(RANDOM.nextInt(), hop.getKademliaId(), body);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/im/redpanda/flaschenpost/GarlicRouterTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/GarlicRouterTest.java
@@ -1,0 +1,263 @@
+package im.redpanda.flaschenpost;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import im.redpanda.core.Command;
+import im.redpanda.core.InboundCommandProcessor;
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.Peer;
+import im.redpanda.core.ServerContext;
+import im.redpanda.outbound.OhDht;
+import im.redpanda.outbound.OutboundHandleStore;
+import im.redpanda.outbound.OutboundMailboxStore;
+import im.redpanda.outbound.OutboundService;
+import im.redpanda.outbound.v1.MailItem;
+import im.redpanda.proto.FlaschenpostPut;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * MS04 acceptance: a 3-layer Flaschenpost v2 garlic packet traverses three relays — every relay
+ * peels exactly its own layer, rebuilds a fresh 2048-byte packet and forwards it; the last relay
+ * deposits the payload into the OH mailbox. Plus the negative paths: dedup, foreign packets,
+ * malformed packets.
+ */
+public class GarlicRouterTest {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private ServerContext node1;
+  private ServerContext node2;
+  private ServerContext node3;
+  private InboundCommandProcessor processor1;
+  private InboundCommandProcessor processor2;
+  private InboundCommandProcessor processor3;
+  private OutboundMailboxStore mailbox3;
+
+  private byte[] ohId;
+
+  @Before
+  public void setUp() {
+    node1 = ServerContext.buildDefaultServerContext();
+    node1.setOutboundService(
+        new OutboundService(new OutboundHandleStore(), new OutboundMailboxStore()));
+    processor1 = new InboundCommandProcessor(node1);
+
+    node2 = ServerContext.buildDefaultServerContext();
+    node2.setOutboundService(
+        new OutboundService(new OutboundHandleStore(), new OutboundMailboxStore()));
+    processor2 = new InboundCommandProcessor(node2);
+
+    node3 = ServerContext.buildDefaultServerContext();
+    OutboundHandleStore handleStore3 = new OutboundHandleStore();
+    mailbox3 = new OutboundMailboxStore();
+    node3.setOutboundService(new OutboundService(handleStore3, mailbox3));
+    processor3 = new InboundCommandProcessor(node3);
+
+    ohId = new byte[KademliaId.ID_LENGTH_BYTES];
+    RANDOM.nextBytes(ohId);
+
+    // OH registered on node 3 only
+    long now = System.currentTimeMillis();
+    handleStore3.put(ohId, new OutboundHandleStore.HandleRecord(new byte[65], now, now + 60_000));
+  }
+
+  /** Builds a [4-byte len][payload] frame as expected by {@code parseCommand}. */
+  private static ByteBuffer buildFrame(byte[] payload) {
+    ByteBuffer buf = ByteBuffer.allocate(4 + payload.length);
+    buf.putInt(payload.length);
+    buf.put(payload);
+    buf.flip();
+    return buf;
+  }
+
+  /** Adds a connected peer object representing {@code target} to {@code host}'s peer list. */
+  private static Peer connect(ServerContext host, ServerContext target, int port) {
+    Peer peer = new Peer("127.0.0.1", port, target.getNodeId());
+    peer.setConnected(true);
+    peer.writeBuffer = ByteBuffer.allocate(65536);
+    host.getPeerList().add(peer);
+    return peer;
+  }
+
+  /** A connected sender peer (the packet origin, e.g. a light client). */
+  private static Peer sender(ServerContext host, int port) {
+    Peer peer = new Peer("127.0.0.1", port, host.getNodeId());
+    peer.setConnected(true);
+    peer.writeBuffer = ByteBuffer.allocate(65536);
+    host.getPeerList().add(peer);
+    return peer;
+  }
+
+  /** Reads one FLASCHENPOST_V2 frame from the peer's write buffer. */
+  private static byte[] readV2Frame(Peer peer) {
+    ByteBuffer out = peer.writeBuffer;
+    out.flip();
+    assertThat(out.hasRemaining()).as("expected a forwarded FLASCHENPOST_V2 frame").isTrue();
+    assertThat(out.get()).isEqualTo(Command.FLASCHENPOST_V2);
+    byte[] packet = new byte[out.getInt()];
+    out.get(packet);
+    assertThat(out.hasRemaining()).as("exactly one frame expected").isFalse();
+    out.clear();
+    return packet;
+  }
+
+  /**
+   * Builds a layered garlic packet along the given hops: CMD_FORWARD layers for all but the last
+   * hop, a CMD_DELIVER layer (to {@code ohId}) for the last hop.
+   */
+  private byte[] buildLayeredPacket(byte[] payload, ServerContext... hops) throws Exception {
+    ServerContext last = hops[hops.length - 1];
+    ByteBuffer deliver = ByteBuffer.allocate(1 + KademliaId.ID_LENGTH_BYTES + 4 + payload.length);
+    deliver.put(FlaschenpostV2.CMD_DELIVER);
+    deliver.put(ohId);
+    deliver.putInt(payload.length);
+    deliver.put(payload);
+    byte[] body =
+        FlaschenpostV2.encryptLayer(
+            last.getNodeId().getEncryptionPubKey(), last.getNonce(), deliver.array());
+
+    for (int i = hops.length - 2; i >= 0; i--) {
+      ByteBuffer forward = ByteBuffer.allocate(1 + KademliaId.ID_LENGTH_BYTES + body.length);
+      forward.put(FlaschenpostV2.CMD_FORWARD);
+      forward.put(hops[i + 1].getNonce().getBytes());
+      forward.put(body);
+      body =
+          FlaschenpostV2.encryptLayer(
+              hops[i].getNodeId().getEncryptionPubKey(), hops[i].getNonce(), forward.array());
+    }
+    return FlaschenpostV2.buildPacket(RANDOM.nextInt(), hops[0].getNonce(), body);
+  }
+
+  @Test
+  public void threeLayerPacket_isPeeledByThreeRelays_andDeliveredToOhMailbox() throws Exception {
+    Peer peer1To2 = connect(node1, node2, 9401);
+    Peer peer2To3 = connect(node2, node3, 9402);
+
+    byte[] payload = "multi hop garlic message".getBytes(StandardCharsets.UTF_8);
+    byte[] packet = buildLayeredPacket(payload, node1, node2, node3);
+    int originalPacketId = FlaschenpostV2.parse(packet).getPacketId();
+
+    // relay 1 peels its layer and forwards a rebuilt 2048-byte packet to node 2
+    processor1.parseCommand(Command.FLASCHENPOST_V2, buildFrame(packet), sender(node1, 9400));
+    byte[] toNode2 = readV2Frame(peer1To2);
+    assertThat(toNode2).hasSize(FlaschenpostV2.PACKET_SIZE);
+    FlaschenpostV2 parsed2 = FlaschenpostV2.parse(toNode2);
+    assertThat(parsed2.getNextHop()).isEqualTo(node2.getNonce());
+    assertThat(parsed2.getPacketId())
+        .as("relays must assign a fresh packet_id")
+        .isNotEqualTo(originalPacketId);
+
+    // relay 2 peels its layer and forwards to node 3
+    processor2.parseCommand(Command.FLASCHENPOST_V2, buildFrame(toNode2), sender(node2, 9403));
+    byte[] toNode3 = readV2Frame(peer2To3);
+    assertThat(toNode3).hasSize(FlaschenpostV2.PACKET_SIZE);
+    assertThat(FlaschenpostV2.parse(toNode3).getNextHop()).isEqualTo(node3.getNonce());
+
+    // relay 3 peels the CMD_DELIVER layer and deposits into the OH mailbox
+    processor3.parseCommand(Command.FLASCHENPOST_V2, buildFrame(toNode3), sender(node3, 9404));
+    List<MailItem> items = mailbox3.fetchMessages(ohId, 10, 0);
+    assertThat(items).hasSize(1);
+    assertThat(items.get(0).getPayload().toByteArray()).isEqualTo(payload);
+  }
+
+  @Test
+  public void duplicatePacketId_isProcessedOnlyOnce() throws Exception {
+    Peer peer1To2 = connect(node1, node2, 9411);
+    byte[] packet = buildLayeredPacket(new byte[16], node1, node2);
+
+    processor1.parseCommand(Command.FLASCHENPOST_V2, buildFrame(packet), sender(node1, 9410));
+    byte[] first = readV2Frame(peer1To2);
+    assertThat(first).hasSize(FlaschenpostV2.PACKET_SIZE);
+
+    // the identical packet (same packet_id) again — must be dropped by the dedup cache
+    processor1.parseCommand(Command.FLASCHENPOST_V2, buildFrame(packet), sender(node1, 9412));
+    peer1To2.writeBuffer.flip();
+    assertThat(peer1To2.writeBuffer.hasRemaining())
+        .as("a duplicate packet_id must not be forwarded again")
+        .isFalse();
+  }
+
+  @Test
+  public void foreignPacket_failsAuthentication_andIsDroppedSilently() throws Exception {
+    Peer peer1To2 = connect(node1, node2, 9421);
+
+    // layer encrypted for node 2, but addressed (next_hop) to node 1: node 1 cannot
+    // authenticate it and must drop silently — no crash, no forward, no deposit
+    byte[] deliver = ByteBuffer.allocate(1 + 20 + 4).put(FlaschenpostV2.CMD_DELIVER).array();
+    byte[] body =
+        FlaschenpostV2.encryptLayer(
+            node2.getNodeId().getEncryptionPubKey(), node2.getNonce(), deliver);
+    byte[] packet = FlaschenpostV2.buildPacket(RANDOM.nextInt(), node1.getNonce(), body);
+
+    processor1.parseCommand(Command.FLASCHENPOST_V2, buildFrame(packet), sender(node1, 9420));
+
+    peer1To2.writeBuffer.flip();
+    assertThat(peer1To2.writeBuffer.hasRemaining()).isFalse();
+  }
+
+  @Test
+  public void packetForAnotherNode_isRoutedUnchangedTowardNextHop() throws Exception {
+    Peer peer1To2 = connect(node1, node2, 9431);
+
+    // single-layer packet addressed to node 2 arrives at node 1: pure Kademlia step, the
+    // packet must be forwarded byte-identically (no peeling, no rebuild)
+    byte[] packet = buildLayeredPacket(new byte[8], node2);
+
+    processor1.parseCommand(Command.FLASCHENPOST_V2, buildFrame(packet), sender(node1, 9430));
+
+    byte[] forwarded = readV2Frame(peer1To2);
+    assertThat(forwarded).isEqualTo(packet);
+  }
+
+  @Test
+  public void malformedPacket_isDroppedWithoutCrash() {
+    Peer peer1To2 = connect(node1, node2, 9441);
+
+    // wrong size — must be dropped before any processing
+    processor1.parseCommand(
+        Command.FLASCHENPOST_V2, buildFrame(new byte[100]), sender(node1, 9440));
+
+    peer1To2.writeBuffer.flip();
+    assertThat(peer1To2.writeBuffer.hasRemaining()).isFalse();
+  }
+
+  @Test
+  public void deliverForRemoteOh_fallsBackToMs02bForwarding() throws Exception {
+    // the final garlic hop (node 1) does not host the OH; it knows the announce record
+    // pointing to node 2 and must forward a FlaschenpostPut with the oh_id preserved
+    byte[] remoteOhId = new byte[KademliaId.ID_LENGTH_BYTES];
+    RANDOM.nextBytes(remoteOhId);
+    node1
+        .getKadStoreManager()
+        .put(OhDht.buildAnnounceContent(remoteOhId, node2.getNonce(), System.currentTimeMillis()));
+    Peer peer1To2 = connect(node1, node2, 9451);
+
+    byte[] payload = "deliver elsewhere".getBytes(StandardCharsets.UTF_8);
+    ByteBuffer deliver = ByteBuffer.allocate(1 + KademliaId.ID_LENGTH_BYTES + 4 + payload.length);
+    deliver.put(FlaschenpostV2.CMD_DELIVER);
+    deliver.put(remoteOhId);
+    deliver.putInt(payload.length);
+    deliver.put(payload);
+    byte[] body =
+        FlaschenpostV2.encryptLayer(
+            node1.getNodeId().getEncryptionPubKey(), node1.getNonce(), deliver.array());
+    byte[] packet = FlaschenpostV2.buildPacket(RANDOM.nextInt(), node1.getNonce(), body);
+
+    processor1.parseCommand(Command.FLASCHENPOST_V2, buildFrame(packet), sender(node1, 9450));
+
+    ByteBuffer out = peer1To2.writeBuffer;
+    out.flip();
+    assertThat(out.hasRemaining()).as("MS02b forward expected").isTrue();
+    assertThat(out.get()).isEqualTo(Command.FLASCHENPOST_PUT);
+    byte[] forwardedBytes = new byte[out.getInt()];
+    out.get(forwardedBytes);
+    FlaschenpostPut forwarded = FlaschenpostPut.parseFrom(forwardedBytes);
+    assertThat(forwarded.getOhId().toByteArray()).isEqualTo(remoteOhId);
+    assertThat(forwarded.getContent().toByteArray()).isEqualTo(payload);
+  }
+}


### PR DESCRIPTION
## Summary

Backend part of MS04 (see `milestones/backend/ms04_multi_hop_garlic.md`): full nodes act as stateless garlic relays for fixed-size 2048-byte **Flaschenpost v2** packets.

- **`FlaschenpostV2`** — packet format `[1 ver=0x02][4 packet_id][20 next_hop][12 nonce][32 ephemeral_pub][4 ct_len][ct+tag][random padding]`, always exactly 2048 bytes. Per-layer crypto: X25519 ephemeral ECDH → HKDF-SHA256 (info `"flaschenpost-v2"`) → AES-256-GCM with the layer's `next_hop` KademliaId as AAD (a redirected packet fails authentication).
- **`GarlicRouter`** — handler for the new wire command `FLASCHENPOST_V2 (142)`:
  - dedup on `packet_id` (5-minute window in `GMStoreManager`) — doubles as loop protection; the packet deliberately carries no hop counter (would leak path position),
  - packets not addressed to us are routed unchanged toward `next_hop` (Kademlia step between garlic hops),
  - `CMD_FORWARD (0x01)`: peel own layer, rebuild a fresh 2048-byte packet (new random `packet_id`, new random padding), forward to the inner next hop,
  - `CMD_DELIVER (0x02)`: deposit payload into the local OH mailbox; falls back to the MS02b `OhForwarder` when the OH is hosted elsewhere,
  - every malformed/unauthenticated packet is dropped silently (best-effort layer).
- **Routing reuse** — extracted `OhForwarder.selectNextPeer` (direct connection → weighted graph route → greedy Kademlia step with strict progress), shared by MS02b forwarding and v2 relay routing.
- **`PeerInfoProto.encryption_public_key`** — 32-byte X25519 key included in the peer list exchange so clients can pick garlic hops (duplicates bytes 32..63 of the 64-byte `node_id` export, set only when the NodeId is known).

## Tests

- `GarlicRouterTest`: 3-layer packet end-to-end across three in-process relays → OH mailbox; dedup; foreign packet silent drop; unchanged forward for other next_hops; malformed drop; remote-OH deliver fallback (analog `OhForwarderTest`).
- `FlaschenpostV2Test`: wire-format constants locked, encrypt/build/parse/decrypt round-trip, AAD binding (tampered next_hop fails), malformed packets, max-size body.
- Full suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)