### PR TITLE
T10: gate updater signing behind release-signing profile, deflake jar-upload test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,31 +440,6 @@
 
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>java</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <mainClass>im.redpanda.core.Updater</mainClass>
-                    <arguments>
-                        <argument>argument1</argument>
-                    </arguments>
-                    <systemProperties>
-                        <systemProperty>
-                            <key>myproperty</key>
-                            <value>myvalue</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
@@ -568,6 +543,41 @@
                             <includes>
                                 <include>**/*IT.java</include>
                             </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- Signs and inserts the update into the network (Updater.main); only meant to be
+                 run explicitly by the release/signing process (see updater key-ceremony runbook
+                 in the docs repo), never as part of a plain `mvn package`. -->
+            <id>release-signing</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <mainClass>im.redpanda.core.Updater</mainClass>
+                            <arguments>
+                                <argument>argument1</argument>
+                            </arguments>
+                            <systemProperties>
+                                <systemProperty>
+                                    <key>myproperty</key>
+                                    <value>myvalue</value>
+                                </systemProperty>
+                            </systemProperties>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -569,15 +569,6 @@
                         </executions>
                         <configuration>
                             <mainClass>im.redpanda.core.Updater</mainClass>
-                            <arguments>
-                                <argument>argument1</argument>
-                            </arguments>
-                            <systemProperties>
-                                <systemProperty>
-                                    <key>myproperty</key>
-                                    <value>myvalue</value>
-                                </systemProperty>
-                            </systemProperties>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -64,9 +64,9 @@ public class InboundCommandProcessor {
    * Surefire forks sharing the working directory don't collide).
    */
   static Path updateJarPath() {
-    String override = System.getProperty(JAR_PATH_PROPERTY);
+    Path override = pathOverride(JAR_PATH_PROPERTY);
     if (override != null) {
-      return Path.of(override);
+      return override;
     }
     return Settings.isSeedNode() ? Path.of("target/redpanda.jar") : Path.of("redpanda.jar");
   }
