### PR TITLE
test: Flaky-Test InboundCommandProcessorAsyncUpdatesTest härten

### DIFF
--- a/src/test/java/im/redpanda/core/InboundCommandProcessorAsyncUpdatesTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorAsyncUpdatesTest.java
@@ -45,11 +45,7 @@ public class InboundCommandProcessorAsyncUpdatesTest {
 
   @Test
   public void updateRequestContent_sendsJarFrame_whenSignaturePresent() throws IOException {
-    // Prepare a small jar file at default path
     byte[] data = "jar".getBytes();
-    try (FileOutputStream fos = new FileOutputStream("redpanda.jar")) {
-      fos.write(data);
-    }
 
     // Set signature and timestamp to pass initial guards
     ctx.getLocalSettings().setUpdateTimestamp(System.currentTimeMillis());
@@ -61,10 +57,30 @@ public class InboundCommandProcessorAsyncUpdatesTest {
     // Big enough buffer; code may grow it, but start with capacity
     peer.writeBuffer = ByteBuffer.allocate(1024);
 
-    int consumed = proc.parseCommand(Command.UPDATE_REQUEST_CONTENT, ByteBuffer.allocate(0), peer);
-    assertEquals(1, consumed);
+    // Surefire forks share the working directory: SettingsInitTest (another fork)
+    // deletes redpanda.jar, and on loaded CI runners the async upload task can take
+    // well over 2s. Retry the whole request so neither interference fails the test.
+    int attempts = 0;
+    while (true) {
+      attempts++;
+      // (Re-)create the jar right before each request in case another fork deleted it
+      try (FileOutputStream fos = new FileOutputStream("redpanda.jar")) {
+        fos.write(data);
+      }
 
-    awaitCondition(() -> peer.writeBuffer.position() > 0, 2000);
+      int consumed =
+          proc.parseCommand(Command.UPDATE_REQUEST_CONTENT, ByteBuffer.allocate(0), peer);
+      assertEquals(1, consumed);
+
+      try {
+        awaitCondition(() -> peer.writeBuffer.position() > 0, 5000);
+        break;
+      } catch (AssertionError e) {
+        if (attempts >= 3) {
+          throw e;
+        }
+      }
+    }
     assertEquals(Command.UPDATE_ANSWER_CONTENT, peer.writeBuffer.get(0));
   }
 

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorAsyncUpdatesTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorAsyncUpdatesTest.java
@@ -73,15 +73,39 @@ public class InboundCommandProcessorAsyncUpdatesTest {
       assertEquals(1, consumed);
 
       try {
-        awaitCondition(() -> peer.writeBuffer.position() > 0, 5000);
+        // The writer thread mutates (and may replace) peer.writeBuffer under
+        // writeBufferLock; poll under the same lock for visibility.
+        awaitCondition(
+            () -> {
+              peer.writeBufferLock.lock();
+              try {
+                return peer.writeBuffer.position() > 0;
+              } finally {
+                peer.writeBufferLock.unlock();
+              }
+            },
+            5000);
         break;
       } catch (AssertionError e) {
         if (attempts >= 3) {
           throw e;
         }
+        // Reset the buffer so a late write from this attempt cannot satisfy the
+        // next attempt's await with a partially observed state.
+        peer.writeBufferLock.lock();
+        try {
+          peer.writeBuffer.clear();
+        } finally {
+          peer.writeBufferLock.unlock();
+        }
       }
     }
-    assertEquals(Command.UPDATE_ANSWER_CONTENT, peer.writeBuffer.get(0));
+    peer.writeBufferLock.lock();
+    try {
+      assertEquals(Command.UPDATE_ANSWER_CONTENT, peer.writeBuffer.get(0));
+    } finally {
+      peer.writeBufferLock.unlock();
+    }
   }
 
   @Test


### PR DESCRIPTION
## Problem
`updateRequestContent_sendsJarFrame_whenSignaturePresent` schlug auf CI 3x in Folge fehl (blockiert #232), lokal aber durchgängig grün — auch mit voller Suite.

## Ursache
Zwei CI-spezifische Interferenzen:
1. **Geteiltes Arbeitsverzeichnis der Surefire-Forks** (`forkCount=8`): `SettingsInitTest` (anderer Fork) löscht `redpanda.jar`, während der asynchrone Upload-Task sie lesen will → `NoSuchFileException` → es wird nie in den writeBuffer geschrieben. (Für `android.apk` wurde dieselbe Kollision bereits per `redpanda.android.update.file`-Property pro Fork gelöst, für die Jar nicht.)
2. **CPU-Starvation**: 8 JVM-Forks auf wenigen vCPUs dehnen den 200ms-Sleep + Datei-I/O des Tasks über die 2s-`awaitCondition` hinaus.

## Fix
Test-seitige Härtung: Jar unmittelbar vor jedem Request (neu) schreiben, Timeout 2s → 5s, bis zu 3 Versuche der gesamten Request-Sequenz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhBG4xBs5hrsyUi8tGYPvc