### PR TITLE
docs: sync milestone mirrors (Backend-MS04 Done)

### DIFF
--- a/milestones/00_status_overview.md
+++ b/milestones/00_status_overview.md
@@ -21,7 +21,7 @@ Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den
 | [MS02b](ms02b_oh_discovery_forwarding.md) | OH Discovery & Forwarding | Done | Frontend MS02b kann starten (Status-Codes, `want_response`) |
 | [MS03](ms03_authenticated_encryption.md) | Crypto Migration (Ed25519/X25519/GCM) | Done | Frontend MS03 kann starten (Handshake v23, Garlic v2, Ed25519 OH-Auth stehen) |
 | [MS03b](ms03b_forward_secrecy.md) | Forward Secrecy | Done | Verifiziert 2026-06-12 (keine Code-Änderung): Payloads bleiben opak, 64-KiB-Limit unkritisch — Frontend MS03b Done |
-| [MS04](ms04_multi_hop_garlic.md) | Multi-Hop Relay | Partial | Frontend MS04 blocked — Relay-Peeling muss serverseitig funktionieren |
+| [MS04](ms04_multi_hop_garlic.md) | Multi-Hop Relay | Done | Frontend MS04 kann starten (Flaschenpost v2 Relay, `FLASCHENPOST_V2` (142), `encryption_public_key` im Peer-Austausch) |
 | [MS05](ms05_reverse_garlic.md) | Reverse Garlic (Relay-Seite) | Missing | Frontend MS05 blocked — CMD_DELIVER mit session_tag muss funktionieren |
 | [MS06](ms06_two_layer_ack.md) | R-ACK Generation | Missing | Frontend MS06 blocked — OH muss R-ACK erzeugen können |
 | [MS07](ms07_push_notifications.md) | Push Sender (FCM/APNs) | Missing | Frontend MS07 blocked — Push-Infrastruktur muss serverseitig stehen |
@@ -39,6 +39,7 @@ Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den
 | OH Forwarding (Option A) | `OhForwarder.java`, `GMParser.java` | Done — oh_id + hop_count erhalten, max. 3 Hops |
 | OH Auth (Ed25519 + replay) | `OutboundAuth.java` | Done — Ed25519 + Signing-Versions-Byte (MS03), Legacy-ECDSA-Fallback bis v22-Removal |
 | Garlic encryption (single layer) | `GarlicMessage.java` | Done — v2: AES-256-GCM + X25519 + HKDF, AAD = Ziel-KademliaId (MS03) |
+| Multi-hop garlic relay | `FlaschenpostV2.java`, `GarlicRouter.java` | Done — fixe 2048-B-Pakete, Layer-Peeling, Rebuild + Re-Padding, packet_id-Dedup (MS04) |
 | Kademlia DHT | `KadStoreManager.java` | Done (in-memory) — Ed25519-Signaturen (MS03) |
 | TCP handshake + stream encryption | `ConnectionHandler.java`, `GcmFramedStreams.java` | Done — v23: framed AES-256-GCM, Counter-Nonces; v22 nur noch Light Clients (MS03) |
 | Node identity | `NodeId.java` | Done — Ed25519 (sign) + X25519 (encrypt) Dual-Keypair (MS03) |

--- a/milestones/ms04_multi_hop_garlic.md
+++ b/milestones/ms04_multi_hop_garlic.md
@@ -1,9 +1,13 @@
 # Backend MS04: Multi-Hop Relay
 
