### PR TITLE
Backend-MS05: Reverse Garlic — CMD_DELIVER_TAGGED with session_tag

### DIFF
--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -854,11 +854,14 @@ public class InboundCommandProcessor {
       }
       // MS05: a reverse-garlic session tag arrives here when the final garlic hop was not the
       // OH host and forwarded the tagged deliver (OhForwarder). Empty for direct deposits.
-      byte[] sessionTag = putMsg.getSessionTag().toByteArray();
-      if (sessionTag.length != 0 && sessionTag.length != OutboundService.SESSION_TAG_BYTES) {
+      // Validate the size on the ByteString before materializing the array (cf. oh_id above).
+      ByteString sessionTagBytes = putMsg.getSessionTag();
+      if (sessionTagBytes.size() != 0
+          && sessionTagBytes.size() != OutboundService.SESSION_TAG_BYTES) {
         respondToDeposit(peer, putMsg, im.redpanda.outbound.v1.Status.BAD_REQUEST);
         return;
       }
+      byte[] sessionTag = sessionTagBytes.toByteArray();
       OutboundService.DepositResult result =
           outboundService.depositMessage(ohId, content, sessionTag);
       if (result == OutboundService.DepositResult.NOT_FOUND) {

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -852,11 +852,21 @@ public class InboundCommandProcessor {
         respondToDeposit(peer, putMsg, im.redpanda.outbound.v1.Status.BAD_REQUEST);
         return;
       }
-      OutboundService.DepositResult result = outboundService.depositMessage(ohId, content);
+      // MS05: a reverse-garlic session tag arrives here when the final garlic hop was not the
+      // OH host and forwarded the tagged deliver (OhForwarder). Empty for direct deposits.
+      byte[] sessionTag = putMsg.getSessionTag().toByteArray();
+      if (sessionTag.length != 0 && sessionTag.length != OutboundService.SESSION_TAG_BYTES) {
+        respondToDeposit(peer, putMsg, im.redpanda.outbound.v1.Status.BAD_REQUEST);
+        return;
+      }
+      OutboundService.DepositResult result =
+          outboundService.depositMessage(ohId, content, sessionTag);
       if (result == OutboundService.DepositResult.NOT_FOUND) {
         // MS02b: not our OH — forward toward the host node (resolved via the DHT announce),
-        // preserving the oh_id on every hop. Best-effort: OK means "accepted for forwarding".
-        boolean accepted = OhForwarder.forward(serverContext, ohId, content, putMsg.getHopCount());
+        // preserving the oh_id (and MS05 session tag) on every hop. Best-effort: OK means
+        // "accepted for forwarding".
+        boolean accepted =
+            OhForwarder.forward(serverContext, ohId, content, putMsg.getHopCount(), sessionTag);
         respondToDeposit(
             peer,
             putMsg,

--- a/src/main/java/im/redpanda/flaschenpost/FlaschenpostV2.java
+++ b/src/main/java/im/redpanda/flaschenpost/FlaschenpostV2.java
@@ -33,13 +33,19 @@ import org.bouncycastle.crypto.params.X25519PublicKeyParameters;
  * <p>Layer plaintexts start with a command byte:
  *
  * <pre>
- * CMD_FORWARD (0x01): [1 cmd][20 inner next_hop][12 nonce][32 ephemeral_pub][4 ct_len][ct + tag]
- * CMD_DELIVER (0x02): [1 cmd][20 oh_id][4 payload_len][payload][optional padding]
+ * CMD_FORWARD        (0x01): [1 cmd][20 inner next_hop][12 nonce][32 ephemeral_pub][4 ct_len][ct + tag]
+ * CMD_DELIVER        (0x02): [1 cmd][20 oh_id][4 payload_len][payload][optional padding]
+ * CMD_DELIVER_TAGGED (0x03): [1 cmd][20 oh_id][16 session_tag][4 payload_len][payload][optional padding]
  * </pre>
  *
- * After peeling a {@code CMD_FORWARD} layer, the relay rebuilds a fresh 2048-byte packet with a new
- * random {@code packet_id}, the inner {@code next_hop} and the remaining plaintext as body, padded
- * with random bytes (see {@link #buildPacket}).
+ * <p>{@code CMD_DELIVER_TAGGED} (MS05) is the reverse-garlic deliver: identical to {@code
+ * CMD_DELIVER} plus a 16-byte session tag that is stored on the mailbox {@code MailItem}, so the
+ * fetching client can correlate the reply with a conversation. The tag stays inside the innermost
+ * encrypted layer — relays never see it.
+ *
+ * <p>After peeling a {@code CMD_FORWARD} layer, the relay rebuilds a fresh 2048-byte packet with a
+ * new random {@code packet_id}, the inner {@code next_hop} and the remaining plaintext as body,
+ * padded with random bytes (see {@link #buildPacket}).
  */
 public final class FlaschenpostV2 {
 
@@ -57,6 +63,15 @@ public final class FlaschenpostV2 {
 
   /** Layer command: final hop — deposit the payload into the OH mailbox. */
   public static final byte CMD_DELIVER = 0x02;
+
+  /**
+   * Layer command (MS05, reverse garlic): final hop — deposit the payload into the OH mailbox
+   * together with the 16-byte session tag that follows the oh_id.
+   */
+  public static final byte CMD_DELIVER_TAGGED = 0x03;
+
+  /** Length of the reverse-garlic session tag inside a {@link #CMD_DELIVER_TAGGED} layer. */
+  public static final int SESSION_TAG_LEN = 16;
 
   /** Length of a layer body prefix: [12 nonce][32 ephemeral_pub][4 ciphertext_len] (48). */
   public static final int BODY_HEADER_LEN =

--- a/src/main/java/im/redpanda/flaschenpost/GMParser.java
+++ b/src/main/java/im/redpanda/flaschenpost/GMParser.java
@@ -327,16 +327,23 @@ public class GMParser {
   }
 
   private static void sendFpToPeer(Peer peerToSendFP, byte[] content) {
-    sendFpToPeer(peerToSendFP, content, null, 0);
+    sendFpToPeer(peerToSendFP, content, null, 0, null);
+  }
+
+  public static void sendFpToPeer(Peer peerToSendFP, byte[] content, byte[] ohId, int hopCount) {
+    sendFpToPeer(peerToSendFP, content, ohId, hopCount, null);
   }
 
   /**
    * Writes a FlaschenpostPut to the peer. MS02b (Option A): when {@code ohId} is non-null it is
    * preserved on the forwarded packet, so the destination node can deposit into the correct mailbox
    * — before MS02b the packet was rebuilt with {@code content} only and the oh_id was lost. {@code
-   * hopCount} carries the forwarding budget (loop protection).
+   * hopCount} carries the forwarding budget (loop protection). {@code sessionTag} (MS05) preserves
+   * the reverse-garlic session tag when a tagged deliver is forwarded to the OH host node; {@code
+   * null}/empty for untagged deposits.
    */
-  public static void sendFpToPeer(Peer peerToSendFP, byte[] content, byte[] ohId, int hopCount) {
+  public static void sendFpToPeer(
+      Peer peerToSendFP, byte[] content, byte[] ohId, int hopCount, byte[] sessionTag) {
     peerToSendFP.getWriteBufferLock().lock();
     try {
       var builder =
@@ -347,6 +354,9 @@ public class GMParser {
       }
       if (hopCount > 0) {
         builder.setHopCount(hopCount);
+      }
+      if (sessionTag != null && sessionTag.length > 0) {
+        builder.setSessionTag(com.google.protobuf.ByteString.copyFrom(sessionTag));
       }
       byte[] data = builder.build().toByteArray();
 

--- a/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
+++ b/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
@@ -66,7 +66,8 @@ public final class GarlicRouter {
     byte cmd = plaintext[0]; // MIN_CIPHERTEXT_LEN guarantees at least one plaintext byte
     switch (cmd) {
       case FlaschenpostV2.CMD_FORWARD -> handleForward(serverContext, plaintext);
-      case FlaschenpostV2.CMD_DELIVER -> handleDeliver(serverContext, plaintext);
+      case FlaschenpostV2.CMD_DELIVER -> handleDeliver(serverContext, plaintext, false);
+      case FlaschenpostV2.CMD_DELIVER_TAGGED -> handleDeliver(serverContext, plaintext, true);
       default -> log.debug("unknown flaschenpost v2 layer command {}, dropping", cmd);
     }
   }
@@ -101,9 +102,16 @@ public final class GarlicRouter {
     routeToNextHop(serverContext, innerNextHop, rebuilt);
   }
 
-  /** CMD_DELIVER: [1 cmd][20 oh_id][4 payload_len][payload][ignored padding]. */
-  private static void handleDeliver(ServerContext serverContext, byte[] plaintext) {
-    if (plaintext.length < 1 + KademliaId.ID_LENGTH_BYTES + 4) {
+  /**
+   * CMD_DELIVER: {@code [1 cmd][20 oh_id][4 payload_len][payload][ignored padding]}.
+   *
+   * <p>CMD_DELIVER_TAGGED (MS05, {@code tagged = true}): {@code [1 cmd][20 oh_id][16 session_tag][4
+   * payload_len][payload][ignored padding]} — the session tag is deposited with the payload so the
+   * fetching client can correlate the reverse-garlic reply with a conversation.
+   */
+  private static void handleDeliver(ServerContext serverContext, byte[] plaintext, boolean tagged) {
+    int tagLen = tagged ? FlaschenpostV2.SESSION_TAG_LEN : 0;
+    if (plaintext.length < 1 + KademliaId.ID_LENGTH_BYTES + tagLen + 4) {
       log.debug("flaschenpost v2 deliver layer too short, dropping");
       return;
     }
@@ -111,6 +119,8 @@ public final class GarlicRouter {
     buffer.get(); // command byte
     byte[] ohId = new byte[KademliaId.ID_LENGTH_BYTES];
     buffer.get(ohId);
+    byte[] sessionTag = new byte[tagLen];
+    buffer.get(sessionTag);
     int payloadLen = buffer.getInt();
     if (payloadLen < 0 || payloadLen > buffer.remaining()) {
       log.debug("flaschenpost v2 deliver payload length invalid, dropping");
@@ -123,10 +133,12 @@ public final class GarlicRouter {
     if (outboundService == null) {
       return;
     }
-    OutboundService.DepositResult result = outboundService.depositMessage(ohId, payload);
+    OutboundService.DepositResult result =
+        outboundService.depositMessage(ohId, payload, sessionTag);
     if (result == OutboundService.DepositResult.NOT_FOUND) {
       // the final garlic hop does not have to be the OH host — reuse the MS02b forwarding
-      OhForwarder.forward(serverContext, ohId, payload, 0);
+      // (the session tag rides along on the FlaschenpostPut, see OhForwarder)
+      OhForwarder.forward(serverContext, ohId, payload, 0, sessionTag);
     } else if (result != OutboundService.DepositResult.DEPOSITED) {
       log.debug("flaschenpost v2 deliver not stored: {}", result);
     }

--- a/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
+++ b/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
@@ -40,6 +40,20 @@ public final class OhForwarder {
    */
   public static boolean forward(
       ServerContext serverContext, byte[] ohId, byte[] content, int hopCount) {
+    return forward(serverContext, ohId, content, hopCount, null);
+  }
+
+  /**
+   * Forwards a deposit for a non-local OH toward its host node, preserving an MS05 reverse-garlic
+   * session tag (or {@code null}/empty for untagged deposits). Resolution result and routing happen
+   * asynchronously (the DHT lookup is randomized-delayed against profiling).
+   *
+   * @param hopCount the hop count the packet arrived with
+   * @return {@code true} if forwarding was initiated (hop budget available), {@code false} if the
+   *     packet was dropped at the hop limit
+   */
+  public static boolean forward(
+      ServerContext serverContext, byte[] ohId, byte[] content, int hopCount, byte[] sessionTag) {
     if (hopCount >= MAX_HOPS) {
       log.debug("dropping FlaschenpostPut for unknown OH at hop limit {}", hopCount);
       return false;
@@ -49,7 +63,8 @@ public final class OhForwarder {
         ohId,
         record -> {
           byte[] nodeIdBytes = record.getNodeId().toByteArray();
-          routeToNode(serverContext, new KademliaId(nodeIdBytes), ohId, content, hopCount);
+          routeToNode(
+              serverContext, new KademliaId(nodeIdBytes), ohId, content, hopCount, sessionTag);
         },
         () -> log.debug("OH host resolution failed, dropping forwarded deposit"));
     return true;
@@ -64,10 +79,11 @@ public final class OhForwarder {
       KademliaId targetNodeId,
       byte[] ohId,
       byte[] content,
-      int hopCount) {
+      int hopCount,
+      byte[] sessionTag) {
     Peer nextPeer = selectNextPeer(serverContext, targetNodeId);
     if (nextPeer != null) {
-      GMParser.sendFpToPeer(nextPeer, content, ohId, hopCount + 1);
+      GMParser.sendFpToPeer(nextPeer, content, ohId, hopCount + 1, sessionTag);
     }
   }
 

--- a/src/main/java/im/redpanda/outbound/OutboundService.java
+++ b/src/main/java/im/redpanda/outbound/OutboundService.java
@@ -48,6 +48,11 @@ public class OutboundService {
    */
   private static final int MESSAGE_ID_BYTES = 16;
 
+  /** Required length of a non-empty MS05 reverse-garlic session tag. */
+  public static final int SESSION_TAG_BYTES = 16;
+
+  private static final byte[] EMPTY_SESSION_TAG = new byte[0];
+
   private final OutboundHandleStore handleStore;
   private final OutboundMailboxStore mailboxStore;
   private final OutboundAuth auth;
@@ -330,6 +335,24 @@ public class OutboundService {
    *     is not registered here or expired, or the MS02b rejection reason
    */
   public DepositResult depositMessage(byte[] ohId, byte[] payload) {
+    return depositMessage(ohId, payload, EMPTY_SESSION_TAG);
+  }
+
+  /**
+   * Deposits a message with an MS05 reverse-garlic session tag (see {@link #depositMessage(byte[],
+   * byte[])} for the deposit semantics). The tag is stored on the {@code MailItem} and returned to
+   * the fetching client, which uses it to correlate the reply with a conversation.
+   *
+   * @param sessionTag 16-byte session tag, or empty/{@code null} for untagged messages; any other
+   *     length is rejected with {@link DepositResult#BAD_REQUEST}
+   */
+  public DepositResult depositMessage(byte[] ohId, byte[] payload, byte[] sessionTag) {
+    if (sessionTag == null) {
+      sessionTag = EMPTY_SESSION_TAG;
+    }
+    if (sessionTag.length != 0 && sessionTag.length != SESSION_TAG_BYTES) {
+      return DepositResult.BAD_REQUEST;
+    }
     HandleRecord handle = handleStore.get(ohId);
     if (handle == null) {
       return DepositResult.NOT_FOUND;
@@ -344,6 +367,7 @@ public class OutboundService {
             .setMessageId(ByteString.copyFrom(messageId))
             .setReceivedAtMs(now)
             .setPayload(ByteString.copyFrom(payload))
+            .setSessionTag(ByteString.copyFrom(sessionTag))
             .build();
     return switch (mailboxStore.addMessage(ohId, item)) {
       case ADDED -> DepositResult.DEPOSITED;

--- a/src/main/proto/commands.proto
+++ b/src/main/proto/commands.proto
@@ -70,6 +70,10 @@ message FlaschenpostPut {
     // MS02b: number of node-to-node forwards this packet has taken. Incremented on every
     // forward; packets at the hop limit are dropped instead of forwarded (loop protection).
     uint32 hop_count = 4;
+    // MS05: 16-byte reverse-garlic session tag, preserved when the final garlic hop is not the
+    // OH host and the deliver falls back to this MS02b forwarding. Empty (unset) for direct
+    // deposits and untagged delivers; the host node stores it on the MailItem.
+    bytes session_tag = 5;
 }
 
 // Unified envelope for future-proofing or batching, 

--- a/src/main/proto/outbound.proto
+++ b/src/main/proto/outbound.proto
@@ -54,6 +54,10 @@ message MailItem {
   int64 received_at_ms = 2;
   bytes payload = 3;            // chat payload (later: push payload / garlic delivered)
   uint64 sequence_id = 4;       // monotone per-OH sequence id
+  // MS05: 16-byte session tag from a reverse-garlic reply (CMD_DELIVER_TAGGED), letting the
+  // client correlate the reply with a conversation. Empty for direct messages and untagged
+  // garlic delivers (backward compatible).
+  bytes session_tag = 5;
 }
 
 message FetchResponse {

--- a/src/test/java/im/redpanda/flaschenpost/OhForwarderTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/OhForwarderTest.java
@@ -169,6 +169,6 @@ public class OhForwarderTest {
   public void routeToNode_withoutDirectPeer_dropsWhenNoCloserCandidate() {
     // No peers at all — routing must simply drop without throwing
     OhForwarder.routeToNode(
-        nodeA, NodeId.generateWithSimpleKey().getKademliaId(), ohId, new byte[8], 0);
+        nodeA, NodeId.generateWithSimpleKey().getKademliaId(), ohId, new byte[8], 0, null);
   }
 }

--- a/src/test/java/im/redpanda/flaschenpost/ReverseGarlicRouterTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/ReverseGarlicRouterTest.java
@@ -1,0 +1,297 @@
+package im.redpanda.flaschenpost;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import im.redpanda.core.Command;
+import im.redpanda.core.InboundCommandProcessor;
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.Peer;
+import im.redpanda.core.ServerContext;
+import im.redpanda.outbound.OhDht;
+import im.redpanda.outbound.OutboundHandleStore;
+import im.redpanda.outbound.OutboundMailboxStore;
+import im.redpanda.outbound.OutboundService;
+import im.redpanda.outbound.v1.MailItem;
+import im.redpanda.proto.FlaschenpostPut;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * MS05 acceptance: a reverse-garlic reply — built by the responder along the return-path hops the
+ * recipient chose — traverses three relays exactly like an MS04 forward packet; the last relay
+ * peels the {@code CMD_DELIVER_TAGGED} layer and deposits payload <em>plus 16-byte session tag</em>
+ * into the OH mailbox. Relays on the reverse path run unmodified MS04 logic (no special reverse
+ * handling); the session tag stays inside the innermost encrypted layer.
+ *
+ * <p>Plus the negative paths: dedup/replay of a reply packet, truncated tagged layers, invalid
+ * payload length, and the MS02b fallback preserving the session tag when the final hop is not the
+ * OH host.
+ */
+public class ReverseGarlicRouterTest {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private ServerContext hop1;
+  private ServerContext hop2;
+  private ServerContext hop3;
+  private InboundCommandProcessor processor1;
+  private InboundCommandProcessor processor2;
+  private InboundCommandProcessor processor3;
+  private OutboundMailboxStore aliceMailbox;
+
+  /** Alice's OH, registered on hop3 (the final station of the return path). */
+  private byte[] aliceOhId;
+
+  /** The session tag Alice chose for this conversation's reply path. */
+  private byte[] sessionTag;
+
+  @Before
+  public void setUp() {
+    hop1 = ServerContext.buildDefaultServerContext();
+    hop1.setOutboundService(
+        new OutboundService(new OutboundHandleStore(), new OutboundMailboxStore()));
+    processor1 = new InboundCommandProcessor(hop1);
+
+    hop2 = ServerContext.buildDefaultServerContext();
+    hop2.setOutboundService(
+        new OutboundService(new OutboundHandleStore(), new OutboundMailboxStore()));
+    processor2 = new InboundCommandProcessor(hop2);
+
+    hop3 = ServerContext.buildDefaultServerContext();
+    OutboundHandleStore handleStore3 = new OutboundHandleStore();
+    aliceMailbox = new OutboundMailboxStore();
+    hop3.setOutboundService(new OutboundService(handleStore3, aliceMailbox));
+    processor3 = new InboundCommandProcessor(hop3);
+
+    aliceOhId = new byte[KademliaId.ID_LENGTH_BYTES];
+    RANDOM.nextBytes(aliceOhId);
+    sessionTag = new byte[FlaschenpostV2.SESSION_TAG_LEN];
+    RANDOM.nextBytes(sessionTag);
+
+    long now = System.currentTimeMillis();
+    handleStore3.put(
+        aliceOhId, new OutboundHandleStore.HandleRecord(new byte[65], now, now + 60_000));
+  }
+
+  /** Builds a [4-byte len][payload] frame as expected by {@code parseCommand}. */
+  private static ByteBuffer buildFrame(byte[] payload) {
+    ByteBuffer buf = ByteBuffer.allocate(4 + payload.length);
+    buf.putInt(payload.length);
+    buf.put(payload);
+    buf.flip();
+    return buf;
+  }
+
+  /** Adds a connected peer object representing {@code target} to {@code host}'s peer list. */
+  private static Peer connect(ServerContext host, ServerContext target, int port) {
+    Peer peer = new Peer("127.0.0.1", port, target.getNodeId());
+    peer.setConnected(true);
+    peer.writeBuffer = ByteBuffer.allocate(65536);
+    host.getPeerList().add(peer);
+    return peer;
+  }
+
+  /** A connected sender peer (the packet origin, e.g. the replying light client). */
+  private static Peer sender(ServerContext host, int port) {
+    Peer peer = new Peer("127.0.0.1", port, host.getNodeId());
+    peer.setConnected(true);
+    peer.writeBuffer = ByteBuffer.allocate(65536);
+    host.getPeerList().add(peer);
+    return peer;
+  }
+
+  /** Reads one FLASCHENPOST_V2 frame from the peer's write buffer. */
+  private static byte[] readV2Frame(Peer peer) {
+    ByteBuffer out = peer.writeBuffer;
+    out.flip();
+    assertThat(out.hasRemaining()).as("expected a forwarded FLASCHENPOST_V2 frame").isTrue();
+    assertThat(out.get()).isEqualTo(Command.FLASCHENPOST_V2);
+    byte[] packet = new byte[out.getInt()];
+    out.get(packet);
+    assertThat(out.hasRemaining()).as("exactly one frame expected").isFalse();
+    out.clear();
+    return packet;
+  }
+
+  /** Builds the innermost CMD_DELIVER_TAGGED plaintext (oh_id + session_tag + payload). */
+  private byte[] buildTaggedDeliverPlaintext(byte[] ohId, byte[] tag, byte[] payload) {
+    ByteBuffer deliver =
+        ByteBuffer.allocate(1 + KademliaId.ID_LENGTH_BYTES + tag.length + 4 + payload.length);
+    deliver.put(FlaschenpostV2.CMD_DELIVER_TAGGED);
+    deliver.put(ohId);
+    deliver.put(tag);
+    deliver.putInt(payload.length);
+    deliver.put(payload);
+    return deliver.array();
+  }
+
+  /**
+   * Builds the reply packet exactly like the responder's client will: standard MS04 layer
+   * construction along the return-path hops, with a CMD_DELIVER_TAGGED innermost layer.
+   */
+  private byte[] buildReplyPacket(byte[] payload, ServerContext... hops) throws Exception {
+    ServerContext last = hops[hops.length - 1];
+    byte[] body =
+        FlaschenpostV2.encryptLayer(
+            last.getNodeId().getEncryptionPubKey(),
+            last.getNonce(),
+            buildTaggedDeliverPlaintext(aliceOhId, sessionTag, payload));
+
+    for (int i = hops.length - 2; i >= 0; i--) {
+      ByteBuffer forward = ByteBuffer.allocate(1 + KademliaId.ID_LENGTH_BYTES + body.length);
+      forward.put(FlaschenpostV2.CMD_FORWARD);
+      forward.put(hops[i + 1].getNonce().getBytes());
+      forward.put(body);
+      body =
+          FlaschenpostV2.encryptLayer(
+              hops[i].getNodeId().getEncryptionPubKey(), hops[i].getNonce(), forward.array());
+    }
+    return FlaschenpostV2.buildPacket(RANDOM.nextInt(), hops[0].getNonce(), body);
+  }
+
+  @Test
+  public void replyPacket_traversesThreeRelays_andIsDepositedWithSessionTag() throws Exception {
+    Peer peer1To2 = connect(hop1, hop2, 9501);
+    Peer peer2To3 = connect(hop2, hop3, 9502);
+
+    byte[] payload = "reverse garlic reply".getBytes(StandardCharsets.UTF_8);
+    byte[] packet = buildReplyPacket(payload, hop1, hop2, hop3);
+    int originalPacketId = FlaschenpostV2.parse(packet).getPacketId();
+
+    // return-path relay 1 behaves exactly like an MS04 forward relay
+    processor1.parseCommand(Command.FLASCHENPOST_V2, buildFrame(packet), sender(hop1, 9500));
+    byte[] toHop2 = readV2Frame(peer1To2);
+    assertThat(toHop2).hasSize(FlaschenpostV2.PACKET_SIZE);
+    FlaschenpostV2 parsed2 = FlaschenpostV2.parse(toHop2);
+    assertThat(parsed2.getNextHop()).isEqualTo(hop2.getNonce());
+    assertThat(parsed2.getPacketId()).isNotEqualTo(originalPacketId);
+
+    // return-path relay 2
+    processor2.parseCommand(Command.FLASCHENPOST_V2, buildFrame(toHop2), sender(hop2, 9503));
+    byte[] toHop3 = readV2Frame(peer2To3);
+    assertThat(toHop3).hasSize(FlaschenpostV2.PACKET_SIZE);
+    assertThat(FlaschenpostV2.parse(toHop3).getNextHop()).isEqualTo(hop3.getNonce());
+
+    // final station peels CMD_DELIVER_TAGGED and deposits payload + session tag
+    processor3.parseCommand(Command.FLASCHENPOST_V2, buildFrame(toHop3), sender(hop3, 9504));
+    List<MailItem> items = aliceMailbox.fetchMessages(aliceOhId, 10, 0);
+    assertThat(items).hasSize(1);
+    assertThat(items.get(0).getPayload().toByteArray()).isEqualTo(payload);
+    assertThat(items.get(0).getSessionTag().toByteArray())
+        .as("the session tag must be stored with the mail item")
+        .isEqualTo(sessionTag);
+  }
+
+  @Test
+  public void untaggedDeliver_keepsWorking_withEmptySessionTag() throws Exception {
+    // backward compatibility: an MS04 CMD_DELIVER (no tag) still deposits, tag stays empty
+    byte[] payload = "plain ms04 deliver".getBytes(StandardCharsets.UTF_8);
+    ByteBuffer deliver = ByteBuffer.allocate(1 + KademliaId.ID_LENGTH_BYTES + 4 + payload.length);
+    deliver.put(FlaschenpostV2.CMD_DELIVER);
+    deliver.put(aliceOhId);
+    deliver.putInt(payload.length);
+    deliver.put(payload);
+    byte[] body =
+        FlaschenpostV2.encryptLayer(
+            hop3.getNodeId().getEncryptionPubKey(), hop3.getNonce(), deliver.array());
+    byte[] packet = FlaschenpostV2.buildPacket(RANDOM.nextInt(), hop3.getNonce(), body);
+
+    processor3.parseCommand(Command.FLASCHENPOST_V2, buildFrame(packet), sender(hop3, 9510));
+
+    List<MailItem> items = aliceMailbox.fetchMessages(aliceOhId, 10, 0);
+    assertThat(items).hasSize(1);
+    assertThat(items.get(0).getPayload().toByteArray()).isEqualTo(payload);
+    assertThat(items.get(0).getSessionTag().isEmpty()).isTrue();
+  }
+
+  @Test
+  public void replayedReplyPacket_isDroppedByDedup() throws Exception {
+    Peer peer1To2 = connect(hop1, hop2, 9521);
+    byte[] packet = buildReplyPacket(new byte[16], hop1, hop2, hop3);
+
+    processor1.parseCommand(Command.FLASCHENPOST_V2, buildFrame(packet), sender(hop1, 9520));
+    assertThat(readV2Frame(peer1To2)).hasSize(FlaschenpostV2.PACKET_SIZE);
+
+    // a captured reply packet replayed against the entry hop must be dropped (packet_id dedup)
+    processor1.parseCommand(Command.FLASCHENPOST_V2, buildFrame(packet), sender(hop1, 9522));
+    peer1To2.writeBuffer.flip();
+    assertThat(peer1To2.writeBuffer.hasRemaining())
+        .as("a replayed reply packet must not be forwarded again")
+        .isFalse();
+  }
+
+  @Test
+  public void taggedDeliverLayer_tooShortForTag_isDroppedSilently() throws Exception {
+    // CMD_DELIVER_TAGGED needs 1 + 20 + 16 + 4 = 41 plaintext bytes; this layer only carries
+    // the untagged minimum (25) and must be dropped without crash or deposit
+    ByteBuffer deliver = ByteBuffer.allocate(1 + KademliaId.ID_LENGTH_BYTES + 4);
+    deliver.put(FlaschenpostV2.CMD_DELIVER_TAGGED);
+    deliver.put(aliceOhId);
+    deliver.putInt(0);
+    byte[] body =
+        FlaschenpostV2.encryptLayer(
+            hop3.getNodeId().getEncryptionPubKey(), hop3.getNonce(), deliver.array());
+    byte[] packet = FlaschenpostV2.buildPacket(RANDOM.nextInt(), hop3.getNonce(), body);
+
+    processor3.parseCommand(Command.FLASCHENPOST_V2, buildFrame(packet), sender(hop3, 9530));
+
+    assertThat(aliceMailbox.fetchMessages(aliceOhId, 10, 0)).isEmpty();
+  }
+
+  @Test
+  public void taggedDeliver_invalidPayloadLength_isDropped() throws Exception {
+    // payload_len claims more bytes than the plaintext contains — must be rejected
+    ByteBuffer deliver =
+        ByteBuffer.allocate(1 + KademliaId.ID_LENGTH_BYTES + FlaschenpostV2.SESSION_TAG_LEN + 4);
+    deliver.put(FlaschenpostV2.CMD_DELIVER_TAGGED);
+    deliver.put(aliceOhId);
+    deliver.put(sessionTag);
+    deliver.putInt(500);
+    byte[] body =
+        FlaschenpostV2.encryptLayer(
+            hop3.getNodeId().getEncryptionPubKey(), hop3.getNonce(), deliver.array());
+    byte[] packet = FlaschenpostV2.buildPacket(RANDOM.nextInt(), hop3.getNonce(), body);
+
+    processor3.parseCommand(Command.FLASCHENPOST_V2, buildFrame(packet), sender(hop3, 9540));
+
+    assertThat(aliceMailbox.fetchMessages(aliceOhId, 10, 0)).isEmpty();
+  }
+
+  @Test
+  public void taggedDeliverForRemoteOh_fallsBackToMs02b_preservingSessionTag() throws Exception {
+    // the final return-path hop (hop1) does not host Alice's OH; it must forward a
+    // FlaschenpostPut that carries oh_id, payload AND the session tag toward the host node
+    byte[] remoteOhId = new byte[KademliaId.ID_LENGTH_BYTES];
+    RANDOM.nextBytes(remoteOhId);
+    hop1.getKadStoreManager()
+        .put(OhDht.buildAnnounceContent(remoteOhId, hop2.getNonce(), System.currentTimeMillis()));
+    Peer peer1To2 = connect(hop1, hop2, 9551);
+
+    byte[] payload = "reply for remote oh".getBytes(StandardCharsets.UTF_8);
+    byte[] body =
+        FlaschenpostV2.encryptLayer(
+            hop1.getNodeId().getEncryptionPubKey(),
+            hop1.getNonce(),
+            buildTaggedDeliverPlaintext(remoteOhId, sessionTag, payload));
+    byte[] packet = FlaschenpostV2.buildPacket(RANDOM.nextInt(), hop1.getNonce(), body);
+
+    processor1.parseCommand(Command.FLASCHENPOST_V2, buildFrame(packet), sender(hop1, 9550));
+
+    ByteBuffer out = peer1To2.writeBuffer;
+    out.flip();
+    assertThat(out.hasRemaining()).as("MS02b forward expected").isTrue();
+    assertThat(out.get()).isEqualTo(Command.FLASCHENPOST_PUT);
+    byte[] forwardedBytes = new byte[out.getInt()];
+    out.get(forwardedBytes);
+    FlaschenpostPut forwarded = FlaschenpostPut.parseFrom(forwardedBytes);
+    assertThat(forwarded.getOhId().toByteArray()).isEqualTo(remoteOhId);
+    assertThat(forwarded.getContent().toByteArray()).isEqualTo(payload);
+    assertThat(forwarded.getSessionTag().toByteArray())
+        .as("the session tag must survive the MS02b fallback")
+        .isEqualTo(sessionTag);
+  }
+}

--- a/src/test/java/im/redpanda/outbound/OutboundServiceIntegrationTest.java
+++ b/src/test/java/im/redpanda/outbound/OutboundServiceIntegrationTest.java
@@ -128,6 +128,46 @@ public class OutboundServiceIntegrationTest {
     assertThat(fetchRes.getItems(2).getPayload().toStringUtf8()).isEqualTo(MSG3);
   }
 
+  /** MS05: a deposit with session tag is returned to the client via FetchResponse. */
+  @Test
+  public void testDepositWithSessionTag_FetchReturnsTag() throws Exception {
+    service.handleRegister(peer, createSignedRegisterRequest());
+    readRegisterResponse(); // consume
+
+    byte[] ohId = clientNode.getKademliaId().getBytes();
+    byte[] sessionTag = new byte[OutboundService.SESSION_TAG_BYTES];
+    new SecureRandom().nextBytes(sessionTag);
+
+    OutboundService.DepositResult tagged =
+        service.depositMessage(ohId, MSG1.getBytes(StandardCharsets.UTF_8), sessionTag);
+    assertThat(tagged).isEqualTo(OutboundService.DepositResult.DEPOSITED);
+    // untagged deposits keep working side by side, with an empty tag
+    service.depositMessage(ohId, MSG2.getBytes(StandardCharsets.UTF_8));
+
+    service.handleFetch(peer, createSignedFetchRequest(0));
+    FetchResponse fetchRes = readFetchResponse();
+
+    assertThat(fetchRes.getStatus()).isEqualTo(Status.OK);
+    assertThat(fetchRes.getItemsCount()).isEqualTo(2);
+    assertThat(fetchRes.getItems(0).getSessionTag().toByteArray()).isEqualTo(sessionTag);
+    assertThat(fetchRes.getItems(1).getSessionTag().isEmpty()).isTrue();
+  }
+
+  /** MS05: a non-empty session tag must be exactly 16 bytes. */
+  @Test
+  public void testDepositWithInvalidSessionTagLength_ReturnsBadRequest() throws Exception {
+    service.handleRegister(peer, createSignedRegisterRequest());
+    readRegisterResponse(); // consume
+
+    byte[] ohId = clientNode.getKademliaId().getBytes();
+    OutboundService.DepositResult result =
+        service.depositMessage(ohId, MSG1.getBytes(StandardCharsets.UTF_8), new byte[7]);
+    assertThat(result).isEqualTo(OutboundService.DepositResult.BAD_REQUEST);
+
+    service.handleFetch(peer, createSignedFetchRequest(0));
+    assertThat(readFetchResponse().getItemsCount()).isZero();
+  }
+
   @Test
   public void testDepositAfterRevoke_ReturnsFalse() throws Exception {
     byte[] ohId = clientNode.getKademliaId().getBytes();


### PR DESCRIPTION
## Backend-MS05 (Reverse Garlic, Relay-Seite)

Implements the backend view spec (docs: milestones/backend/ms05_reverse_garlic.md): relays on a reverse-garlic return path behave exactly like MS04 forward relays; the only backend change is that a tagged deliver writes the 16-byte `session_tag` into the OH mailbox so the fetching client can correlate replies with conversations.

### Wire format
- New layer command `CMD_DELIVER_TAGGED (0x03)`:
  `[1 cmd][20 oh_id][16 session_tag][4 payload_len][payload][optional padding]`
  (oh_id is 20 bytes and payload_len explicit, consistent with the MS04 Decision 4 deliver format; the spec pseudo-code's 32-byte oh_id was a known error).
- `CMD_DELIVER (0x02)` is **unchanged** — in-place extension would break released Frontend-MS04 clients; untagged delivers keep working with an empty tag (backend view OQ 1 → optional).
- `MailItem.session_tag = 5` (empty for direct/untagged messages), returned via `FetchResponse`.
- `FlaschenpostPut.session_tag = 5`: preserves the tag on the MS02b fallback when the final garlic hop is not the OH host. Old clients never set it.

### Behavior
- `GarlicRouter`: dispatches 0x03 to the shared deliver handler; deposits payload + tag; NOT_FOUND falls back to `OhForwarder.forward(..., sessionTag)`.
- `OutboundService.depositMessage(ohId, payload, sessionTag)`: tag must be empty or exactly 16 bytes, else `BAD_REQUEST`.
- No reverse-specific relay logic; packet_id dedup (5 min) covers replayed reply packets.

### Tests
- `ReverseGarlicRouterTest` (analog `GarlicRouterTest`): 3-relay reply E2E with session-tag deposit, untagged backward compat, replay dedup, truncated tagged layer, invalid payload_len, remote-OH fallback preserving the tag.
- `OutboundServiceIntegrationTest`: FetchResponse returns the tag; invalid tag length → BAD_REQUEST.

Budget note for Frontend-MS05: tagged deliver layer overhead = 41 B → max deliver payload at 3 hops = **1748 B** (vs. 1764 B untagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)