### PR TITLE
fix: sdd03 immediate fixes — NPE guard in APK send path, no private key on stdout

### DIFF
--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -626,6 +626,10 @@ public class InboundCommandProcessor {
               System.out.println("we send the android.apk update to a peer!");
               byte[] data = Files.readAllBytes(path);
               NodeId publicUpdaterKey = Updater.getPublicUpdaterKey();
+              if (publicUpdaterKey == null) {
+                System.out.println("No public updater key available, cannot verify update.");
+                return;
+              }
               ByteBuffer bytesToHash = ByteBuffer.allocate(8 + data.length);
               bytesToHash.putLong(serverContext.getLocalSettings().getUpdateAndroidTimestamp());
               bytesToHash.put(data);

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -623,13 +623,12 @@ public class InboundCommandProcessor {
             }
             Path path = Path.of(ConnectionReaderThread.ANDROID_UPDATE_FILE);
             try {
-              System.out.println("we send the android.apk update to a peer!");
-              byte[] data = Files.readAllBytes(path);
               NodeId publicUpdaterKey = Updater.getPublicUpdaterKey();
               if (publicUpdaterKey == null) {
                 System.out.println("No public updater key available, cannot verify update.");
                 return;
               }
+              byte[] data = Files.readAllBytes(path);
               ByteBuffer bytesToHash = ByteBuffer.allocate(8 + data.length);
               bytesToHash.putLong(serverContext.getLocalSettings().getUpdateAndroidTimestamp());
               bytesToHash.put(data);
@@ -643,6 +642,7 @@ public class InboundCommandProcessor {
                         + serverContext.getLocalSettings().getUpdateAndroidTimestamp());
                 return;
               }
+              System.out.println("we send the android.apk update to a peer!");
               byte[] androidSignature =
                   serverContext.getLocalSettings().getUpdateAndroidSignature();
               ByteBuffer a = ByteBuffer.allocate(1 + 8 + 4 + androidSignature.length + data.length);

--- a/src/main/java/im/redpanda/core/Updater.java
+++ b/src/main/java/im/redpanda/core/Updater.java
@@ -10,6 +10,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.security.Security;
 
 public class Updater {
@@ -77,7 +78,20 @@ public class Updater {
     NodeId nodeId = new NodeId();
 
     System.out.println("Pub: " + Base58.encode(nodeId.exportPublic()));
-    System.out.println("Priv: " + Base58.encode(nodeId.exportWithPrivate()) + "\n\n\n\n");
+    // The private key must never be written to stdout (it may end up in logs);
+    // write it to the file insertNewUpdate() reads, owner-readable only.
+    Path keyFile = Path.of("privateSigningKey.txt");
+    try {
+      Files.writeString(keyFile, Base58.encode(nodeId.exportWithPrivate()));
+      try {
+        Files.setPosixFilePermissions(keyFile, PosixFilePermissions.fromString("rw-------"));
+      } catch (UnsupportedOperationException ignored) {
+        // non-POSIX filesystem (e.g. Windows); file is still not printed anywhere
+      }
+      System.out.println("Priv: written to " + keyFile.toAbsolutePath());
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
   }
 
   public static void insertNewUpdate() throws IOException, AddressFormatException {

--- a/src/main/java/im/redpanda/core/Updater.java
+++ b/src/main/java/im/redpanda/core/Updater.java
@@ -7,6 +7,7 @@ import im.redpanda.crypt.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -82,6 +83,15 @@ public class Updater {
     // write it to the file insertNewUpdate() reads, owner-readable only.
     Path keyFile = Path.of("privateSigningKey.txt");
     try {
+      try {
+        // Create with 0600 upfront so the key is never world-readable, not even
+        // between creation and the setPosixFilePermissions below.
+        Files.createFile(
+            keyFile,
+            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+      } catch (FileAlreadyExistsException | UnsupportedOperationException ignored) {
+        // pre-existing file or non-POSIX filesystem; permissions re-applied below
+      }
       Files.writeString(keyFile, Base58.encode(nodeId.exportWithPrivate()));
       try {
         Files.setPosixFilePermissions(keyFile, PosixFilePermissions.fromString("rw-------"));


### PR DESCRIPTION
## Summary
Immediate fixes from `plans/sdd03_updater_decision.md` (findings S3-adjacent NPE + S10), independent of the pending A/B decision on the updater subsystem:

- **NPE guard** in `handleAndroidUpdateRequestContent`: `Updater.getPublicUpdaterKey()` returns `null` (MS03 placeholder key), so the APK send path crashed with an NPE in the pool thread whenever a peer requested the update while `android.apk` + signature were present locally. Now guarded like the existing receive paths (`InboundCommandProcessor.java:497,714`).
- **No private key on stdout**: `Updater.createNewKeys()` printed the freshly generated private signing key to stdout (log leakage risk). It now writes it to `privateSigningKey.txt` — the file `insertNewUpdate()` already reads — with owner-only permissions; only the public key is printed.

## Test plan
- `mvn -q verify` green locally (full unit test suite).
- Existing `InboundCommandProcessorAsyncUpdatesTest.androidUpdateRequestContent_doesNotSend_whenSignatureInvalid` exercises the guarded path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EZEvJLQroVfjS87Mu4aKh