### PR TITLE
Fix NPE in Saver.savePeers for bootstrap peers without verify key (T14)

### DIFF
--- a/src/main/java/im/redpanda/core/Saver.java
+++ b/src/main/java/im/redpanda/core/Saver.java
@@ -18,7 +18,9 @@ public class Saver {
     ArrayList<PeerSaveable> arrayList = new ArrayList<>();
 
     for (Peer peer : peers) {
-      if (peer.getNodeId() != null) {
+      // Bootstrap peers may have a NodeId with a known KademliaId but no verify key yet
+      // (handshake not completed) - skip those, serializing them would NPE in NodeId#writeObject.
+      if (peer.getNodeId() != null && peer.getNodeId().hasKey()) {
         arrayList.add(peer.toSaveable());
       }
     }

--- a/src/test/java/im/redpanda/core/SaverTest.java
+++ b/src/test/java/im/redpanda/core/SaverTest.java
@@ -65,6 +65,40 @@ public class SaverTest {
   }
 
   @Test
+  public void testSavePeersSkipsPeerWithoutVerifyKey() {
+    // Simulates the first-boot race: a bootstrap peer's KademliaId is known (e.g. from the DHT)
+    // but its handshake has not completed yet, so its NodeId has no verify key. Saving must not
+    // throw and must still persist the other, fully-identified peers.
+    ArrayList<Peer> peers = new ArrayList<>();
+
+    Peer keyedPeer = new Peer("127.0.0.1", 1234);
+    keyedPeer.setNodeId(new NodeId());
+    peers.add(keyedPeer);
+
+    Peer bootstrapPeer = new Peer("10.0.0.1", 4321);
+    bootstrapPeer.setNodeId(new NodeId(new KademliaId()));
+    peers.add(bootstrapPeer);
+
+    Saver.savePeers(peers);
+
+    File file = new File(TEST_FILE);
+    assertTrue(file.exists());
+
+    Map<KademliaId, Peer> loadedPeers = Saver.loadPeers();
+
+    assertNotNull(loadedPeers);
+    assertEquals(1, loadedPeers.size());
+
+    Peer loadedKeyedPeer = loadedPeers.get(keyedPeer.getKademliaId());
+    assertNotNull(loadedKeyedPeer);
+    assertEquals(keyedPeer.getIp(), loadedKeyedPeer.getIp());
+    assertEquals(keyedPeer.getPort(), loadedKeyedPeer.getPort());
+
+    assertTrue(
+        loadedPeers.values().stream().noneMatch(p -> p.getIp().equals(bootstrapPeer.getIp())));
+  }
+
+  @Test
   public void testLoadMissingFile() {
     // Ensure file does not exist
     File file = new File(TEST_FILE);


### PR DESCRIPTION
## T14 — First-boot race: Saver.savePeers NPE

**Root cause:** `Saver.savePeers` (src/main/java/im/redpanda/core/Saver.java:20-24) only
checked `peer.getNodeId() != null` before including a peer in the save batch. A bootstrap
peer whose KademliaId is known (e.g. discovered via the DHT) but whose handshake has not
completed yet gets a `NodeId` constructed via `new NodeId(kademliaId)`
(see `PeerList.updateKademliaId`, src/main/java/im/redpanda/core/PeerList.java:290),
which leaves `verifyKey` null. Such a peer passes the `!= null` check, so
`NodeId#writeObject` (src/main/java/im/redpanda/core/NodeId.java:315-322) is reached during
serialization; `hasPrivate()` is false, so it falls into `exportPublic()`
(NodeId.java:153-158), which calls `verifyKey.getEncoded()` → NPE. The exception is caught
in `Saver.savePeers`'s try/catch around the whole write, so the *entire* peers.dat write for
that run is skipped, not just the bad peer.

Observed 2x during Raspi first boot on 2026-07-11 (exception logged/caught, but no peers
persisted for that run).

**Fix:** skip peers without a verify key when building the save batch — check
`peer.getNodeId().hasKey()` in addition to the existing null check. `hasKey()` already
existed on `NodeId` (`verifyKey != null`). This is the minimal, KISS fix that matches the
existing code (an equivalent "not yet a real identity" filter already existed for `null`
NodeIds); no serialization format/`serialVersionUID` changes, so existing `peers.dat` files
on the live testnet remain loadable.

**Regression test:** `SaverTest.testSavePeersSkipsPeerWithoutVerifyKey` builds a peer list
with one fully-keyed peer and one bootstrap-style peer (`new NodeId(new KademliaId())`,
verify key null), asserts `savePeers` does not throw, and that only the keyed peer is
persisted and reloadable.

**Out of scope / backlog note:** `loadPeers` has no symmetric problem today because the
write-side filter now guarantees only fully-keyed peers ever land in `peers.dat` — didn't
touch `loadPeers`.

## Test plan
- [x] `mvn spotless:apply`
- [x] `mvn verify` locally, 2x green (only pre-existing SpotBugs report-only findings unrelated to this change)