### PR TITLE
Make bootstrap node list configurable without rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ chmod +x build.sh
 ## Data & configuration
 
 - Local state is stored in `./data/` (e.g., `data/localSettings<port>.dat`).
-- Default port: **59558** (`Settings.DEFAULT_PORT`)
-- Seed/known nodes are currently hardcoded in `Settings.knownNodes` (this will evolve as discovery hardening improves).
+- Default port: **59558** (`Settings.DEFAULT_PORT`); override with the `PORT` environment variable.
+- Bootstrap/known nodes default to the list in `Settings.knownNodes` and can be overridden without a rebuild via the system property `redpanda.knownNodes` or the environment variable `REDPANDA_KNOWN_NODES` (comma-separated `host:port` entries; blank values keep the defaults), e.g. `REDPANDA_KNOWN_NODES="5.75.137.166:59558,46.224.156.238:59558" java -jar redpanda.jar`.
 
 ---
 

--- a/src/main/java/im/redpanda/core/ListenConsole.java
+++ b/src/main/java/im/redpanda/core/ListenConsole.java
@@ -43,6 +43,12 @@ public class ListenConsole extends Thread {
 
       String readLine = bufferedReader.readLine();
 
+      if (readLine == null) {
+        // stdin is closed (e.g. running headless under systemd) — no console available.
+        System.out.println("stdin closed, disabling interactive console");
+        return;
+      }
+
       if (peerList.size() == 0) {
         System.out.println("no peers..., set log level to 400");
         Log.LEVEL = 400;

--- a/src/main/java/im/redpanda/core/Settings.java
+++ b/src/main/java/im/redpanda/core/Settings.java
@@ -62,8 +62,37 @@ public class Settings {
         Arrays.stream(configured.split(","))
             .map(String::trim)
             .filter(s -> !s.isEmpty())
+            .filter(Settings::isValidKnownNode)
             .toArray(String[]::new);
     return entries.length == 0 ? DEFAULT_KNOWN_NODES.clone() : entries;
+  }
+
+  /** Accepts {@code host:port} or a bracketed IPv6 literal, matching what reseeding can parse. */
+  private static boolean isValidKnownNode(String entry) {
+    if (entry.startsWith("[")) {
+      if (entry.endsWith("]") && entry.length() > 2) {
+        return true;
+      }
+      return warnInvalidKnownNode(entry);
+    }
+    String[] split = entry.split(":");
+    if (split.length != 2 || split[0].isEmpty()) {
+      return warnInvalidKnownNode(entry);
+    }
+    try {
+      int port = Integer.parseInt(split[1]);
+      if (port < 1 || port > 65535) {
+        return warnInvalidKnownNode(entry);
+      }
+    } catch (NumberFormatException e) {
+      return warnInvalidKnownNode(entry);
+    }
+    return true;
+  }
+
+  private static boolean warnInvalidKnownNode(String entry) {
+    System.err.println("ignoring invalid known-node entry: '" + entry + "' (expected host:port)");
+    return false;
   }
 
   public static String[] blacklistIps = {};

--- a/src/main/java/im/redpanda/core/Settings.java
+++ b/src/main/java/im/redpanda/core/Settings.java
@@ -1,6 +1,7 @@
 package im.redpanda.core;
 
 import java.io.File;
+import java.util.Arrays;
 
 public class Settings {
 
@@ -39,9 +40,31 @@ public class Settings {
     }
   }
 
-  public static String[] knownNodes = {
+  private static final String[] DEFAULT_KNOWN_NODES = {
     "195.201.25.223:59558", "redpanda.im:59559", "127.0.0.1:59558"
   };
+
+  /**
+   * Bootstrap peers as {@code host:port}. Overridable without rebuilding via the system property
+   * {@code redpanda.knownNodes} (same key the E2E launcher uses) or the environment variable {@code
+   * REDPANDA_KNOWN_NODES}, both as a comma-separated list; the property wins over the environment,
+   * blank values fall back to the defaults.
+   */
+  public static String[] knownNodes =
+      parseKnownNodes(
+          System.getProperty("redpanda.knownNodes", System.getenv("REDPANDA_KNOWN_NODES")));
+
+  static String[] parseKnownNodes(String configured) {
+    if (configured == null) {
+      return DEFAULT_KNOWN_NODES.clone();
+    }
+    String[] entries =
+        Arrays.stream(configured.split(","))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .toArray(String[]::new);
+    return entries.length == 0 ? DEFAULT_KNOWN_NODES.clone() : entries;
+  }
 
   public static String[] blacklistIps = {};
 

--- a/src/test/java/im/redpanda/core/SettingsKnownNodesTest.java
+++ b/src/test/java/im/redpanda/core/SettingsKnownNodesTest.java
@@ -34,4 +34,22 @@ public class SettingsKnownNodesTest {
         new String[] {"node.example.org:59558"},
         Settings.parseKnownNodes("node.example.org:59558,, "));
   }
+
+  @Test
+  public void dropsInvalidEntriesButKeepsValidOnes() {
+    assertArrayEquals(
+        new String[] {"5.75.137.166:59558"},
+        Settings.parseKnownNodes(
+            "no-port,host:notaport,host:0,host:70000,:59558,a:b:c,5.75.137.166:59558"));
+  }
+
+  @Test
+  public void allInvalidFallsBackToDefaults() {
+    assertArrayEquals(DEFAULTS, Settings.parseKnownNodes("no-port,host:notaport"));
+  }
+
+  @Test
+  public void acceptsBracketedIpv6() {
+    assertArrayEquals(new String[] {"[2001:db8::1]"}, Settings.parseKnownNodes("[2001:db8::1]"));
+  }
 }

--- a/src/test/java/im/redpanda/core/SettingsKnownNodesTest.java
+++ b/src/test/java/im/redpanda/core/SettingsKnownNodesTest.java
@@ -1,0 +1,37 @@
+package im.redpanda.core;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+public class SettingsKnownNodesTest {
+
+  private static final String[] DEFAULTS = {
+    "195.201.25.223:59558", "redpanda.im:59559", "127.0.0.1:59558"
+  };
+
+  @Test
+  public void nullFallsBackToDefaults() {
+    assertArrayEquals(DEFAULTS, Settings.parseKnownNodes(null));
+  }
+
+  @Test
+  public void blankFallsBackToDefaults() {
+    assertArrayEquals(DEFAULTS, Settings.parseKnownNodes("   "));
+    assertArrayEquals(DEFAULTS, Settings.parseKnownNodes(",,"));
+  }
+
+  @Test
+  public void parsesCommaSeparatedListAndTrims() {
+    assertArrayEquals(
+        new String[] {"5.75.137.166:59558", "46.224.156.238:59558"},
+        Settings.parseKnownNodes(" 5.75.137.166:59558 , 46.224.156.238:59558 "));
+  }
+
+  @Test
+  public void dropsEmptyEntries() {
+    assertArrayEquals(
+        new String[] {"node.example.org:59558"},
+        Settings.parseKnownNodes("node.example.org:59558,, "));
+  }
+}


### PR DESCRIPTION
## What

`Settings.knownNodes` can now be overridden at deploy time via the system property `redpanda.knownNodes` (the key the E2E `TestNodeLauncher` already uses) or the environment variable `REDPANDA_KNOWN_NODES`, as a comma-separated `host:port` list. Property wins over env; blank/empty values keep the built-in defaults. Includes unit tests for the parsing and a README note.

## Why

First step of network bootstrapping (MS10a): the hardcoded seed `195.201.25.223` / `redpanda.im:59559` is no longer reachable, so the first real v23 nodes must be pointed at each other without rebuilding the jar.

## Notes

- Default list unchanged — released clients and the mobile E2E baked-in `127.0.0.1:59558` behavior are unaffected.
- `TestNodeLauncher` keeps its explicit override (it needs an *empty* list for isolated topologies, which the production fallback deliberately does not allow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EZEvJLQroVfjS87Mu4aKh