### PR TITLE
docs: Status-Overview-Sync — Backend-MS06 Done

### DIFF
--- a/milestones/00_status_overview.md
+++ b/milestones/00_status_overview.md
@@ -40,7 +40,7 @@ Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den
 | OH Auth (Ed25519 + replay) | `OutboundAuth.java` | Done — Ed25519 + Signing-Versions-Byte (MS03), Legacy-ECDSA-Fallback bis v22-Removal |
 | Garlic encryption (single layer) | `GarlicMessage.java` | Done — v2: AES-256-GCM + X25519 + HKDF, AAD = Ziel-KademliaId (MS03) |
 | Multi-hop garlic relay | `FlaschenpostV2.java`, `GarlicRouter.java` | Done — fixe 2048-B-Pakete, Layer-Peeling, Rebuild + Re-Padding, packet_id-Dedup (MS04); `CMD_DELIVER_TAGGED` mit `session_tag`-Deposit (MS05); `CMD_DELIVER_ACKED` mit Return-Path-Block (MS06) |
-| R-ACK generation | `ReturnPath.java`, `RoutingAckSender.java` | Done — `RoutingAck` als MS04-Onion über Sender-gewählte Return-Path-Hops, Status-Mapping, `FlaschenpostPut.return_path` im MS02b-Fallback (MS06) |
+| R-ACK Generation | `ReturnPath.java`, `RoutingAckSender.java` | Done — `RoutingAck` als MS04-Onion über Sender-gewählte Return-Path-Hops, Status-Mapping, `FlaschenpostPut.return_path` im MS02b-Fallback (MS06) |
 | Kademlia DHT | `KadStoreManager.java` | Done (in-memory) — Ed25519-Signaturen (MS03) |
 | TCP handshake + stream encryption | `ConnectionHandler.java`, `GcmFramedStreams.java` | Done — v23: framed AES-256-GCM, Counter-Nonces; v22 nur noch Light Clients (MS03) |
 | Node identity | `NodeId.java` | Done — Ed25519 (sign) + X25519 (encrypt) Dual-Keypair (MS03) |

--- a/milestones/00_status_overview.md
+++ b/milestones/00_status_overview.md
@@ -1,6 +1,6 @@
 # Backend Milestones — Status Overview
 
-> Last updated: 2026-06-13
+> Last updated: 2026-07-08
 
 Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den fertigen Backend-APIs auf.
 
@@ -23,7 +23,7 @@ Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den
 | [MS03b](ms03b_forward_secrecy.md) | Forward Secrecy | Done | Verifiziert 2026-06-12 (keine Code-Änderung): Payloads bleiben opak, 64-KiB-Limit unkritisch — Frontend MS03b Done |
 | [MS04](ms04_multi_hop_garlic.md) | Multi-Hop Relay | Done | Frontend MS04 kann starten (Flaschenpost v2 Relay, `FLASCHENPOST_V2` (142), `encryption_public_key` im Peer-Austausch) |
 | [MS05](ms05_reverse_garlic.md) | Reverse Garlic (Relay-Seite) | Done | Frontend MS05 kann starten (`CMD_DELIVER_TAGGED` (0x03), `MailItem.session_tag`, RGB-Modell = Hop-Deskriptoren laut Master-Spec Decision 6) |
-| [MS06](ms06_two_layer_ack.md) | R-ACK Generation | Missing | Frontend MS06 blocked — OH muss R-ACK erzeugen können |
+| [MS06](ms06_two_layer_ack.md) | R-ACK Generation | Done | Frontend MS06 kann starten (`CMD_DELIVER_ACKED` (0x04), `ReturnPath`-Block, `RoutingAck`-Payload — redpandaj [#229](https://github.com/redPanda-project/redpandaj/pull/229), 2026-07-03) |
 | [MS07](ms07_push_notifications.md) | Push Sender (FCM/APNs) | Missing | Frontend MS07 blocked — Push-Infrastruktur muss serverseitig stehen |
 | [MS08](ms08_group_chat.md) | (keine Backend-Änderungen) | N/A | Frontend MS08 kann nach MS05 starten |
 | [MS09](ms09_incentive_system.md) | Reputation & Anti-Sybil | Missing | Frontend MS09 blocked — ReputationService muss verfügbar sein |
@@ -39,7 +39,8 @@ Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den
 | OH Forwarding (Option A) | `OhForwarder.java`, `GMParser.java` | Done — oh_id + hop_count erhalten, max. 3 Hops |
 | OH Auth (Ed25519 + replay) | `OutboundAuth.java` | Done — Ed25519 + Signing-Versions-Byte (MS03), Legacy-ECDSA-Fallback bis v22-Removal |
 | Garlic encryption (single layer) | `GarlicMessage.java` | Done — v2: AES-256-GCM + X25519 + HKDF, AAD = Ziel-KademliaId (MS03) |
-| Multi-hop garlic relay | `FlaschenpostV2.java`, `GarlicRouter.java` | Done — fixe 2048-B-Pakete, Layer-Peeling, Rebuild + Re-Padding, packet_id-Dedup (MS04); `CMD_DELIVER_TAGGED` mit `session_tag`-Deposit (MS05) |
+| Multi-hop garlic relay | `FlaschenpostV2.java`, `GarlicRouter.java` | Done — fixe 2048-B-Pakete, Layer-Peeling, Rebuild + Re-Padding, packet_id-Dedup (MS04); `CMD_DELIVER_TAGGED` mit `session_tag`-Deposit (MS05); `CMD_DELIVER_ACKED` mit Return-Path-Block (MS06) |
+| R-ACK generation | `ReturnPath.java`, `RoutingAckSender.java` | Done — `RoutingAck` als MS04-Onion über Sender-gewählte Return-Path-Hops, Status-Mapping, `FlaschenpostPut.return_path` im MS02b-Fallback (MS06) |
 | Kademlia DHT | `KadStoreManager.java` | Done (in-memory) — Ed25519-Signaturen (MS03) |
 | TCP handshake + stream encryption | `ConnectionHandler.java`, `GcmFramedStreams.java` | Done — v23: framed AES-256-GCM, Counter-Nonces; v22 nur noch Light Clients (MS03) |
 | Node identity | `NodeId.java` | Done — Ed25519 (sign) + X25519 (encrypt) Dual-Keypair (MS03) |


### PR DESCRIPTION
Mirror-Sync aus dem docs-Repo (Quelle: [docs#27](https://github.com/redPanda-project/docs/pull/27)): Status-Overview auf Backend-MS06 Done aktualisiert.

**Bitte erst nach dem Merge von docs#27 mergen**, damit Source of Truth und Mirror synchron bleiben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhBG4xBs5hrsyUi8tGYPvc