@@ -77,11 +77,29 @@ public class InboundCommandProcessor {
    * overridable via {@value #APK_PATH_PROPERTY} (tests only).
    */
   static Path updateApkPath() {
-    String override = System.getProperty(APK_PATH_PROPERTY);
+    Path override = pathOverride(APK_PATH_PROPERTY);
     if (override != null) {
-      return Path.of(override);
+      return override;
     }
     return Path.of(ConnectionReaderThread.ANDROID_UPDATE_FILE);
+  }
+
+  /**
+   * Reads a path-override system property, ignoring it (falling back to the caller's default) when
+   * it is blank or not a valid path, so a misconfigured test property can't crash the update
+   * handlers with an unchecked {@link java.nio.file.InvalidPathException}.
+   */
+  private static Path pathOverride(String property) {
+    String value = System.getProperty(property);
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    try {
+      return Path.of(value);
+    } catch (java.nio.file.InvalidPathException e) {
+      logger.warn("ignoring invalid {} override: {}", property, value);
+      return null;
+    }
   }
 
   private final ServerContext serverContext;

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -52,6 +52,38 @@ public class InboundCommandProcessor {
    */
   static Runnable restartAction = () -> System.exit(0);
 
+  /** System property overriding {@link #updateJarPath()}; used by tests to avoid CWD sharing. */
+  private static final String JAR_PATH_PROPERTY = "redpanda.update.jar.path";
+
+  /** System property overriding {@link #updateApkPath()}; used by tests to avoid CWD sharing. */
+  private static final String APK_PATH_PROPERTY = "redpanda.update.apk.path";
+
+  /**
+   * Path of the local redpanda.jar that gets uploaded to peers requesting it. Defaults to the usual
+   * seed-node vs. client layout, overridable via {@value #JAR_PATH_PROPERTY} (tests only, so
+   * Surefire forks sharing the working directory don't collide).
+   */
+  static Path updateJarPath() {
+    String override = System.getProperty(JAR_PATH_PROPERTY);
+    if (override != null) {
+      return Path.of(override);
+    }
+    return Settings.isSeedNode() ? Path.of("target/redpanda.jar") : Path.of("redpanda.jar");
+  }
+
+  /**
+   * Path of the local android.apk that gets uploaded to peers requesting it / that a received
+   * update is written to. Defaults to {@link ConnectionReaderThread#ANDROID_UPDATE_FILE},
+   * overridable via {@value #APK_PATH_PROPERTY} (tests only).
+   */
+  static Path updateApkPath() {
+    String override = System.getProperty(APK_PATH_PROPERTY);
+    if (override != null) {
+      return Path.of(override);
+    }
+    return Path.of(ConnectionReaderThread.ANDROID_UPDATE_FILE);
+  }
+
   private final ServerContext serverContext;
 
   @FunctionalInterface
@@ -443,8 +475,7 @@ public class InboundCommandProcessor {
               Thread.sleep(200);
             } catch (InterruptedException ignored) {
             }
-            Path path =
-                Settings.isSeedNode() ? Path.of("target/redpanda.jar") : Path.of("redpanda.jar");
+            Path path = updateJarPath();
             try {
               System.out.println("we send the update to a peer!");
               byte[] data = Files.readAllBytes(path);
@@ -582,7 +613,7 @@ public class InboundCommandProcessor {
   }
 
   private int handleAndroidUpdateRequestTimestamp(Peer peer) {
-    File file = new File(ConnectionReaderThread.ANDROID_UPDATE_FILE);
+    File file = updateApkPath().toFile();
     if (!file.exists()) {
       return 1;
     }
@@ -659,7 +690,7 @@ public class InboundCommandProcessor {
               Thread.sleep(200);
             } catch (InterruptedException ignored) {
             }
-            Path path = Path.of(ConnectionReaderThread.ANDROID_UPDATE_FILE);
+            Path path = updateApkPath();
             try {
               NodeId publicUpdaterKey = Updater.getPublicUpdaterKey();
               if (publicUpdaterKey == null) {
@@ -784,8 +815,7 @@ public class InboundCommandProcessor {
         return consumedBytes;
       }
 
-      try (FileOutputStream fos =
-          new FileOutputStream(ConnectionReaderThread.ANDROID_UPDATE_FILE)) {
+      try (FileOutputStream fos = new FileOutputStream(updateApkPath().toFile())) {
         fos.write(data);
       } catch (IOException e) {
         e.printStackTrace();

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorAsyncUpdatesTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorAsyncUpdatesTest.java
@@ -6,14 +6,21 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.BooleanSupplier;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class InboundCommandProcessorAsyncUpdatesTest {
+
+  private static final String JAR_PATH_PROPERTY = "redpanda.update.jar.path";
+
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
   private ServerContext ctx;
   private InboundCommandProcessor proc;
@@ -31,7 +38,7 @@ public class InboundCommandProcessorAsyncUpdatesTest {
   @After
   public void cleanup() {
     // Remove files created by tests
-    new File("redpanda.jar").delete();
+    System.clearProperty(JAR_PATH_PROPERTY);
     new File("tmp_redpanda.jar").delete();
     new File(ConnectionReaderThread.ANDROID_UPDATE_FILE).delete();
   }
@@ -47,6 +54,15 @@ public class InboundCommandProcessorAsyncUpdatesTest {
   public void updateRequestContent_sendsJarFrame_whenSignaturePresent() throws IOException {
     byte[] data = "jar".getBytes();
 
+    // Point the handler at a private temp-dir jar so this test cannot collide with other
+    // Surefire forks sharing the working directory (e.g. SettingsInitTest, which creates and
+    // deletes a CWD-relative redpanda.jar).
+    Path jarPath = tempFolder.newFile("redpanda.jar").toPath();
+    System.setProperty(JAR_PATH_PROPERTY, jarPath.toString());
+    try (FileOutputStream fos = new FileOutputStream(jarPath.toFile())) {
+      fos.write(data);
+    }
+
     // Set signature and timestamp to pass initial guards
     ctx.getLocalSettings().setUpdateTimestamp(System.currentTimeMillis());
     ctx.getLocalSettings().setUpdateSignature(fakeSignature());
@@ -57,49 +73,22 @@ public class InboundCommandProcessorAsyncUpdatesTest {
     // Big enough buffer; code may grow it, but start with capacity
     peer.writeBuffer = ByteBuffer.allocate(1024);
 
-    // Surefire forks share the working directory: SettingsInitTest (another fork)
-    // deletes redpanda.jar, and on loaded CI runners the async upload task can take
-    // well over 2s. Retry the whole request so neither interference fails the test.
-    int attempts = 0;
-    while (true) {
-      attempts++;
-      // (Re-)create the jar right before each request in case another fork deleted it
-      try (FileOutputStream fos = new FileOutputStream("redpanda.jar")) {
-        fos.write(data);
-      }
+    int consumed = proc.parseCommand(Command.UPDATE_REQUEST_CONTENT, ByteBuffer.allocate(0), peer);
+    assertEquals(1, consumed);
 
-      int consumed =
-          proc.parseCommand(Command.UPDATE_REQUEST_CONTENT, ByteBuffer.allocate(0), peer);
-      assertEquals(1, consumed);
+    // The writer thread mutates (and may replace) peer.writeBuffer under writeBufferLock; poll
+    // under the same lock for visibility.
+    awaitCondition(
+        () -> {
+          peer.writeBufferLock.lock();
+          try {
+            return peer.writeBuffer.position() > 0;
+          } finally {
+            peer.writeBufferLock.unlock();
+          }
+        },
+        5000);
 
-      try {
-        // The writer thread mutates (and may replace) peer.writeBuffer under
-        // writeBufferLock; poll under the same lock for visibility.
-        awaitCondition(
-            () -> {
-              peer.writeBufferLock.lock();
-              try {
-                return peer.writeBuffer.position() > 0;
-              } finally {
-                peer.writeBufferLock.unlock();
-              }
-            },
-            5000);
-        break;
-      } catch (AssertionError e) {
-        if (attempts >= 3) {
-          throw e;
-        }
-        // Reset the buffer so a late write from this attempt cannot satisfy the
-        // next attempt's await with a partially observed state.
-        peer.writeBufferLock.lock();
-        try {
-          peer.writeBuffer.clear();
-        } finally {
-          peer.writeBufferLock.unlock();
-        }
-      }
-    }
     peer.writeBufferLock.lock();
     try {
       assertEquals(Command.UPDATE_ANSWER_CONTENT, peer.writeBuffer.get(0));


### PR DESCRIPTION
## Summary
PR 2 of T10 (Updater Option B), per `plans/PLAN-updater-option-b.md` — "PR 2 (redpandaj) — Build-Hook + Deflake". Builds on PR 1 (#245, merged as ebcc029).

- **Build hook**: moved the `exec-maven-plugin` `Updater.main()` execution out of the default `package` phase into a new `release-signing` Maven profile. A plain `mvn package` no longer runs it at all (previously a silent no-op unless `privateSigningKey.txt` was present, but still printed "No private key for signing found, skipping insert update into network."). The hook now only runs via `mvn package -Prelease-signing`, matching the key-ceremony runbook's per-release signing step.
- **Testable jar/apk paths**: added package-private `InboundCommandProcessor.updateJarPath()` / `updateApkPath()` static helpers. Default behavior is unchanged (`Settings.isSeedNode() ? target/redpanda.jar : redpanda.jar`, and `ConnectionReaderThread.ANDROID_UPDATE_FILE`), overridable via the `redpanda.update.jar.path` / `redpanda.update.apk.path` system properties (test-only escape hatch). Wired into all read/write sites in the four update content handlers. `tmp_redpanda.jar` / `update` were left hardcoded per the plan — verified via `grep -rn '"update"' src/test` that no other test collides on those names.
- **Deflake**: reworked `InboundCommandProcessorAsyncUpdatesTest.updateRequestContent_sendsJarFrame_whenSignaturePresent` to use a `@Rule TemporaryFolder` jar addressed via the new system property instead of a CWD-relative `redpanda.jar`. Removed the retry-loop workaround that existed because Surefire forks share the working directory (another fork, `SettingsInitTest`, creates/deletes a CWD-relative `redpanda.jar`). Verified green 5x in a row.

No wire-format change: CMD bytes, frame layouts, `serialVersionUID = 639`, and the `LocalSettings` update fields are untouched.

## Proof
- `mvn package -DskipTests` (no profile): BUILD SUCCESS, no exec-maven-plugin execution logged, no "No private key" message.
- `mvn package -DskipTests -Prelease-signing`: prints "No private key for signing found, skipping insert update into network." (hook runs, fails closed as before since there's no key in this checkout).
- `for i in 1 2 3 4 5; do mvn -q -Dtest=InboundCommandProcessorAsyncUpdatesTest test || break; done`: 5/5 green.
- `mvn verify` run twice locally: both green, 305 tests, 0 failures/errors, 1 pre-existing skip.

## Test plan
- [x] `mvn package -DskipTests` clean of signing-hook output
- [x] `mvn package -DskipTests -Prelease-signing` runs the hook
- [x] Flaky test green 5x in a row without the retry-loop
- [x] `mvn verify` 2x green locally
- [ ] CI green
- [ ] Copilot review threads resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EZEvJLQroVfjS87Mu4aKh