### PR TITLE
docs: MS08-Done-Mirror-Sync (docs #31)

### DIFF
--- a/milestones/00_status_overview.md
+++ b/milestones/00_status_overview.md
@@ -1,6 +1,6 @@
 # Backend Milestones — Status Overview
 
-> Last updated: 2026-07-08
+> Last updated: 2026-07-09
 
 Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den fertigen Backend-APIs auf.
 
@@ -25,7 +25,7 @@ Backend-Milestones werden **immer zuerst** umgesetzt. Das Frontend setzt auf den
 | [MS05](ms05_reverse_garlic.md) | Reverse Garlic (Relay-Seite) | Done | Frontend MS05 kann starten (`CMD_DELIVER_TAGGED` (0x03), `MailItem.session_tag`, RGB-Modell = Hop-Deskriptoren laut Master-Spec Decision 6) |
 | [MS06](ms06_two_layer_ack.md) | R-ACK Generation | Done | Frontend MS06 kann starten (`CMD_DELIVER_ACKED` (0x04), `ReturnPath`-Block, `RoutingAck`-Payload — redpandaj [#229](https://github.com/redPanda-project/redpandaj/pull/229), 2026-07-03) |
 | [MS07](ms07_push_notifications.md) | Push Sender (FCM/APNs) | Missing | Frontend MS07 blocked — Push-Infrastruktur muss serverseitig stehen |
-| [MS08](ms08_group_chat.md) | (keine Backend-Änderungen) | N/A | Frontend MS08 kann nach MS05 starten |
+| [MS08](ms08_group_chat.md) | (keine Backend-Änderungen) | N/A | Frontend MS08 Done (2026-07-09, mobile [#40](https://github.com/redPanda-project/redpanda-mobile/pull/40)) — wie vorhergesagt ohne Backend-Änderungen umgesetzt |
 | [MS09](ms09_incentive_system.md) | Reputation & Anti-Sybil | Missing | Frontend MS09 blocked — ReputationService muss verfügbar sein |
 
 ## Component Readiness

--- a/milestones/ms08_group_chat.md
+++ b/milestones/ms08_group_chat.md
@@ -7,6 +7,9 @@
 > Bestätigt durch den sdd05-Fan-out-Spike (2026-07-08): Modell 3 („Multi-OH-Fan-out-Node“,
 > der einzige Backend-relevante Kandidat) wurde wegen Metadaten-Konzentration abgelehnt —
 > siehe [Decisions in der Master-Spec](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms08_group_chat.md#decisions-fan-out-spike-sdd05-2026-07-08).
+>
+> **Frontend MS08 ist Done** (2026-07-09, mobile [#40](https://github.com/redPanda-project/redpanda-mobile/pull/40)) —
+> wie vorhergesagt ohne jede Backend-Änderung umgesetzt (kein neues Release nötig).
 
 ## Goal
 
@@ -22,6 +25,7 @@ Kein Backend-Anteil. Der OH-Service ist group-agnostic — er speichert und lief
 ## Abhängigkeiten
 
 Das Frontend MS08 braucht:
-- Frontend MS05 (Reverse Garlic) — RGB für Reply-Paths in der Gruppe
+- Frontend MS06 (ACK Handling) — R-ACK je Fan-out-Zustellung (RGBs/Session-Tags
+  werden in Gruppen **nicht** verwendet, Master-Spec Decision 7)
 - Backend MS04 (Multi-Hop Relay) — Garlic-Routing für Fan-Out
 - Backend MS02 (Reliable Mailbox) — zuverlässige Zustellung an jedes Mitglieds-OH


### PR DESCRIPTION
Mirror-Sync aus dem docs-Repo (redPanda-project/docs#31) via `scripts/sync_milestones.sh`: Backend-View MS08 (Frontend Done per mobile redPanda-project/redpanda-mobile#40, Backend bleibt N/A) und Status-Overview (Matrix, Component Readiness inkl. MS06-Nachzug). Keine Code-Änderungen — reine Doku-Spiegel. `sync_milestones.sh --check` ist clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EZEvJLQroVfjS87Mu4aKh