### PR TITLE
docs: MS08-Decisions-Mirror-Sync (sdd05-Spike)

### DIFF
--- a/milestones/ms08_group_chat.md
+++ b/milestones/ms08_group_chat.md
@@ -4,7 +4,7 @@
 
 > **Frontend-Alignment**: Kein Backend-Blocker für [Frontend MS08](../frontend/ms08_group_chat.md).
 > Group Chat ist reine Frontend-Logik (Fan-Out, Key Rotation, Member Management).
-> Bestätigt durch den sdd05-Fan-out-Spike (2026-07-08): Modell 3 („Multi-OH-Fan-out-Node",
+> Bestätigt durch den sdd05-Fan-out-Spike (2026-07-08): Modell 3 („Multi-OH-Fan-out-Node“,
 > der einzige Backend-relevante Kandidat) wurde wegen Metadaten-Konzentration abgelehnt —
 > siehe [Decisions in der Master-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms08_group_chat.md#decisions-fan-out-spike-sdd05-2026-07-08).
 

--- a/milestones/ms08_group_chat.md
+++ b/milestones/ms08_group_chat.md
@@ -4,6 +4,9 @@
 
 > **Frontend-Alignment**: Kein Backend-Blocker für [Frontend MS08](../frontend/ms08_group_chat.md).
 > Group Chat ist reine Frontend-Logik (Fan-Out, Key Rotation, Member Management).
+> Bestätigt durch den sdd05-Fan-out-Spike (2026-07-08): Modell 3 („Multi-OH-Fan-out-Node",
+> der einzige Backend-relevante Kandidat) wurde wegen Metadaten-Konzentration abgelehnt —
+> siehe [Decisions in der Master-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms08_group_chat.md#decisions-fan-out-spike-sdd05-2026-07-08).
 
 ## Goal
 


### PR DESCRIPTION
Mirror-Sync aus dem docs-Repo (Quelle: redPanda-project/docs#30): der sdd05-Fan-out-Spike bestätigt, dass MS08 keinen Backend-Anteil hat — Modell 3 (Multi-OH-Fan-out-Node) wurde wegen Metadaten-Konzentration abgelehnt. Nur Doku, kein Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhBG4xBs5hrsyUi8tGYPvc