### PR TITLE
Harden OutboundAuth replay cache (sdd02 phase 3)

### DIFF
--- a/src/main/java/im/redpanda/outbound/OutboundAuth.java
+++ b/src/main/java/im/redpanda/outbound/OutboundAuth.java
@@ -3,6 +3,8 @@ package im.redpanda.outbound;
 import im.redpanda.core.NodeId;
 import im.redpanda.crypt.Utils;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -19,13 +21,39 @@ public class OutboundAuth {
    */
   public static final byte SIGNING_VERSION_ED25519 = 0x02;
 
-  // Allow requests within ±5 minutes of server time
-  // Allow requests within ±5 minutes of server time
-  private static final long TIME_WINDOW_MS = 5L * 60L * 1000L;
+  /**
+   * Validity window for signed outbound commands (timestamps up to this far in the past OR future
+   * are accepted — clock-skew tolerance); also the replay-cache retention time. The cache is not
+   * persisted across restarts (accepted residual risk: replay of a command captured within the
+   * window during the seconds of a node restart — see sdd02 decision 3). Package-private for tests.
+   */
+  static final long TIME_WINDOW_MS = 5L * 60L * 1000L;
 
-  // Simple replay cache: (ohId + nonce) -> timestamp
-  // In a real prod environment, this should be LRU or expire based on timestamp
+  /** How often at most {@link #cleanupCache(long)} runs (time-based, not size-triggered). */
+  private static final long CLEANUP_INTERVAL_MS = 60_000L;
+
+  /**
+   * Maximum replay-cache entries per source (oh_id) within the retention window. When reached,
+   * further commands from that source are rejected — never evicted, so flooding one source can
+   * neither displace other sources' entries nor reopen the replay window for its own.
+   * Package-private for tests.
+   */
+  static final int MAX_ENTRIES_PER_SOURCE = 1_000;
+
+  /** Safety valve only (forces an early cleanup); not reached in normal operation. */
+  private static final int GLOBAL_SAFETY_LIMIT = 100_000;
+
+  // Replay cache: (ohIdHex + "_" + nonceHex) -> command timestamp
   private final ConcurrentHashMap<String, Long> replayCache = new ConcurrentHashMap<>();
+
+  /**
+   * Entries per source (key = ohIdHex); rebuilt from scratch on every cleanup. Counters may be off
+   * by a few under concurrent verifies — acceptable, the cap is a flood limit, not an exact quota.
+   */
+  private final ConcurrentHashMap<String, AtomicInteger> entriesPerSource =
+      new ConcurrentHashMap<>();
+
+  private final AtomicLong lastCleanupMs = new AtomicLong(0);
 
   public enum AuthResult {
     OK,
@@ -56,13 +84,9 @@ public class OutboundAuth {
     }
 
     // 2. Check Replay
-    String replayKey = Utils.bytesToHexString(ohId) + "_" + Utils.bytesToHexString(nonce);
+    String ohIdHex = Utils.bytesToHexString(ohId);
+    String replayKey = ohIdHex + "_" + Utils.bytesToHexString(nonce);
     if (replayCache.containsKey(replayKey)) {
-      // In a robust implementation, we'd check if the entry is old enough to be
-      // forgotten,
-      // but for now, if it's in the map, it's a replay (assuming map is cleaned up or
-      // small enough
-      // for PoC)
       logger.warn("OutboundAuth: Replay detected for key {}", replayKey);
       return AuthResult.REPLAY;
     }
@@ -74,21 +98,45 @@ public class OutboundAuth {
       return AuthResult.INVALID_SIGNATURE;
     }
 
-    // Auth successful -> store nonce to prevent replay
-    replayCache.put(replayKey, timestampMs);
-
-    // Cleanup cache occasionally (simple strategy: remove entries older than
-    // window)
-    // NOTE: This is a lazy cleanup for PoC.
-    if (replayCache.size() > 10000) {
+    // Time-based cleanup, at most once per interval; the CAS keeps concurrent verifies from
+    // cleaning up in parallel. Runs before the cap check so a capped source recovers as soon as
+    // its entries have expired.
+    long last = lastCleanupMs.get();
+    if ((now - last > CLEANUP_INTERVAL_MS || replayCache.size() > GLOBAL_SAFETY_LIMIT)
+        && lastCleanupMs.compareAndSet(last, now)) {
       cleanupCache(now);
     }
+
+    // Per-source cap: reject, never evict (evicting would reopen the replay window — an attacker
+    // could flood until an earlier command of his is displaced and then replay it). With no free
+    // slot the nonce cannot be recorded, so freshness cannot be guaranteed -> REPLAY.
+    AtomicInteger sourceCount = entriesPerSource.computeIfAbsent(ohIdHex, k -> new AtomicInteger());
+    if (sourceCount.get() >= MAX_ENTRIES_PER_SOURCE) {
+      logger.warn("OutboundAuth: per-source replay-cache cap reached for {}, rejecting", ohIdHex);
+      return AuthResult.REPLAY;
+    }
+    sourceCount.incrementAndGet();
+
+    // Auth successful -> store nonce to prevent replay
+    replayCache.put(replayKey, timestampMs);
 
     return AuthResult.OK;
   }
 
-  private void cleanupCache(long now) {
+  /**
+   * Removes entries older than {@link #TIME_WINDOW_MS} (relative to {@code now}) and rebuilds the
+   * per-source counters from the remaining entries. Triggered from {@link #verify} at most once per
+   * {@link #CLEANUP_INTERVAL_MS} (or early via {@link #GLOBAL_SAFETY_LIMIT}). The rebuild is O(n)
+   * once per interval — deliberately simpler than incremental bookkeeping, and empty sources
+   * disappear automatically. Package-private for tests.
+   */
+  void cleanupCache(long now) {
     replayCache.entrySet().removeIf(entry -> Math.abs(now - entry.getValue()) > TIME_WINDOW_MS);
+    entriesPerSource.clear();
+    for (String key : replayCache.keySet()) {
+      String source = key.substring(0, key.indexOf('_'));
+      entriesPerSource.computeIfAbsent(source, k -> new AtomicInteger()).incrementAndGet();
+    }
   }
 
   /**

--- a/src/main/java/im/redpanda/outbound/OutboundAuth.java
+++ b/src/main/java/im/redpanda/outbound/OutboundAuth.java
@@ -83,7 +83,8 @@ public class OutboundAuth {
       return AuthResult.INVALID_TIMESTAMP;
     }
 
-    // 2. Check Replay
+    // 2. Check Replay — fast path only; the authoritative, race-free check is the putIfAbsent
+    // below (two threads passing containsKey concurrently must not both get accepted)
     String ohIdHex = Utils.bytesToHexString(ohId);
     String replayKey = ohIdHex + "_" + Utils.bytesToHexString(nonce);
     if (replayCache.containsKey(replayKey)) {
@@ -117,17 +118,23 @@ public class OutboundAuth {
     }
     sourceCount.incrementAndGet();
 
-    // Auth successful -> store nonce to prevent replay
-    replayCache.put(replayKey, timestampMs);
+    // Auth successful -> record the nonce atomically; putIfAbsent guarantees at most one caller
+    // ever gets OK for a given (ohId, nonce), even if both raced past the containsKey above
+    if (replayCache.putIfAbsent(replayKey, timestampMs) != null) {
+      sourceCount.decrementAndGet();
+      logger.warn("OutboundAuth: Replay detected for key {}", replayKey);
+      return AuthResult.REPLAY;
+    }
 
     return AuthResult.OK;
   }
 
   /**
-   * Removes entries older than {@link #TIME_WINDOW_MS} (relative to {@code now}) and rebuilds the
-   * per-source counters from the remaining entries. Triggered from {@link #verify} at most once per
-   * {@link #CLEANUP_INTERVAL_MS} (or early via {@link #GLOBAL_SAFETY_LIMIT}). The rebuild is O(n)
-   * once per interval — deliberately simpler than incremental bookkeeping, and empty sources
+   * Removes entries whose timestamp lies outside the ±{@link #TIME_WINDOW_MS} window around {@code
+   * now} — past or future, matching the clock-skew semantics of the timestamp check — and rebuilds
+   * the per-source counters from the remaining entries. Triggered from {@link #verify} at most once
+   * per {@link #CLEANUP_INTERVAL_MS} (or early via {@link #GLOBAL_SAFETY_LIMIT}). The rebuild is
+   * O(n) once per interval — deliberately simpler than incremental bookkeeping, and empty sources
    * disappear automatically. Package-private for tests.
    */
   void cleanupCache(long now) {

--- a/src/test/java/im/redpanda/outbound/OutboundAuthTest.java
+++ b/src/test/java/im/redpanda/outbound/OutboundAuthTest.java
@@ -24,10 +24,14 @@ public class OutboundAuthTest {
    * (Ed25519) client signs and what {@link OutboundAuth} verifies for 32-byte keys.
    */
   private byte[] signV2(byte[] payload) {
+    return signV2(clientNode, payload);
+  }
+
+  private static byte[] signV2(NodeId node, byte[] payload) {
     byte[] versioned = new byte[payload.length + 1];
     versioned[0] = OutboundAuth.SIGNING_VERSION_ED25519;
     System.arraycopy(payload, 0, versioned, 1, payload.length);
-    return clientNode.sign(versioned);
+    return node.sign(versioned);
   }
 
   @Test
@@ -136,7 +140,7 @@ public class OutboundAuthTest {
   }
 
   @Test
-  public void testVerify_Replay() {
+  public void replay_sameCommandTwiceWithinWindow_secondRejected() {
     long timestamp = System.currentTimeMillis();
     byte[] payload = "testPayload".getBytes();
     byte[] nonce = "nonceReplay".getBytes();
@@ -152,5 +156,136 @@ public class OutboundAuthTest {
     OutboundAuth.AuthResult result2 =
         auth.verify(clientNode.getVerifyKeyBytes(), payload, signature, timestamp, ohId, nonce);
     assertEquals(OutboundAuth.AuthResult.REPLAY, result2);
+  }
+
+  /**
+   * sdd02 Phase 3: flooding from one source hits the per-source cap (further commands rejected,
+   * never evicted) and does not displace other sources' replay-cache entries. The signature covers
+   * only the payload here, so one signature per source is reused across unique nonces — nonce
+   * uniqueness is what the cache tracks.
+   */
+  @Test
+  public void floodFromOneSource_doesNotEvictOtherSources_andCapsSource() {
+    long timestamp = System.currentTimeMillis();
+    byte[] payload = "testPayload".getBytes();
+
+    // Source B first: one accepted command that must survive the flood
+    byte[] ohIdB = clientNode.getKademliaId().getBytes();
+    byte[] nonceB = "nonceB".getBytes();
+    byte[] signatureB = signV2(payload);
+    assertEquals(
+        OutboundAuth.AuthResult.OK,
+        auth.verify(clientNode.getVerifyKeyBytes(), payload, signatureB, timestamp, ohIdB, nonceB));
+
+    // Source A floods up to the cap — every command accepted
+    NodeId attacker = NodeId.generateWithSimpleKey();
+    byte[] ohIdA = attacker.getKademliaId().getBytes();
+    byte[] signatureA = signV2(attacker, payload);
+    for (int i = 0; i < OutboundAuth.MAX_ENTRIES_PER_SOURCE; i++) {
+      assertEquals(
+          "flood command " + i + " must be accepted",
+          OutboundAuth.AuthResult.OK,
+          auth.verify(
+              attacker.getVerifyKeyBytes(),
+              payload,
+              signatureA,
+              timestamp,
+              ohIdA,
+              ("floodNonce" + i).getBytes()));
+    }
+
+    // Command MAX+1 from A -> rejected by the cap
+    assertEquals(
+        OutboundAuth.AuthResult.REPLAY,
+        auth.verify(
+            attacker.getVerifyKeyBytes(),
+            payload,
+            signatureA,
+            timestamp,
+            ohIdA,
+            "floodNonceOverCap".getBytes()));
+
+    // Source B was not evicted: replaying its command is still detected
+    assertEquals(
+        OutboundAuth.AuthResult.REPLAY,
+        auth.verify(clientNode.getVerifyKeyBytes(), payload, signatureB, timestamp, ohIdB, nonceB));
+  }
+
+  /**
+   * sdd02 Phase 3: {@link OutboundAuth#cleanupCache(long)} removes only expired entries and
+   * rebuilds the per-source counters, so a previously capped source can send again once its entries
+   * have expired.
+   */
+  @Test
+  public void cleanup_removesOnlyExpiredEntries_andRebuildsSourceCounts() {
+    long now = System.currentTimeMillis();
+    // Still inside the ±window when inserted (60 s margin so slow CI runs stay valid), but
+    // expired after the cleanup below
+    long agingTimestamp = now - OutboundAuth.TIME_WINDOW_MS + 60_000;
+    byte[] payload = "testPayload".getBytes();
+
+    // Cap source A with aging entries
+    NodeId sourceA = NodeId.generateWithSimpleKey();
+    byte[] ohIdA = sourceA.getKademliaId().getBytes();
+    byte[] signatureA = signV2(sourceA, payload);
+    for (int i = 0; i < OutboundAuth.MAX_ENTRIES_PER_SOURCE; i++) {
+      assertEquals(
+          OutboundAuth.AuthResult.OK,
+          auth.verify(
+              sourceA.getVerifyKeyBytes(),
+              payload,
+              signatureA,
+              agingTimestamp,
+              ohIdA,
+              ("agingNonce" + i).getBytes()));
+    }
+    assertEquals(
+        "source A must be capped before cleanup",
+        OutboundAuth.AuthResult.REPLAY,
+        auth.verify(
+            sourceA.getVerifyKeyBytes(),
+            payload,
+            signatureA,
+            agingTimestamp,
+            ohIdA,
+            "cappedNonce".getBytes()));
+
+    // One fresh entry from source B that must survive the cleanup
+    byte[] ohIdB = clientNode.getKademliaId().getBytes();
+    byte[] nonceB = "freshNonceB".getBytes();
+    byte[] signatureB = signV2(payload);
+    assertEquals(
+        OutboundAuth.AuthResult.OK,
+        auth.verify(clientNode.getVerifyKeyBytes(), payload, signatureB, now, ohIdB, nonceB));
+
+    // 130 s later the aging entries are outside the window, the fresh one is not
+    auth.cleanupCache(now + 130_000);
+
+    // Expired entries are gone: the same aging command is accepted again ...
+    assertEquals(
+        OutboundAuth.AuthResult.OK,
+        auth.verify(
+            sourceA.getVerifyKeyBytes(),
+            payload,
+            signatureA,
+            agingTimestamp,
+            ohIdA,
+            "agingNonce0".getBytes()));
+
+    // ... the fresh entry survived: replaying it is still detected ...
+    assertEquals(
+        OutboundAuth.AuthResult.REPLAY,
+        auth.verify(clientNode.getVerifyKeyBytes(), payload, signatureB, now, ohIdB, nonceB));
+
+    // ... and the rebuilt counters let the previously capped source send new commands
+    assertEquals(
+        OutboundAuth.AuthResult.OK,
+        auth.verify(
+            sourceA.getVerifyKeyBytes(),
+            payload,
+            signatureA,
+            System.currentTimeMillis(),
+            ohIdA,
+            "newNonceAfterCleanup".getBytes()));
   }
 }


### PR DESCRIPTION
## Summary

sdd02 Phase 3 (T9, plan: `plans/PLAN-replay-hardening.md`, security-review finding S5): replaces the "lazy cleanup for PoC" in the outbound replay cache with production-quality behavior.

- **Time-based cleanup** instead of size-triggered: runs at most once per 60 s (CAS-guarded so concurrent verifies never clean up in parallel), plus a 100k global safety valve.
- **Per-source cap** (1000 entries per oh_id within the window): further commands from a capped source are **rejected, never evicted** — evicting would let an attacker flood until an earlier command of his is displaced and then replay it. Rejection reuses `AuthResult.REPLAY` (no wire/proto change; with no free slot the nonce cannot be recorded, so freshness cannot be guaranteed).
- **Documented window**: `TIME_WINDOW_MS` Javadoc now states the ±5 min clock-skew semantics, the retention time, and the sdd02 decision 3 outcome — the cache is deliberately **not persisted** across restarts (accepted residual risk: replay of a command captured within the window during the seconds of a node restart).
- Per-source counters are rebuilt from scratch on every cleanup (O(n) once per minute, KISS) — empty sources disappear automatically, no drift.
- Legacy/ECDSA verify path untouched (belongs to the v22-removal plan).

## Tests

- `replay_sameCommandTwiceWithinWindow_secondRejected` (renamed from `testVerify_Replay`)
- `floodFromOneSource_doesNotEvictOtherSources_andCapsSource` — 1000 accepted, 1001st rejected, other source's entry still replay-detected
- `cleanup_removesOnlyExpiredEntries_andRebuildsSourceCounts` — expired gone, fresh kept, capped source can send again after expiry
- `mvn verify` locally green 2×

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EZEvJLQroVfjS87Mu4aKh