### PR TITLE
chore(deps): jackson entfernen (ungenutzt), commons-lang3 3.18.0 (sdd01)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <logback.version>1.4.14</logback.version>
         <bcprov.version>1.78</bcprov.version>
         <commons-text.version>1.12.0</commons-text.version>
-        <commons-lang3.version>3.17.0</commons-lang3.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <kotlin.version>2.0.21</kotlin.version>
         <lombok.version>1.18.42</lombok.version>
         <protobuf.version>3.25.5</protobuf.version>
@@ -139,17 +139,6 @@
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.18.6</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.18.6</version>
-        </dependency>
-
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>


### PR DESCRIPTION
## Was
- **jackson-core + jackson-databind entfernt**: kein Nutzer in `src/main` + `src/test` (grep + `dependency:analyze` 3.8.1: „Unused declared"). Schließt 4 Dependabot-Alerts (CVE-2026-54512/-54513 high, CVE-2026-54514 medium, CVE-2026-54515 medium **ohne Fix-Version** — Entfernung ist der einzige Weg, den zu schließen). Ersetzt #228.
- **commons-lang3 3.17.0 → 3.18.0**: schließt CVE-2025-48924 (medium); dafür gab es keinen offenen Dependabot-PR.

## Verifikation
`mvn verify` lokal grün (278 Tests). Kein Wire-Format-Bezug.

Teil von `plans/sdd01_dependency_hardening.md`; bcprov/log4j kommen über die rebasten Dependabot-PRs #211/#210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhBG4xBs5hrsyUi8tGYPvc