### PR TITLE
Harden updater: rollback protection, skew guard, key caching, --create-keys

### DIFF
--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -43,6 +43,15 @@ public class InboundCommandProcessor {
   /** Ed25519 signatures are fixed-size (64 bytes, no DER framing). */
   public static final int SIGNATURE_LEN = NodeId.SIGNATURE_LEN;
 
+  /** Reject update timestamps further in the future than this (clock-skew / spoofing guard). */
+  private static final long MAX_FUTURE_SKEW_MS = 24L * 60 * 60 * 1000;
+
+  /**
+   * Invoked to apply an installed update. Default restarts the JVM; tests replace this with a
+   * counter so the positive-path test never actually exits the test JVM.
+   */
+  static Runnable restartAction = () -> System.exit(0);
+
   private final ServerContext serverContext;
 
   @FunctionalInterface
@@ -383,11 +392,17 @@ public class InboundCommandProcessor {
       return 0;
     }
     long othersTimestamp = readBuffer.getLong();
+    if (othersTimestamp > System.currentTimeMillis() + MAX_FUTURE_SKEW_MS) {
+      logger.warn("rejecting update timestamp too far in the future: {}", othersTimestamp);
+      return 1 + 8;
+    }
+    long floor =
+        Math.max(
+            serverContext.getLocalSettings().getUpdateTimestamp(), Updater.MIN_UPDATE_TIMESTAMP_MS);
     if (othersTimestamp < serverContext.getLocalSettings().getUpdateTimestamp()) {
       System.out.println("WARNING: peer has outdated redPandaj version! " + peer.getNodeId());
     }
-    if (othersTimestamp > serverContext.getLocalSettings().getUpdateTimestamp()
-        && Settings.isLoadUpdates()) {
+    if (othersTimestamp > floor && Settings.isLoadUpdates()) {
       Runnable runnable =
           () -> {
             ConnectionReaderThread.updateDownloadLock.lock();
@@ -490,13 +505,21 @@ public class InboundCommandProcessor {
     }
     byte[] data = new byte[toReadBytes];
     readBuffer.get(data);
-    if (othersTimestamp > serverContext.getLocalSettings().getUpdateTimestamp()) {
+    int consumedBytes = 1 + 8 + 4 + lenOfSignature + data.length;
+    if (othersTimestamp > System.currentTimeMillis() + MAX_FUTURE_SKEW_MS) {
+      logger.warn("rejecting update: timestamp too far in the future: {}", othersTimestamp);
+      return consumedBytes;
+    }
+    long floor =
+        Math.max(
+            serverContext.getLocalSettings().getUpdateTimestamp(), Updater.MIN_UPDATE_TIMESTAMP_MS);
+    if (othersTimestamp > floor) {
 
       // Verify signature before writing anything
       NodeId publicUpdaterKey = Updater.getPublicUpdaterKey();
       if (publicUpdaterKey == null) {
         System.out.println("No public updater key available, cannot verify update.");
-        return 1 + 8 + 4 + lenOfSignature + data.length;
+        return consumedBytes;
       }
 
       ByteBuffer toHash = ByteBuffer.allocate(8 + data.length);
@@ -505,14 +528,14 @@ public class InboundCommandProcessor {
 
       if (!publicUpdaterKey.verify(toHash.array(), signatureBytes)) {
         System.out.println("Update verification failed! Signature invalid.");
-        return 1 + 8 + 4 + lenOfSignature + data.length;
+        return consumedBytes;
       }
 
       try (FileOutputStream fos = new FileOutputStream("tmp_redpanda.jar")) {
         fos.write(data);
       } catch (IOException e) {
         Log.sentry(e);
-        return 1 + 8 + 4 + lenOfSignature + data.length;
+        return consumedBytes;
       }
 
       try {
@@ -540,7 +563,7 @@ public class InboundCommandProcessor {
                     Thread.sleep(2000);
                   } catch (InterruptedException e) {
                   }
-                  System.exit(0);
+                  restartAction.run();
                 });
 
       } catch (IOException e) {
@@ -548,7 +571,7 @@ public class InboundCommandProcessor {
         System.out.println("Failed to install update: " + e.getMessage());
       }
     }
-    return 1 + 8 + 4 + lenOfSignature + data.length;
+    return consumedBytes;
   }
 
   private int handleAndroidUpdateRequestTimestamp(Peer peer) {
@@ -569,6 +592,14 @@ public class InboundCommandProcessor {
       return 0;
     }
     long othersTimestamp = readBuffer.getLong();
+    if (othersTimestamp > System.currentTimeMillis() + MAX_FUTURE_SKEW_MS) {
+      logger.warn("rejecting android update timestamp too far in the future: {}", othersTimestamp);
+      return 1 + 8;
+    }
+    long floor =
+        Math.max(
+            serverContext.getLocalSettings().getUpdateAndroidTimestamp(),
+            Updater.MIN_UPDATE_TIMESTAMP_MS);
     Log.put(
         "Update found from: "
             + new Date(othersTimestamp)
@@ -578,7 +609,7 @@ public class InboundCommandProcessor {
     if (othersTimestamp < serverContext.getLocalSettings().getUpdateAndroidTimestamp()) {
       System.out.println("WARNING: peer has outdated android.apk version! " + peer.getNodeId());
     }
-    if (othersTimestamp > serverContext.getLocalSettings().getUpdateAndroidTimestamp()) {
+    if (othersTimestamp > floor) {
       Runnable runnable =
           () -> {
             ConnectionReaderThread.updateUploadLock.acquireUninterruptibly();
@@ -711,13 +742,22 @@ public class InboundCommandProcessor {
     }
     byte[] data = new byte[toReadBytes];
     readBuffer.get(data);
-    if (othersTimestamp > serverContext.getLocalSettings().getUpdateAndroidTimestamp()) {
+    int consumedBytes = 1 + 8 + 4 + signatureLen + data.length;
+    if (othersTimestamp > System.currentTimeMillis() + MAX_FUTURE_SKEW_MS) {
+      logger.warn("rejecting android update: timestamp too far in the future: {}", othersTimestamp);
+      return consumedBytes;
+    }
+    long floor =
+        Math.max(
+            serverContext.getLocalSettings().getUpdateAndroidTimestamp(),
+            Updater.MIN_UPDATE_TIMESTAMP_MS);
+    if (othersTimestamp > floor) {
 
       // Verify signature
       NodeId publicUpdaterKey = Updater.getPublicUpdaterKey();
       if (publicUpdaterKey == null) {
         System.out.println("No public updater key available, cannot verify android update.");
-        return 1 + 8 + 4 + signatureLen + data.length;
+        return consumedBytes;
       }
 
       ByteBuffer toHash = ByteBuffer.allocate(8 + data.length);
@@ -726,7 +766,7 @@ public class InboundCommandProcessor {
 
       if (!publicUpdaterKey.verify(toHash.array(), signature)) {
         System.out.println("Android update verification failed! Signature invalid.");
-        return 1 + 8 + 4 + signatureLen + data.length;
+        return consumedBytes;
       }
 
       try (FileOutputStream fos =
@@ -739,7 +779,7 @@ public class InboundCommandProcessor {
       serverContext.getLocalSettings().setUpdateAndroidSignature(signature);
       serverContext.getLocalSettings().save(serverContext.getPort());
     }
-    return 1 + 8 + 4 + signatureLen + data.length;
+    return consumedBytes;
   }
 
   private void handleJobAck(byte[] payload, Peer peer) throws InvalidProtocolBufferException {

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -500,6 +500,13 @@ public class InboundCommandProcessor {
     byte[] signatureBytes = new byte[SIGNATURE_LEN];
     readBuffer.get(signatureBytes);
     int lenOfSignature = signatureBytes.length;
+    if (toReadBytes < 0) {
+      // Network-controlled length: a negative value is a protocol violation and would
+      // throw NegativeArraySizeException below (reader thread DoS).
+      logger.warn("negative update content length from peer, disconnecting: {}", toReadBytes);
+      peer.disconnect("negative update content length");
+      return 0;
+    }
     if (toReadBytes > readBuffer.remaining()) {
       return 0;
     }
@@ -737,6 +744,14 @@ public class InboundCommandProcessor {
     byte[] signature = new byte[SIGNATURE_LEN];
     readBuffer.get(signature);
     int signatureLen = signature.length;
+    if (toReadBytes < 0) {
+      // Network-controlled length: a negative value is a protocol violation and would
+      // throw NegativeArraySizeException below (reader thread DoS).
+      logger.warn(
+          "negative android update content length from peer, disconnecting: {}", toReadBytes);
+      peer.disconnect("negative android update content length");
+      return 0;
+    }
     if (toReadBytes > readBuffer.remaining()) {
       return 0;
     }

--- a/src/main/java/im/redpanda/core/Updater.java
+++ b/src/main/java/im/redpanda/core/Updater.java
@@ -59,7 +59,9 @@ public class Updater {
             cachedPublicUpdaterKey =
                 NodeId.importPublic(Base58.decode(PUBLIC_SIGNING_KEY_OF_CORE_DEVELOPERS));
           } catch (AddressFormatException | IllegalArgumentException e) {
-            logger.warn("update channel fail-closed: no production updater key configured");
+            logger.warn(
+                "update channel fail-closed: no production updater key configured ({})",
+                e.toString());
             cachedPublicUpdaterKey = null;
           }
           decoded = true;
@@ -129,12 +131,20 @@ public class Updater {
 
   public static void createNewKeys() {
 
+    Path keyFile = Path.of("privateSigningKey.txt");
+    if (Files.exists(keyFile)) {
+      // Never overwrite an existing signing key (accidental key loss during the key
+      // ceremony); move the old file away first if a new key is really intended.
+      System.out.println(
+          "Refusing to create new keys: " + keyFile.toAbsolutePath() + " already exists.");
+      return;
+    }
+
     NodeId nodeId = new NodeId();
 
     System.out.println("Pub: " + Base58.encode(nodeId.exportPublic()));
     // The private key must never be written to stdout (it may end up in logs);
     // write it to the file insertNewUpdate() reads, owner-readable only.
-    Path keyFile = Path.of("privateSigningKey.txt");
     try {
       try {
         // Create with 0600 upfront so the key is never world-readable, not even

--- a/src/main/java/im/redpanda/core/Updater.java
+++ b/src/main/java/im/redpanda/core/Updater.java
@@ -13,8 +13,19 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.Security;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class Updater {
+
+  private static final Logger logger = LogManager.getLogger();
+
+  /**
+   * Build-time floor for accepted update timestamps (rollback protection). Raise this to the
+   * release-signing timestamp with every signed release (see updater key-ceremony runbook in the
+   * docs repo). Updates with timestamp &lt;= this value are rejected even on a fresh LocalSettings.
+   */
+  public static final long MIN_UPDATE_TIMESTAMP_MS = 1783728000000L; // 2026-07-11T00:00:00Z
 
   /**
    * Base58 of the 64-byte MS03 public NodeId export ([32 Ed25519 verify key][32 X25519 key]) of the
@@ -31,13 +42,47 @@ public class Updater {
     Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
   }
 
+  /**
+   * Lazily-decoded, cached updater public key. {@code null} both before the first lookup and after
+   * a failed decode (fail-closed) — {@link #decoded} distinguishes the two so the warning is only
+   * logged once.
+   */
+  private static volatile NodeId cachedPublicUpdaterKey;
+
+  private static volatile boolean decoded;
+
   public static NodeId getPublicUpdaterKey() {
-    try {
-      return NodeId.importPublic(Base58.decode(PUBLIC_SIGNING_KEY_OF_CORE_DEVELOPERS));
-    } catch (AddressFormatException | IllegalArgumentException e) {
-      e.printStackTrace();
+    if (!decoded) {
+      synchronized (Updater.class) {
+        if (!decoded) {
+          try {
+            cachedPublicUpdaterKey =
+                NodeId.importPublic(Base58.decode(PUBLIC_SIGNING_KEY_OF_CORE_DEVELOPERS));
+          } catch (AddressFormatException | IllegalArgumentException e) {
+            logger.warn("update channel fail-closed: no production updater key configured");
+            cachedPublicUpdaterKey = null;
+          }
+          decoded = true;
+        }
+      }
     }
-    return null;
+    return cachedPublicUpdaterKey;
+  }
+
+  /** Test-only override of the cached updater key; bypasses the normal decode path. */
+  static void setPublicUpdaterKeyForTests(NodeId key) {
+    synchronized (Updater.class) {
+      cachedPublicUpdaterKey = key;
+      decoded = true;
+    }
+  }
+
+  /** Test-only reset of the lazy-holder cache so the next call re-decodes normally. */
+  static void resetPublicUpdaterKeyForTests() {
+    synchronized (Updater.class) {
+      cachedPublicUpdaterKey = null;
+      decoded = false;
+    }
   }
 
   /**
@@ -46,7 +91,11 @@ public class Updater {
    * @param args
    */
   public static void main(String[] args) {
-    // createNewKeys();
+    if (args.length > 0 && "--create-keys".equals(args[0])) {
+      // CLI entry point for the offline key ceremony (T13) — never invoked from CI/build.
+      createNewKeys();
+      return;
+    }
 
     if (!Path.of("privateSigningKey.txt").toFile().exists()) {
       System.out.println("No private key for signing found, skipping insert update into network.");

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorUpdateHardeningTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorUpdateHardeningTest.java
@@ -44,6 +44,7 @@ public class InboundCommandProcessorUpdateHardeningTest {
     InboundCommandProcessor.restartAction = () -> System.exit(0);
     new File("tmp_redpanda.jar").delete();
     new File("update").delete();
+    new File(ConnectionReaderThread.ANDROID_UPDATE_FILE).delete();
     new File(Settings.SAVE_DIR + "/localSettings" + TEST_PORT + ".dat").delete();
   }
 
@@ -187,6 +188,119 @@ public class InboundCommandProcessorUpdateHardeningTest {
     // JVM (this test process) is still alive to observe it.
     awaitCondition(() -> restartCount.get() == 1, 5000);
     assertEquals(1, restartCount.get());
+  }
+
+  @Test
+  public void negativeContentLength_disconnectsPeer() {
+    ByteBuffer in = ByteBuffer.allocate(8 + 4 + NodeId.SIGNATURE_LEN);
+    in.putLong(Updater.MIN_UPDATE_TIMESTAMP_MS + 1_000_000L);
+    in.putInt(-1); // network-controlled length: protocol violation
+    in.put(fakeSignature());
+    in.flip();
+
+    Peer peer = newPeer(8806);
+    int consumed = proc.parseCommand(Command.UPDATE_ANSWER_CONTENT, in, peer);
+
+    assertEquals(0, consumed);
+    assertFalse("peer must be disconnected on negative content length", peer.isConnected());
+    assertFalse("tmp file must not be written", new File("tmp_redpanda.jar").exists());
+  }
+
+  @Test
+  public void androidNegativeContentLength_disconnectsPeer() {
+    ByteBuffer in = ByteBuffer.allocate(8 + 4 + NodeId.SIGNATURE_LEN);
+    in.putLong(Updater.MIN_UPDATE_TIMESTAMP_MS + 1_000_000L);
+    in.putInt(Integer.MIN_VALUE);
+    in.put(fakeSignature());
+    in.flip();
+
+    Peer peer = newPeer(8807);
+    int consumed = proc.parseCommand(Command.ANDROID_UPDATE_ANSWER_CONTENT, in, peer);
+
+    assertEquals(0, consumed);
+    assertFalse("peer must be disconnected on negative android content length", peer.isConnected());
+    assertFalse(
+        "apk file must not be written",
+        new File(ConnectionReaderThread.ANDROID_UPDATE_FILE).exists());
+  }
+
+  @Test
+  public void androidFutureSkew_rejected() {
+    long othersTs = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(25);
+    byte[] data = new byte[] {3, 3, 3};
+    byte[] sig = fakeSignature();
+
+    ByteBuffer in = buildUpdateAnswerContent(othersTs, sig, data);
+
+    int consumed = proc.parseCommand(Command.ANDROID_UPDATE_ANSWER_CONTENT, in, newPeer(8808));
+
+    assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
+    assertFalse(
+        "apk file must not be written",
+        new File(ConnectionReaderThread.ANDROID_UPDATE_FILE).exists());
+  }
+
+  @Test
+  public void androidDowngrade_rejected_belowBuildFloor_onFreshLocalSettings() {
+    byte[] data = new byte[] {4, 4, 4, 4};
+    byte[] sig = fakeSignature();
+    // Not above the compile-time floor -> rejected before any verification.
+    ByteBuffer in = buildUpdateAnswerContent(Updater.MIN_UPDATE_TIMESTAMP_MS, sig, data);
+
+    int consumed = proc.parseCommand(Command.ANDROID_UPDATE_ANSWER_CONTENT, in, newPeer(8809));
+
+    assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
+    assertFalse(
+        "apk file must not be written",
+        new File(ConnectionReaderThread.ANDROID_UPDATE_FILE).exists());
+    assertEquals(0L, ctx.getLocalSettings().getUpdateAndroidTimestamp());
+  }
+
+  @Test
+  public void updateAnswerTimestamp_futureSkew_rejected() {
+    Settings.loadUpdates = true;
+    ByteBuffer in = ByteBuffer.allocate(8);
+    in.putLong(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(25));
+    in.flip();
+
+    int consumed = proc.parseCommand(Command.UPDATE_ANSWER_TIMESTAMP, in, newPeer(8810));
+
+    assertEquals(1 + 8, consumed);
+  }
+
+  @Test
+  public void updateAnswerTimestamp_belowBuildFloor_noDownload() {
+    Settings.loadUpdates = true;
+    // Above the fresh local timestamp (-1) but not above the build floor -> no download.
+    ByteBuffer in = ByteBuffer.allocate(8);
+    in.putLong(Updater.MIN_UPDATE_TIMESTAMP_MS);
+    in.flip();
+
+    int consumed = proc.parseCommand(Command.UPDATE_ANSWER_TIMESTAMP, in, newPeer(8811));
+
+    assertEquals(1 + 8, consumed);
+  }
+
+  @Test
+  public void androidUpdateAnswerTimestamp_futureSkew_rejected() {
+    ByteBuffer in = ByteBuffer.allocate(8);
+    in.putLong(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(25));
+    in.flip();
+
+    int consumed = proc.parseCommand(Command.ANDROID_UPDATE_ANSWER_TIMESTAMP, in, newPeer(8812));
+
+    assertEquals(1 + 8, consumed);
+  }
+
+  @Test
+  public void androidUpdateAnswerTimestamp_belowBuildFloor_noDownload() {
+    ByteBuffer in = ByteBuffer.allocate(8);
+    in.putLong(Updater.MIN_UPDATE_TIMESTAMP_MS);
+    in.flip();
+
+    int consumed = proc.parseCommand(Command.ANDROID_UPDATE_ANSWER_TIMESTAMP, in, newPeer(8813));
+
+    assertEquals(1 + 8, consumed);
   }
 
   private static void awaitCondition(BooleanSupplier condition, long timeoutMillis) {

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorUpdateHardeningTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorUpdateHardeningTest.java
@@ -1,0 +1,202 @@
+package im.redpanda.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.BooleanSupplier;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Covers the T10 (updater option B) hardening added to the UPDATE_ANSWER_CONTENT handler: rollback
+ * protection via a build-time floor, a future-timestamp skew guard, and fail-closed behaviour when
+ * no updater key is configured. See PLAN-updater-option-b.md, PR 1.
+ */
+public class InboundCommandProcessorUpdateHardeningTest {
+
+  private static final int TEST_PORT = 49781;
+
+  private ServerContext ctx;
+  private InboundCommandProcessor proc;
+
+  @Before
+  public void setup() {
+    ctx = ServerContext.buildDefaultServerContext();
+    ctx.setPort(TEST_PORT);
+    proc = new InboundCommandProcessor(ctx);
+    ByteBufferPool.init();
+    Settings.seedNode = false;
+    Settings.loadUpdates = false;
+  }
+
+  @After
+  public void cleanup() {
+    Updater.resetPublicUpdaterKeyForTests();
+    InboundCommandProcessor.restartAction = () -> System.exit(0);
+    new File("tmp_redpanda.jar").delete();
+    new File("update").delete();
+    new File(Settings.SAVE_DIR + "/localSettings" + TEST_PORT + ".dat").delete();
+  }
+
+  /** A syntactically valid (fixed 64-byte Ed25519) but cryptographically fake signature. */
+  private static byte[] fakeSignature() {
+    byte[] sig = new byte[NodeId.SIGNATURE_LEN];
+    for (int i = 0; i < sig.length; i++) sig[i] = (byte) i;
+    return sig;
+  }
+
+  private static ByteBuffer buildUpdateAnswerContent(
+      long timestamp, byte[] signature, byte[] data) {
+    ByteBuffer in = ByteBuffer.allocate(8 + 4 + signature.length + data.length);
+    in.putLong(timestamp);
+    in.putInt(data.length);
+    in.put(signature);
+    in.put(data);
+    in.flip();
+    return in;
+  }
+
+  private Peer newPeer(int port) {
+    Peer peer = new Peer("127.0.0.1", port, ctx.getNodeId());
+    peer.setConnected(true);
+    ctx.getPeerList().add(peer);
+    return peer;
+  }
+
+  @Test
+  public void downgrade_rejected_whenTimestampNotAboveLocal() {
+    long localTs = Updater.MIN_UPDATE_TIMESTAMP_MS + 1_000_000L;
+    ctx.getLocalSettings().setUpdateTimestamp(localTs);
+
+    byte[] data = new byte[] {1, 2, 3};
+    byte[] sig = fakeSignature();
+    // othersTimestamp == localTs -> not strictly greater -> rejected as a downgrade/replay.
+    ByteBuffer in = buildUpdateAnswerContent(localTs, sig, data);
+
+    int consumed = proc.parseCommand(Command.UPDATE_ANSWER_CONTENT, in, newPeer(8801));
+
+    assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
+    assertFalse("tmp file must not be written", new File("tmp_redpanda.jar").exists());
+    assertFalse("update file must not be written", new File("update").exists());
+    assertEquals(localTs, ctx.getLocalSettings().getUpdateTimestamp());
+  }
+
+  @Test
+  public void downgrade_rejected_belowBuildFloor_onFreshLocalSettings() {
+    // Fresh LocalSettings: updateTimestamp == -1 (see LocalSettings() ctor).
+    assertEquals(-1L, ctx.getLocalSettings().getUpdateTimestamp());
+
+    NodeId testKey = new NodeId();
+    Updater.setPublicUpdaterKeyForTests(testKey);
+
+    byte[] data = new byte[] {5, 6, 7, 8};
+    // Validly signed, but not above the compile-time floor -> still rejected.
+    long othersTs = Updater.MIN_UPDATE_TIMESTAMP_MS;
+    ByteBuffer toHash = ByteBuffer.allocate(8 + data.length);
+    toHash.putLong(othersTs);
+    toHash.put(data);
+    byte[] sig = testKey.sign(toHash.array());
+
+    ByteBuffer in = buildUpdateAnswerContent(othersTs, sig, data);
+
+    int consumed = proc.parseCommand(Command.UPDATE_ANSWER_CONTENT, in, newPeer(8802));
+
+    assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
+    assertFalse("tmp file must not be written", new File("tmp_redpanda.jar").exists());
+    assertFalse("update file must not be written", new File("update").exists());
+    assertEquals(-1L, ctx.getLocalSettings().getUpdateTimestamp());
+  }
+
+  @Test
+  public void futureSkew_rejected() {
+    long othersTs = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(25);
+    byte[] data = new byte[] {1, 1, 1};
+    byte[] sig = fakeSignature();
+
+    ByteBuffer in = buildUpdateAnswerContent(othersTs, sig, data);
+
+    int consumed = proc.parseCommand(Command.UPDATE_ANSWER_CONTENT, in, newPeer(8803));
+
+    assertEquals(
+        "handler must report exactly the consumed byte length or the parser desyncs",
+        1 + 8 + 4 + sig.length + data.length,
+        consumed);
+    assertFalse("tmp file must not be written", new File("tmp_redpanda.jar").exists());
+    assertFalse("update file must not be written", new File("update").exists());
+  }
+
+  @Test
+  public void placeholderKey_failClosed_noFileWritten() {
+    // Force the fail-closed state via the test override instead of relying on the (now real,
+    // non-placeholder) PUBLIC_SIGNING_KEY_OF_CORE_DEVELOPERS constant.
+    Updater.setPublicUpdaterKeyForTests(null);
+
+    byte[] data = new byte[] {2, 4, 6, 8};
+    long othersTs = Updater.MIN_UPDATE_TIMESTAMP_MS + 1_000_000L;
+    byte[] sig = fakeSignature();
+
+    ByteBuffer in = buildUpdateAnswerContent(othersTs, sig, data);
+
+    int consumed = proc.parseCommand(Command.UPDATE_ANSWER_CONTENT, in, newPeer(8804));
+
+    assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
+    assertFalse("tmp file must not be written", new File("tmp_redpanda.jar").exists());
+    assertFalse("update file must not be written", new File("update").exists());
+    assertEquals(-1L, ctx.getLocalSettings().getUpdateTimestamp());
+  }
+
+  @Test
+  public void validUpdate_installs_andInvokesRestartAction() throws Exception {
+    NodeId testKey = new NodeId();
+    Updater.setPublicUpdaterKeyForTests(testKey);
+
+    AtomicInteger restartCount = new AtomicInteger();
+    InboundCommandProcessor.restartAction = restartCount::incrementAndGet;
+
+    byte[] data = "fake-jar-bytes".getBytes();
+    long othersTs = Updater.MIN_UPDATE_TIMESTAMP_MS + 1_000_000L;
+    ByteBuffer toHash = ByteBuffer.allocate(8 + data.length);
+    toHash.putLong(othersTs);
+    toHash.put(data);
+    byte[] sig = testKey.sign(toHash.array());
+
+    ByteBuffer in = buildUpdateAnswerContent(othersTs, sig, data);
+
+    int consumed = proc.parseCommand(Command.UPDATE_ANSWER_CONTENT, in, newPeer(8805));
+    assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
+
+    File updateFile = new File("update");
+    awaitCondition(updateFile::exists, 5000);
+    assertTrue(
+        "installed update file must contain the received data",
+        java.util.Arrays.equals(data, Files.readAllBytes(updateFile.toPath())));
+
+    assertEquals(othersTs, ctx.getLocalSettings().getUpdateTimestamp());
+    assertTrue(java.util.Arrays.equals(sig, ctx.getLocalSettings().getUpdateSignature()));
+
+    // The restart happens 2s after installing, asynchronously; wait for it and make sure the
+    // JVM (this test process) is still alive to observe it.
+    awaitCondition(() -> restartCount.get() == 1, 5000);
+    assertEquals(1, restartCount.get());
+  }
+
+  private static void awaitCondition(BooleanSupplier condition, long timeoutMillis) {
+    long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+    while (System.nanoTime() < deadlineNanos) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10));
+    }
+    fail("Condition not met within " + timeoutMillis + "ms");
+  }
+}

--- a/src/test/java/im/redpanda/core/UpdaterCreateKeysTest.java
+++ b/src/test/java/im/redpanda/core/UpdaterCreateKeysTest.java
@@ -1,0 +1,45 @@
+package im.redpanda.core;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * The key-ceremony CLI entry point (T10/T13) must never overwrite an existing signing key file —
+ * accidental key loss would permanently break the update channel. No real keys are ever generated
+ * here: the guard fires before key generation.
+ */
+public class UpdaterCreateKeysTest {
+
+  private static final Path KEY_FILE = Path.of("privateSigningKey.txt");
+  private static final String DUMMY_CONTENT = "dummy-not-a-key";
+
+  @Before
+  public void setup() throws IOException {
+    Files.writeString(KEY_FILE, DUMMY_CONTENT);
+  }
+
+  @After
+  public void cleanup() throws IOException {
+    Files.deleteIfExists(KEY_FILE);
+  }
+
+  @Test
+  public void createNewKeys_refusesToOverwriteExistingKeyFile() throws IOException {
+    Updater.createNewKeys();
+    assertEquals(DUMMY_CONTENT, Files.readString(KEY_FILE));
+  }
+
+  @Test
+  public void mainCreateKeys_onlyRunsCreateNewKeys_andKeepsExistingFile() throws IOException {
+    // --create-keys must go through the same guard and must not fall through to the
+    // update-inserting code path.
+    Updater.main(new String[] {"--create-keys"});
+    assertEquals(DUMMY_CONTENT, Files.readString(KEY_FILE));
+  }
+}


### PR DESCRIPTION
Implements **T10 / PLAN-updater-option-b — PR 1 (redpandaj)**: production-hardening of the P2P auto-updater (option B decision 2026-07-09), plus the `--create-keys` CLI entry point needed for the T13 key ceremony.

## Changes

### `Updater.java`
- New build-time rollback floor `MIN_UPDATE_TIMESTAMP_MS = 1783728000000L` (2026-07-11T00:00:00Z, implementation date). To be raised to the signing timestamp with every signed release.
- `getPublicUpdaterKey()` now decodes the baked-in key **once** and caches the result. On a broken/placeholder key it fails closed (`null`) with a single `logger.warn` instead of stacktrace spam on every call. Package-private test hooks `setPublicUpdaterKeyForTests` / `resetPublicUpdaterKeyForTests`.
- `main()` accepts `--create-keys` and then only runs `createNewKeys()` (offline key-ceremony entry point; `createNewKeys()` already prints the public key as Base58). The Maven package hook passes `argument1`, so build behaviour is unchanged.

### `InboundCommandProcessor.java`
- All four update answer handlers (`UPDATE_ANSWER_TIMESTAMP/CONTENT`, `ANDROID_UPDATE_ANSWER_TIMESTAMP/CONTENT`) now compare against `max(localSettings timestamp, MIN_UPDATE_TIMESTAMP_MS)` — a freshly set-up node (`updateTimestamp == -1`) can no longer be downgraded to an ancient but validly signed JAR/APK.
- Timestamps more than 24 h in the future are rejected (clock-skew/spoofing guard). All reject paths return the exact consumed byte lengths, so the stream parser stays in sync.
- The `System.exit(0)` after installing an update is now behind an injectable package-private `restartAction` (default unchanged), so the positive-path test never kills the JVM.

### Tests (`InboundCommandProcessorUpdateHardeningTest`, 5 new)
- downgrade rejected when timestamp not above local
- downgrade rejected below build floor on fresh LocalSettings (validly signed)
- future skew rejected with exact consumed byte count
- fail-closed (no key) writes no file — forced via test override since the constant is now a real interim key (#244)
- valid update installs, sets LocalSettings, invokes restartAction exactly once, JVM keeps running

All static hooks are reset in `@After`. Test keys are generated in-memory only.

## No wire-format change
CMD bytes, frame layouts and `Peer.java` send behaviour are unchanged — old nodes see no difference (rejected downgrades/skew were never legitimately triggered).

Local: `mvn verify` green twice in a row (295 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EZEvJLQroVfjS87Mu4aKh