-## Status: Partial
+## Status: Done
+
+> **Backend umgesetzt in redpandaj [#224](https://github.com/redPanda-project/redpandaj/pull/224)** (2026-06-12).
+> Verbindliche Wire-Format-Festlegungen und beantwortete Open Questions: siehe
+> [Decisions (Backend-MS04) in der Master-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms04_multi_hop_garlic.md#decisions-backend-ms04-2026-06-12).
 
 > **Frontend-Alignment**: Backend MS04 ist Voraussetzung für [Frontend MS04](../frontend/ms04_multi_hop_garlic.md).
-> Die Relay-Peeling-Logik und das Flaschenpost v2 Format müssen serverseitig funktionieren, bevor das Frontend Garlic-Pakete baut.
+> Die Relay-Peeling-Logik und das Flaschenpost v2 Format funktionieren jetzt serverseitig — Frontend MS04 kann starten.
 
 ## Goal
 
@@ -17,10 +21,14 @@ Full Nodes als stateless Garlic-Relays: empfangene Flaschenpost v2 Pakete entsch
 
 | Component | File | Status |
 |-----------|------|--------|
-| Single-layer Garlic | `GarlicMessage.java` | Done — wird in MS03 auf v2 umgestellt |
+| Flaschenpost v2 packet format | `FlaschenpostV2.java` | Done — fixe 2048 B, Layer-Krypto (X25519 + HKDF `"flaschenpost-v2"` + AES-256-GCM, AAD = next_hop) |
+| Relay peeling + forwarding | `GarlicRouter.java` | Done — Dedup, Kademlia-Step, CMD_FORWARD-Rebuild, CMD_DELIVER |
+| Wire command | `Command.FLASCHENPOST_V2` (142) | Done — geframed wie alle Payload-Commands |
+| Single-layer Garlic | `GarlicMessage.java` | Done — v2 seit MS03; bleibt für interne Pfade (siehe Decisions) |
 | Flaschenpost base | `Flaschenpost.java` | Done — destination, dedup ID |
-| Dedup cache | `GMStoreManager.java` | Done — 5-min window |
-| Kademlia routing | Peer tables + KadStoreManager | Done |
+| Dedup cache | `GMStoreManager.java` | Done — 5-min window, v1-Messages **und** v2 packet_ids |
+| Kademlia routing | Peer tables + KadStoreManager + `OhForwarder.selectNextPeer` | Done — gemeinsame Next-Peer-Auswahl (direkt → Graph → greedy) |
+| Peer key exchange | `PeerInfoProto.encryption_public_key` | Done — 32-byte X25519 im Peer-Austausch |
 
 ## Spec
 
@@ -141,16 +149,23 @@ Flaschenpost v2 ist binär, kein Protobuf.
 
 ## Acceptance Criteria
 
-- [ ] Ein 2048-Byte Flaschenpost v2 Paket wird korrekt empfangen und die eigene Layer gepeelt
-- [ ] `CMD_FORWARD`: Inneres Paket wird an den nächsten Hop weitergeleitet (erneut 2048 Bytes)
-- [ ] `CMD_DELIVER`: Payload wird in die OH-Mailbox eingeliefert via `outboundService.depositMessage()`
-- [ ] Dedup: Gleiches `packet_id` wird nicht zweimal verarbeitet
-- [ ] Decryption-Failure (fremdes Paket) wird still verworfen — kein Crash
-- [ ] `PeerInfoProto` enthält `encryption_public_key` im Peer-Austausch
-- [ ] Integration-Test: 3-Layer Paket → 3 Relays peelen nacheinander → Delivery an OH
+- [x] Ein 2048-Byte Flaschenpost v2 Paket wird korrekt empfangen und die eigene Layer gepeelt
+- [x] `CMD_FORWARD`: Inneres Paket wird an den nächsten Hop weitergeleitet (erneut 2048 Bytes, neue `packet_id`, neues Random-Padding)
+- [x] `CMD_DELIVER`: Payload wird in die OH-Mailbox eingeliefert via `outboundService.depositMessage()` (bei NOT_FOUND: MS02b-`OhForwarder`-Fallback)
+- [x] Dedup: Gleiches `packet_id` wird nicht zweimal verarbeitet
+- [x] Decryption-Failure (fremdes Paket) wird still verworfen — kein Crash
+- [x] `PeerInfoProto` enthält `encryption_public_key` im Peer-Austausch
+- [x] Integration-Test: 3-Layer Paket → 3 Relays peelen nacheinander → Delivery an OH (`GarlicRouterTest`)
+
+> **Hinweis zum Pseudo-Code oben**: `oh_id` in `CMD_DELIVER` ist **20 Bytes** (KademliaId, wie
+> überall) — die 32 im Pseudo-Code waren ein Fehler; außerdem trägt der Deliver-Plaintext ein
+> explizites `payload_len` (4 Bytes). Verbindlich sind die
+> [Decisions in der Master-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms04_multi_hop_garlic.md#decisions-backend-ms04-2026-06-12).
 
 ## Open Questions
 
-1. Soll der Server bei `CMD_DELIVER` eine Bestätigung zurücksenden (→ R-ACK, MS06), oder ist das erst ab MS06 relevant?
-2. Maximale Paketgröße 2048 Bytes — reicht das? Fragmentierung erst in einem späteren MS?
-3. Wie verhält sich ein Relay, wenn der `next_hop` nicht erreichbar ist? Silent drop oder retry?
+Alle drei Open Questions sind durch die [Decisions in der Master-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms04_multi_hop_garlic.md#decisions-backend-ms04-2026-06-12) beantwortet:
+
+1. ~~Soll der Server bei `CMD_DELIVER` eine Bestätigung zurücksenden?~~ → Nein, best-effort wie die gesamte Flaschenpost-Schicht; R-ACK kommt in MS06 (Decision 9).
+2. ~~Maximale Paketgröße 2048 Bytes — reicht das?~~ → Ja: bei 3 Hops bleiben 1764 B Deliver-Payload (~1,65 KiB Content nach Envelope v4); Fragmentierung deferred (Decision 6).
+3. ~~Verhalten bei nicht erreichbarem `next_hop`?~~ → Silent drop (stateless Relays, kein Retry); Zustellsicherheit liefert die MS02-Retry-Logik des Senders (Decision 8).

--- a/milestones/ms04_multi_hop_garlic.md
+++ b/milestones/ms04_multi_hop_garlic.md
@@ -6,7 +6,7 @@
 > Verbindliche Wire-Format-Festlegungen und beantwortete Open Questions: siehe
 > [Decisions (Backend-MS04) in der Master-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms04_multi_hop_garlic.md#decisions-backend-ms04-2026-06-12).
 
-> **Frontend-Alignment**: Backend MS04 ist Voraussetzung für [Frontend MS04](../frontend/ms04_multi_hop_garlic.md).
+> **Frontend-Alignment**: Backend MS04 ist Voraussetzung für [Frontend MS04](https://github.com/redPanda-project/docs/blob/main/docs/milestones/frontend/ms04_multi_hop_garlic.md).
 > Die Relay-Peeling-Logik und das Flaschenpost v2 Format funktionieren jetzt serverseitig — Frontend MS04 kann starten.
 
 ## Goal
@@ -86,8 +86,9 @@ void handleFlaschenpostV2(Peer peer, byte[] packet) {
             break;
 
         case CMD_DELIVER: // 0x02
-            byte[] ohId = readBytes(plaintext, 1, 32);
-            byte[] payload = readBytes(plaintext, 33, payloadLen);
+            byte[] ohId = readBytes(plaintext, 1, 20);   // 20-byte KademliaId
+            int payloadLen = readInt(plaintext, 21);
+            byte[] payload = readBytes(plaintext, 25, payloadLen);
             outboundService.depositMessage(ohId, payload);
             break;
     }
@@ -157,9 +158,9 @@ Flaschenpost v2 ist binär, kein Protobuf.
 - [x] `PeerInfoProto` enthält `encryption_public_key` im Peer-Austausch
 - [x] Integration-Test: 3-Layer Paket → 3 Relays peelen nacheinander → Delivery an OH (`GarlicRouterTest`)
 
-> **Hinweis zum Pseudo-Code oben**: `oh_id` in `CMD_DELIVER` ist **20 Bytes** (KademliaId, wie
-> überall) — die 32 im Pseudo-Code waren ein Fehler; außerdem trägt der Deliver-Plaintext ein
-> explizites `payload_len` (4 Bytes). Verbindlich sind die
+> **Hinweis**: `oh_id` in `CMD_DELIVER` ist **20 Bytes** (KademliaId, wie überall) mit explizitem
+> `payload_len` (4 Bytes) — der Pseudo-Code oben ist entsprechend korrigiert (ursprünglich stand
+> dort fälschlich 32). Verbindlich sind die
 > [Decisions in der Master-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms04_multi_hop_garlic.md#decisions-backend-ms04-2026-06-12).
 
 ## Open Questions


### PR DESCRIPTION
Mirror-Sync aus dem docs-Repo nach Merge von redPanda-project/docs#18 (Backend-MS04 Done, Decisions). Quelle: `docs/milestones/backend/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)