### PR TITLE
sdd02 Phase 1: v22-Light-Client-Handshake abschalten

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionReaderThread.java
+++ b/src/main/java/im/redpanda/core/ConnectionReaderThread.java
@@ -80,6 +80,9 @@ public class ConnectionReaderThread implements Runnable {
     Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> Log.putCritical(throwable));
   }
 
+  // S5738: the deprecated v22 gate must stay evaluated here until sdd02 Phase 2 removes the
+  // legacy path (PLAN-v22-removal)
+  @SuppressWarnings("java:S5738")
   public static boolean parseHandshake(
       ServerContext serverContext, PeerInHandshake peerInHandshake, ByteBuffer buffer) {
 

--- a/src/main/java/im/redpanda/core/ConnectionReaderThread.java
+++ b/src/main/java/im/redpanda/core/ConnectionReaderThread.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -37,6 +38,14 @@ public class ConnectionReaderThread implements Runnable {
   static final Semaphore updateUploadLock = new Semaphore(1);
 
   static final ReentrantLock updateDownloadLock = new ReentrantLock();
+
+  /**
+   * Counts v22 light-client handshakes rejected since the sdd02 phase-1 shutdown (would have been
+   * accepted while {@link Server#ACCEPT_LEGACY_V22_LIGHT_CLIENTS} was {@code true}). Process-local
+   * observability counter, intentionally not persisted; logged without any IP (privacy).
+   */
+  public static final AtomicLong REJECTED_LEGACY_V22_ATTEMPTS = new AtomicLong();
+
   private final ByteBuffer myReaderBuffer = ByteBuffer.allocate(1024 * 50);
   private final ServerContext serverContext;
   private final InboundCommandProcessor inboundProcessor;
@@ -92,16 +101,24 @@ public class ConnectionReaderThread implements Runnable {
     }
 
     /**
-     * MS03 dual-version support: v23 is the current protocol (Ed25519/X25519/AES-GCM). v22 is only
-     * accepted for light clients during the transition phase (deprecated legacy crypto) — v22 full
-     * nodes use incompatible identities (brainpool) and are rejected. Unknown (e.g. future)
-     * versions are rejected as well: we cannot speak a protocol we do not know.
+     * MS03 dual-version support: v23 is the current protocol (Ed25519/X25519/AES-GCM). v22 light
+     * clients were accepted during the transition phase (deprecated legacy crypto) until the sdd02
+     * phase-1 shutdown (MS03 Decision 10) — v22 full nodes use incompatible identities (brainpool)
+     * and were always rejected. Unknown (e.g. future) versions are rejected as well: we cannot
+     * speak a protocol we do not know.
      */
     boolean acceptedLegacy =
         Server.ACCEPT_LEGACY_V22_LIGHT_CLIENTS
             && version == Server.LEGACY_VERSION
             && peerInHandshake.isLightClient();
     if (version != Server.VERSION && !acceptedLegacy) {
+      if (version == Server.LEGACY_VERSION && peerInHandshake.isLightClient()) {
+        // would have been accepted before the shutdown — count for residual-usage observability
+        Log.put(
+            "rejected legacy v22 light client handshake, total rejected: %d"
+                .formatted(REJECTED_LEGACY_V22_ATTEMPTS.incrementAndGet()),
+            10);
+      }
       Log.put(
           "unsupported protocol version %s (lightClient=%s), disconnecting..."
               .formatted(version, peerInHandshake.isLightClient()),

--- a/src/main/java/im/redpanda/core/Server.java
+++ b/src/main/java/im/redpanda/core/Server.java
@@ -27,9 +27,11 @@ public class Server {
 
   /**
    * Transition switch: accept v22 light-client handshakes. Phase 1 shutdown 2026-07 (sdd02, MS03
-   * Decision 10); emergency re-enable = flip back to {@code true}. Removal of the whole legacy path
-   * is tracked in PLAN-v22-removal (Phase 2). Rejected v22 attempts are counted in {@link
-   * ConnectionReaderThread#REJECTED_LEGACY_V22_ATTEMPTS}.
+   * Decision 10); emergency re-enable = flip back to {@code true}. Rejected v22 attempts are
+   * counted in {@link ConnectionReaderThread#REJECTED_LEGACY_V22_ATTEMPTS}.
+   *
+   * @deprecated kept one release period as an emergency switch only; removed together with the
+   *     whole legacy path in sdd02 Phase 2 (PLAN-v22-removal).
    */
   @Deprecated(forRemoval = true)
   public static final boolean ACCEPT_LEGACY_V22_LIGHT_CLIENTS = false;

--- a/src/main/java/im/redpanda/core/Server.java
+++ b/src/main/java/im/redpanda/core/Server.java
@@ -15,9 +15,9 @@ import org.slf4j.LoggerFactory;
 public class Server {
 
   /**
-   * Protocol version. 23 = MS03 crypto (Ed25519/X25519/AES-256-GCM). 22 (legacy crypto) is still
-   * accepted for light clients during the transition phase, see {@link
-   * ConnectionReaderThread#parseHandshake}.
+   * Protocol version. 23 = MS03 crypto (Ed25519/X25519/AES-256-GCM). 22 (legacy crypto) was
+   * accepted for light clients during the transition phase until the sdd02 phase-1 shutdown, see
+   * {@link ConnectionReaderThread#parseHandshake} and {@link #ACCEPT_LEGACY_V22_LIGHT_CLIENTS}.
    */
   public static final int VERSION = 23;
 
@@ -26,12 +26,13 @@ public class Server {
   public static final int LEGACY_VERSION = 22;
 
   /**
-   * Transition switch: accept v22 light-client handshakes. Set to {@code false} (and remove the
-   * legacy path) once all light clients have migrated to MS03 crypto. The duration of the
-   * transition phase is an operational decision, see the MS03 milestone decisions.
+   * Transition switch: accept v22 light-client handshakes. Phase 1 shutdown 2026-07 (sdd02, MS03
+   * Decision 10); emergency re-enable = flip back to {@code true}. Removal of the whole legacy path
+   * is tracked in PLAN-v22-removal (Phase 2). Rejected v22 attempts are counted in {@link
+   * ConnectionReaderThread#REJECTED_LEGACY_V22_ATTEMPTS}.
    */
   @Deprecated(forRemoval = true)
-  public static final boolean ACCEPT_LEGACY_V22_LIGHT_CLIENTS = true;
+  public static final boolean ACCEPT_LEGACY_V22_LIGHT_CLIENTS = false;
 
   public static final String MAGIC = "k3gV";
   private static volatile boolean shuttingDown = false;

--- a/src/test/java/im/redpanda/core/ConnectionReaderThreadTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionReaderThreadTest.java
@@ -1,0 +1,60 @@
+package im.redpanda.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import org.junit.Test;
+
+public class ConnectionReaderThreadTest {
+
+  /**
+   * sdd02 phase 1: a v22 light-client handshake is rejected (channel closed) and counted in {@link
+   * ConnectionReaderThread#REJECTED_LEGACY_V22_ATTEMPTS} — in-process twin of the E2E reject test
+   * so the branch shows up in unit-test coverage.
+   */
+  @Test
+  public void v22LightClientHandshakeIsRejectedAndCounted() throws Exception {
+    try (SocketChannel channel = SocketChannel.open()) {
+      PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", channel);
+      long before = ConnectionReaderThread.REJECTED_LEGACY_V22_ATTEMPTS.get();
+
+      boolean accepted =
+          ConnectionReaderThread.parseHandshake(
+              new ServerContext(), peerInHandshake, handshake(22, (byte) 160));
+
+      assertFalse("v22 light client must be rejected after the shutdown", accepted);
+      assertFalse("channel must be closed on reject", channel.isOpen());
+      assertEquals(before + 1, ConnectionReaderThread.REJECTED_LEGACY_V22_ATTEMPTS.get());
+    }
+  }
+
+  /** Unknown protocol versions are rejected too, but do not count as legacy v22 attempts. */
+  @Test
+  public void unknownVersionRejectDoesNotCountAsLegacyAttempt() throws Exception {
+    try (SocketChannel channel = SocketChannel.open()) {
+      PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", channel);
+      long before = ConnectionReaderThread.REJECTED_LEGACY_V22_ATTEMPTS.get();
+
+      boolean accepted =
+          ConnectionReaderThread.parseHandshake(
+              new ServerContext(), peerInHandshake, handshake(21, (byte) 160));
+
+      assertFalse(accepted);
+      assertFalse(channel.isOpen());
+      assertEquals(before, ConnectionReaderThread.REJECTED_LEGACY_V22_ATTEMPTS.get());
+    }
+  }
+
+  private static ByteBuffer handshake(int version, byte clientType) {
+    ByteBuffer handshake = ByteBuffer.allocate(30);
+    handshake.put(Server.MAGIC.getBytes());
+    handshake.put((byte) version);
+    handshake.put(clientType); // > 128 as unsigned byte marks a light client
+    handshake.put(new byte[20]); // KademliaId
+    handshake.putInt(0); // port
+    handshake.flip();
+    return handshake;
+  }
+}

--- a/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
+++ b/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
@@ -97,6 +97,12 @@ public class HandshakeVersionsE2EIT {
     try (TestNodeProcess node = TestNodeProcess.start(nodeDir, port, "", 0)) {
       assertTrue("node failed to start", node.awaitReady(Duration.ofSeconds(30)));
 
+      // startup logs a benign FileNotFoundException for the not-yet-existing localSettings —
+      // only the output produced by the reject itself must be exception-free (stdout and stderr
+      // are append-only, so per-stream prefixes give an exact delta)
+      String stdoutBaseline = node.getStdout();
+      String stderrBaseline = node.getStderr();
+
       try (Socket socket = new Socket("127.0.0.1", port)) {
         socket.setSoTimeout(20_000);
         byte[] kademliaId = new byte[20];
@@ -127,14 +133,26 @@ public class HandshakeVersionsE2EIT {
             bytesBeforeClose <= 30);
       }
 
-      node.stop(Duration.ofSeconds(10));
-
-      String output = node.getCombinedOutput();
+      // the pipe reader may lag slightly behind the socket close — poll for the counter line
+      String rejectLog = "";
+      long deadline = System.currentTimeMillis() + 10_000;
+      while (System.currentTimeMillis() < deadline) {
+        rejectLog =
+            node.getStdout().substring(stdoutBaseline.length())
+                + node.getStderr().substring(stderrBaseline.length());
+        if (rejectLog.contains("rejected legacy v22 light client handshake, total rejected: 1")) {
+          break;
+        }
+        Thread.sleep(200);
+      }
       assertTrue(
-          "expected the rejected-v22 counter log line, got:\n" + output,
-          output.contains("rejected legacy v22 light client handshake, total rejected: 1"));
+          "expected the rejected-v22 counter log line, got:\n" + rejectLog,
+          rejectLog.contains("rejected legacy v22 light client handshake, total rejected: 1"));
       assertFalse(
-          "the reject must not cause a server exception:\n" + output, output.contains("Exception"));
+          "the reject must not cause a server exception:\n" + rejectLog,
+          rejectLog.contains("Exception"));
+
+      node.stop(Duration.ofSeconds(10));
     }
   }
 

--- a/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
+++ b/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
@@ -153,6 +153,7 @@ public class HandshakeVersionsE2EIT {
           rejectLog.contains("Exception"));
 
       node.stop(Duration.ofSeconds(10));
+      assertEquals("node exit code\n" + node.getCombinedOutput(), 0, node.exitCode());
     }
   }
 

--- a/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
+++ b/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
@@ -1,6 +1,7 @@
 package im.redpanda.e2e;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import im.redpanda.core.Command;
@@ -8,8 +9,6 @@ import im.redpanda.core.GcmFramedStreams;
 import im.redpanda.core.NodeId;
 import im.redpanda.core.PeerInHandshake;
 import im.redpanda.crypt.CryptoUtils;
-import im.redpanda.crypt.Sha256Hash;
-import im.redpanda.crypt.legacy.LegacyNodeId;
 import im.redpanda.testutil.TestNodeProcess;
 import java.io.EOFException;
 import java.io.IOException;
@@ -22,11 +21,6 @@ import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Arrays;
-import javax.crypto.Cipher;
-import javax.crypto.KeyAgreement;
-import javax.crypto.SecretKey;
-import javax.crypto.spec.IvParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 import org.bouncycastle.crypto.params.X25519PrivateKeyParameters;
 import org.bouncycastle.crypto.params.X25519PublicKeyParameters;
 import org.junit.Rule;
@@ -39,11 +33,10 @@ import org.junit.rules.TemporaryFolder;
  * <ul>
  *   <li>v23 light client: 64-byte key exchange, ephemeral X25519, HKDF, framed AES-256-GCM —
  *       ping/pong roundtrip works and a flipped bit in a frame kills the connection.
- *   <li>v22 legacy light client (pre-MS03 mobile app): 65-byte brainpool keys, AES-CTR — still
- *       accepted during the transition phase.
+ *   <li>v22 legacy light client (pre-MS03 mobile app): rejected since the sdd02 phase-1 shutdown
+ *       (MS03 Decision 10) — clean disconnect, no server exception, reject counter increments.
  * </ul>
  */
-@SuppressWarnings("deprecation")
 public class HandshakeVersionsE2EIT {
 
   private static final String MAGIC = "k3gV";
@@ -95,26 +88,44 @@ public class HandshakeVersionsE2EIT {
   }
 
   @Test
-  public void v22LegacyLightClientIsStillAcceptedDuringTransition() throws Exception {
+  public void v22LegacyLightClientIsRejectedAfterShutdown() throws Exception {
     Path nodeDir = temporaryFolder.newFolder("nodeV22").toPath();
     int port = nextFreePort();
 
     try (TestNodeProcess node = TestNodeProcess.start(nodeDir, port, "", 0)) {
       assertTrue("node failed to start", node.awaitReady(Duration.ofSeconds(30)));
 
-      try (V22LegacyClient client = V22LegacyClient.connect(port)) {
-        byte firstCommand = client.readEncryptedCommand();
-        assertEquals(Command.PING, firstCommand);
+      try (Socket socket = new Socket("127.0.0.1", port)) {
+        socket.setSoTimeout(20_000);
+        byte[] kademliaId = new byte[20];
+        RANDOM.nextBytes(kademliaId);
+        ByteBuffer handshake = ByteBuffer.allocate(30);
+        handshake.put(MAGIC.getBytes());
+        handshake.put((byte) 22);
+        handshake.put((byte) 160); // light client marker
+        handshake.put(kademliaId);
+        handshake.putInt(0);
+        socket.getOutputStream().write(handshake.array());
+        socket.getOutputStream().flush();
 
-        // initial ping completes the handshake, the second one is answered with a pong
-        client.sendEncrypted(new byte[] {Command.PING});
-        LightClientBase.pause();
-
-        client.sendEncrypted(new byte[] {Command.PING});
-        assertEquals(Command.PONG, client.readEncryptedCommand());
+        // the node must close the connection instead of answering with its own handshake
+        int read;
+        try {
+          read = socket.getInputStream().read();
+        } catch (IOException resetByPeer) {
+          read = -1; // a TCP reset is also a disconnect
+        }
+        assertEquals("node must disconnect a v22 light client", -1, read);
       }
 
       node.stop(Duration.ofSeconds(10));
+
+      String output = node.getCombinedOutput();
+      assertTrue(
+          "expected the rejected-v22 counter log line, got:\n" + output,
+          output.contains("rejected legacy v22 light client handshake, total rejected: 1"));
+      assertFalse(
+          "the reject must not cause a server exception:\n" + output, output.contains("Exception"));
     }
   }
 
@@ -301,86 +312,6 @@ public class HandshakeVersionsE2EIT {
       byte[] bytes = Arrays.copyOf(frame.array(), frame.position());
       bytes[bytes.length - 1] ^= 0x01; // flip one bit in the GCM tag
       out.write(bytes);
-      out.flush();
-    }
-  }
-
-  /** Protocol v22 (deprecated): brainpool ECDH + AES-CTR, exactly like the pre-MS03 mobile app. */
-  private static final class V22LegacyClient extends LightClientBase {
-    private Cipher encryptCipher;
-    private Cipher decryptCipher;
-
-    private V22LegacyClient(int port) throws IOException {
-      super(port);
-    }
-
-    static V22LegacyClient connect(int port) throws Exception {
-      V22LegacyClient client = new V22LegacyClient(port);
-      client.handshake();
-      return client;
-    }
-
-    private void handshake() throws Exception {
-      LegacyNodeId identity = LegacyNodeId.generate();
-      sendHandshake(22, identity.getKademliaId().getBytes());
-
-      out.write(new byte[] {Command.REQUEST_PUBLIC_KEY});
-      out.flush();
-      readPlaintextCommandAnswering(identity.exportPublic(), Command.SEND_PUBLIC_KEY);
-      byte[] nodePublicKey = readFully(LegacyNodeId.PUBLIC_KEYLEN);
-
-      pause();
-      byte[] randomFromUs = new byte[8];
-      RANDOM.nextBytes(randomFromUs);
-      ByteBuffer activate = ByteBuffer.allocate(1 + 8);
-      activate.put(Command.ACTIVATE_ENCRYPTION);
-      activate.put(randomFromUs);
-      out.write(activate.array());
-      out.flush();
-
-      readPlaintextCommandAnswering(identity.exportPublic(), Command.ACTIVATE_ENCRYPTION);
-      byte[] randomFromNode = readFully(8);
-
-      // static-static ECDH exactly like the legacy client
-      KeyAgreement keyAgreement = KeyAgreement.getInstance("ECDH", "BC");
-      keyAgreement.init(identity.getKeyPair().getPrivate());
-      keyAgreement.doPhase(LegacyNodeId.importPublic(nodePublicKey).getKeyPair().getPublic(), true);
-      byte[] sharedSecret = keyAgreement.generateSecret("AES").getEncoded();
-
-      SecretKey sendKey = legacyKey(sharedSecret, randomFromUs, randomFromNode);
-      SecretKey receiveKey = legacyKey(sharedSecret, randomFromNode, randomFromUs);
-      IvParameterSpec sendIv = legacyIv(randomFromUs, randomFromNode);
-      IvParameterSpec receiveIv = legacyIv(randomFromNode, randomFromUs);
-
-      encryptCipher = Cipher.getInstance("AES/CTR/NoPadding", "SunJCE");
-      encryptCipher.init(Cipher.ENCRYPT_MODE, sendKey, sendIv);
-      decryptCipher = Cipher.getInstance("AES/CTR/NoPadding", "SunJCE");
-      decryptCipher.init(Cipher.DECRYPT_MODE, receiveKey, receiveIv);
-    }
-
-    private static SecretKey legacyKey(
-        byte[] sharedSecret, byte[] firstRandom, byte[] secondRandom) {
-      ByteBuffer keyBytes = ByteBuffer.allocate(sharedSecret.length + 16);
-      keyBytes.put(sharedSecret);
-      keyBytes.put(firstRandom);
-      keyBytes.put(secondRandom);
-      return new SecretKeySpec(Sha256Hash.create(keyBytes.array()).getBytes(), "AES");
-    }
-
-    private static IvParameterSpec legacyIv(byte[] firstRandom, byte[] secondRandom) {
-      ByteBuffer iv = ByteBuffer.allocate(16);
-      iv.put(firstRandom);
-      iv.put(secondRandom);
-      return new IvParameterSpec(iv.array());
-    }
-
-    byte readEncryptedCommand() throws Exception {
-      byte[] encrypted = readFully(1);
-      return decryptCipher.update(encrypted)[0];
-    }
-
-    void sendEncrypted(byte[] plaintext) throws Exception {
-      out.write(encryptCipher.update(plaintext));
       out.flush();
     }
   }

--- a/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
+++ b/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
@@ -3,6 +3,7 @@ package im.redpanda.e2e;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import im.redpanda.core.Command;
 import im.redpanda.core.GcmFramedStreams;
@@ -16,6 +17,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.security.SecureRandom;
@@ -108,14 +110,21 @@ public class HandshakeVersionsE2EIT {
         socket.getOutputStream().write(handshake.array());
         socket.getOutputStream().flush();
 
-        // the node must close the connection instead of answering with its own handshake
-        int read;
+        // the node must close the connection; depending on timing it may have written its own
+        // 30-byte handshake before parsing (and rejecting) ours, but never anything beyond it
+        int bytesBeforeClose = 0;
         try {
-          read = socket.getInputStream().read();
+          while (socket.getInputStream().read() != -1) {
+            bytesBeforeClose++;
+          }
+        } catch (SocketTimeoutException timeout) {
+          fail("node did not disconnect the v22 light client");
         } catch (IOException resetByPeer) {
-          read = -1; // a TCP reset is also a disconnect
+          // a TCP reset is also a disconnect
         }
-        assertEquals("node must disconnect a v22 light client", -1, read);
+        assertTrue(
+            "node must not proceed past its own handshake, but sent " + bytesBeforeClose + " bytes",
+            bytesBeforeClose <= 30);
       }
 
       node.stop(Duration.ofSeconds(10));


### PR DESCRIPTION
## Zusammenfassung
- `ACCEPT_LEGACY_V22_LIGHT_CLIENTS = false` — v22-Light-Clients werden ab jetzt abgelehnt (User-Entscheidung 2026-07-09, MS03 Decision 10, docs#34).
- Neuer Zähler `ConnectionReaderThread.REJECTED_LEGACY_V22_ATTEMPTS` (AtomicLong, prozess-lokal): zählt abgelehnte v22-Light-Client-Handshakes und loggt den Stand — **ohne IP** (Privacy-Vorgabe sdd02).
- E2E-Test umgeschrieben: `v22LegacyLightClientIsRejectedAfterShutdown` — v22-Handshake ⇒ sauberer Disconnect, keine Server-Exception, Zähler-Logzeile vorhanden. v23-Tests unverändert.
- **Nichts gelöscht**: der Legacy-Pfad (`crypt/legacy`, `LegacyCtrCipherStreams`) bleibt als Notfall-Schalter erhalten; Entfernung ist sdd02 Phase 2 (`PLAN-v22-removal.md`). Sonar/CodeQL-Hinweise auf jetzt toten Legacy-Code bitte in diesem Licht lesen.

## Tests
- `mvn verify` 2× lokal grün (278 Tests, 0 Failures), inkl. neuem Reject-E2E gegen echten Node-Prozess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EZEvJLQroVfjS87Mu4aKh