### PR TITLE
ci: Sonar-Skip am Dependabot-Actor festmachen (Follow-up zu #235)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,10 +48,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
-        if [ -z "$SONAR_TOKEN" ]; then
-          # Dependabot-triggered runs get no repo secrets. Tests already gated the
-          # PR in the coverage step above, so only the Sonar analysis is skipped.
-          echo "SONAR_TOKEN not available (e.g. Dependabot run); skipping Sonar analysis."
+        # Dependabot runs read from the separate Dependabot secret store (its
+        # SONAR_TOKEN is invalid there), so gate on the actor, not the token.
+        # Tests already gated the PR in the coverage step above.
+        if [ "${{ github.actor }}" = "dependabot[bot]" ] || [ -z "$SONAR_TOKEN" ]; then
+          echo "Dependabot run or SONAR_TOKEN not available; skipping Sonar analysis."
         else
           mvn -B jacoco:prepare-agent verify jacoco:report sonar:sonar -Dsonar.projectKey=redPanda-project_redpandaj
         fi

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -49,9 +49,10 @@ jobs:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
         # Dependabot runs read from the separate Dependabot secret store (its
-        # SONAR_TOKEN is invalid there), so gate on the actor, not the token.
-        # Tests already gated the PR in the coverage step above.
-        if [ "${{ github.actor }}" = "dependabot[bot]" ] || [ -z "$SONAR_TOKEN" ]; then
+        # SONAR_TOKEN is invalid there), so gate on the PR author/actor, not the
+        # token. PR author stays dependabot[bot] across maintainer re-runs; on
+        # push events it is empty. Tests already gated the PR in the coverage step.
+        if [ "${{ github.event.pull_request.user.login }}" = "dependabot[bot]" ] || [ "${{ github.actor }}" = "dependabot[bot]" ] || [ -z "$SONAR_TOKEN" ]; then
           echo "Dependabot run or SONAR_TOKEN not available; skipping Sonar analysis."
         else
           mvn -B jacoco:prepare-agent verify jacoco:report sonar:sonar -Dsonar.projectKey=redPanda-project_redpandaj


### PR DESCRIPTION
#235 prüfte auf leeres `SONAR_TOKEN` — aber Dependabot-Runs lesen aus dem **separaten Dependabot-Secret-Store**, und dort existiert ein `SONAR_TOKEN` mit ungültigem Wert (SonarCloud: „Not authorized"; alle 4 rebasten Dependabot-PRs erneut daran gescheitert, Tests jeweils grün). Der Actor-Check `github.actor == dependabot[bot]` deckt das ab, der Leer-Check bleibt als Fallback.

Alternativ/zusätzlich kann ein Maintainer das kaputte Dependabot-Secret unter *Settings → Secrets → Dependabot* korrigieren oder löschen — dieser Fix macht die CI davon unabhängig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhBG4xBs5hrsyUi8tGYPvc