### PR TITLE
Activate interim testnet updater signing key

### DIFF
--- a/src/main/java/im/redpanda/core/Updater.java
+++ b/src/main/java/im/redpanda/core/Updater.java
@@ -20,8 +20,12 @@ public class Updater {
    * Base58 of the 64-byte MS03 public NodeId export ([32 Ed25519 verify key][32 X25519 key]) of the
    * core developers' update-signing identity. Regenerated for MS03 — pre-MS03 (brainpool) update
    * signatures are no longer accepted.
+   *
+   * <p>INTERIM TESTNET KEY (2026-07-11): generated for the first real v23 network; to be rotated by
+   * the human key ceremony (T13) once the updater hardening (T10) has landed.
    */
-  public static final String PUBLIC_SIGNING_KEY_OF_CORE_DEVELOPERS = "MS03_PLACEHOLDER_PUBLIC_KEY";
+  public static final String PUBLIC_SIGNING_KEY_OF_CORE_DEVELOPERS =
+      "pSX1GUpVfPuNUPvC5LZZQtRyt1f8xk9JvnYeWocXtVEgeXNwK3VPQe626HmA45af9zipa47W5gu26wnJT19FMaQ";
 
   static {
     Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());

--- a/src/test/java/im/redpanda/core/UpdaterKeyTest.java
+++ b/src/test/java/im/redpanda/core/UpdaterKeyTest.java
@@ -15,6 +15,6 @@ public class UpdaterKeyTest {
   public void publicUpdaterKeyIsImportable() {
     NodeId key = Updater.getPublicUpdaterKey();
     assertNotNull(key);
-    assertEquals(64, key.exportPublic().length);
+    assertEquals(NodeId.PUBLIC_KEYLEN, key.exportPublic().length);
   }
 }

--- a/src/test/java/im/redpanda/core/UpdaterKeyTest.java
+++ b/src/test/java/im/redpanda/core/UpdaterKeyTest.java
@@ -1,0 +1,20 @@
+package im.redpanda.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+public class UpdaterKeyTest {
+
+  /**
+   * The baked-in updater public key must be a valid 64-byte MS03 public NodeId export — a broken
+   * constant would silently disable update verification (getPublicUpdaterKey() returns null).
+   */
+  @Test
+  public void publicUpdaterKeyIsImportable() {
+    NodeId key = Updater.getPublicUpdaterKey();
+    assertNotNull(key);
+    assertEquals(64, key.exportPublic().length);
+  }
+}


### PR DESCRIPTION
## What

Replaces the `MS03_PLACEHOLDER_PUBLIC_KEY` with a real Ed25519/X25519 public NodeId export (Base58), generated 2026-07-11 for the first real v23 network. Adds `UpdaterKeyTest` asserting the baked-in constant is importable (a broken value would silently disable update verification via the `getPublicUpdaterKey() == null` guards).

## Key custody

- **INTERIM TESTNET KEY** — will be rotated by the human key ceremony (T13) after the updater hardening (T10) lands; the Javadoc on the constant says exactly that.
- Private key is held offline by the operator (0600, outside any repo). Generated with `Updater.createNewKeys()` (post-#237: key goes to file, never stdout).
- Authorized by Robin on 2026-07-11, explicitly overriding the T13 "never by agent" restriction for the testnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EZEvJLQroVfjS87Mu4aKh