### PR TITLE
Harden legacy FlaschenpostPut path against malformed/encrypted content (REDPANDAJ-2DR)

### DIFF
--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -230,7 +230,10 @@ public class InboundCommandProcessor {
 
     // compact() must run even if a handler throws, otherwise the buffer state is left
     // inconsistent (flipped, position/limit not restored) and the connection keeps retrying
-    // the same malformed packet.
+    // the same malformed packet. But if a handler disconnected the peer (or grew the buffer),
+    // Peer.disconnect()/decryptInputData() already returned this exact buffer instance to
+    // ByteBufferPool (and possibly handed it to a different peer/thread) — compacting it here
+    // would then corrupt that other owner's buffer, so only compact if we still own it.
     try {
       while (readBuffer.hasRemaining() && parsedBytesLocally != 0 && peer.isConnected()) {
         int newPosition = readBuffer.position();
@@ -245,7 +248,9 @@ public class InboundCommandProcessor {
         readBuffer.position(newPosition);
       }
     } finally {
-      readBuffer.compact();
+      if (peer.readBuffer == readBuffer) {
+        readBuffer.compact();
+      }
     }
   }
 
@@ -1039,8 +1044,10 @@ public class InboundCommandProcessor {
     // written to only ever see GarlicMessage/GMAck bytes. A raw E2E-encrypted client payload can
     // collide with a known GMType id (e.g. 0x04 == ACK) and must be rejected explicitly instead
     // of silently dropped by GMParser.parse's defensive fallback — otherwise the sender never
-    // learns the deposit failed and keeps retrying blindly.
-    if (!GMParser.isValidFrame(serverContext, content)) {
+    // learns the deposit failed and keeps retrying blindly. Scoped to the empty-oh_id case only:
+    // a non-empty oh_id that fell through here because outboundService is unset must keep its
+    // pre-existing (unconditional) legacy behavior, not be rejected as if it were this case.
+    if (ohIdBytes.isEmpty() && !GMParser.isValidFrame(serverContext, content)) {
       logger.warn(
           "Rejecting FlaschenpostPut with empty oh_id whose content is not a valid GM frame,"
               + " length: {}",

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -228,20 +228,25 @@ public class InboundCommandProcessor {
 
     int parsedBytesLocally = -1;
 
-    while (readBuffer.hasRemaining() && parsedBytesLocally != 0 && peer.isConnected()) {
-      int newPosition = readBuffer.position();
-      byte b = readBuffer.get();
-      Log.put("command: " + b + " " + readBuffer, 200);
-      parsedBytesLocally = parseCommand(b, readBuffer, peer);
-      if (!peer.isConnected()) {
-        return;
+    // compact() must run even if a handler throws, otherwise the buffer state is left
+    // inconsistent (flipped, position/limit not restored) and the connection keeps retrying
+    // the same malformed packet.
+    try {
+      while (readBuffer.hasRemaining() && parsedBytesLocally != 0 && peer.isConnected()) {
+        int newPosition = readBuffer.position();
+        byte b = readBuffer.get();
+        Log.put("command: " + b + " " + readBuffer, 200);
+        parsedBytesLocally = parseCommand(b, readBuffer, peer);
+        if (!peer.isConnected()) {
+          return;
+        }
+        peer.lastCommand = b;
+        newPosition += parsedBytesLocally;
+        readBuffer.position(newPosition);
       }
-      peer.lastCommand = b;
-      newPosition += parsedBytesLocally;
-      readBuffer.position(newPosition);
+    } finally {
+      readBuffer.compact();
     }
-
-    readBuffer.compact();
   }
 
   public int parseCommand(byte command, ByteBuffer readBuffer, Peer peer) {
@@ -1027,6 +1032,20 @@ public class InboundCommandProcessor {
 
     // Legacy: Try to route via GarlicMessage destination header
     if (tryDepositToLocalOh(content)) {
+      return;
+    }
+
+    // REDPANDAJ-2DR hardening: an empty oh_id falls into legacy garlic parsing, which was
+    // written to only ever see GarlicMessage/GMAck bytes. A raw E2E-encrypted client payload can
+    // collide with a known GMType id (e.g. 0x04 == ACK) and must be rejected explicitly instead
+    // of silently dropped by GMParser.parse's defensive fallback — otherwise the sender never
+    // learns the deposit failed and keeps retrying blindly.
+    if (!GMParser.isValidFrame(serverContext, content)) {
+      logger.warn(
+          "Rejecting FlaschenpostPut with empty oh_id whose content is not a valid GM frame,"
+              + " length: {}",
+          content.length);
+      respondToDeposit(peer, putMsg, im.redpanda.outbound.v1.Status.BAD_REQUEST);
       return;
     }
 

--- a/src/main/java/im/redpanda/flaschenpost/GMParser.java
+++ b/src/main/java/im/redpanda/flaschenpost/GMParser.java
@@ -168,8 +168,17 @@ public class GMParser {
 
     } else if (type == GMType.ACK.getId()) {
 
-      GMAck gmAck = new GMAck(content);
-      gmAck.parseContent();
+      // A network-supplied ACK payload may be malformed (wrong length/truncated), or an
+      // end-to-end encrypted client payload whose first byte just happens to be the ACK type
+      // byte. Dropping it here keeps the malformed packet from unwinding the read loop.
+      GMAck gmAck;
+      try {
+        gmAck = new GMAck(content);
+        gmAck.parseContent();
+      } catch (RuntimeException e) {
+        Log.put("dropping malformed GMAck: " + e.getMessage(), 50);
+        return null;
+      }
 
       Job runningJob = Job.getRunningJob(gmAck.getAckid());
 
@@ -184,7 +193,52 @@ public class GMParser {
       return gmAck;
     }
 
-    throw new RuntimeException("Unknown GMType at parsing: " + type);
+    // Unknown type byte from the network (e.g. an encrypted client payload) — drop it instead
+    // of throwing, which would unwind the reader loop and leave the connection retrying.
+    Log.put("dropping GM with unknown type: " + type, 50);
+    return null;
+  }
+
+  /**
+   * Cheap structural pre-check: is {@code content} a parseable GM frame (a well-formed {@link
+   * GarlicMessage} or {@link GMAck})? Unlike {@link #parse}, this never mutates any state — no
+   * dedup-store insert, no job lookups, no forwarding — so it is safe to call purely to decide
+   * whether content deserves a BAD_REQUEST response before invoking {@link #parse}.
+   *
+   * <p>Used by the {@code FlaschenpostPut} legacy (empty {@code oh_id}) path (REDPANDAJ-2DR): a raw
+   * E2E-encrypted client payload can accidentally start with a byte that collides with a known
+   * {@link GMType} id (e.g. {@code 0x04} == {@link GMType#ACK}), and such content must be rejected
+   * explicitly instead of silently swallowed by {@link #parse}'s defensive drop.
+   *
+   * @return {@code true} if content is a well-formed frame of a known type (regardless of whether
+   *     {@link #parse} would then treat it as a duplicate); {@code false} if the type byte is
+   *     unknown or the frame is malformed/truncated for its type.
+   */
+  public static boolean isValidFrame(ServerContext serverContext, byte[] content) {
+    if (content == null || content.length == 0) {
+      return false;
+    }
+
+    byte type = content[0];
+
+    if (type == GMType.GARLIC_MESSAGE.getId()) {
+      try {
+        new GarlicMessage(serverContext, content);
+        return true;
+      } catch (RuntimeException e) {
+        return false;
+      }
+    } else if (type == GMType.ACK.getId()) {
+      try {
+        GMAck gmAck = new GMAck(content);
+        gmAck.parseContent();
+        return true;
+      } catch (RuntimeException e) {
+        return false;
+      }
+    }
+
+    return false;
   }
 
   private static void sendGarlicMessageToPeer(

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
@@ -371,6 +371,113 @@ public class InboundCommandProcessorFlaschenpostPutTest {
     assertEquals(1 + 4 + putData.length, consumed);
   }
 
+  /**
+   * REDPANDAJ-2DR regression: a light client sent a FlaschenpostPut with empty oh_id and content =
+   * an end-to-end encrypted payload whose first byte is 0x04 (== GMType.ACK). The legacy path fell
+   * into GMParser, GMAck.parseContent threw on the bad length, and the RuntimeException unwound the
+   * reader loop, leaving the connection retrying and generating a fresh Sentry event per retry. The
+   * handler must now reject the packet (BAD_REQUEST, opt-in response only) without throwing, and
+   * consume the frame regardless.
+   */
+  @Test
+  public void flaschenpostPut_emptyOhIdWithEncryptedAckLikePayload_isDroppedWithoutThrowing() {
+    byte[] encryptedPayload = new byte[48];
+    encryptedPayload[0] = im.redpanda.flaschenpost.GMType.ACK.getId(); // 0x04
+    for (int i = 1; i < encryptedPayload.length; i++) {
+      encryptedPayload[i] = (byte) (0x40 + i);
+    }
+
+    FlaschenpostPut putMsg =
+        FlaschenpostPut.newBuilder()
+            .setContent(copyFrom(encryptedPayload))
+            .setOhId(ByteString.EMPTY)
+            .build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9011, ctx.getNodeId());
+    peer.setConnected(true);
+    ctx.getPeerList().add(peer);
+
+    // Must not throw and must consume the full frame.
+    int consumed = proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+    assertEquals(1 + 4 + putData.length, consumed);
+  }
+
+  /**
+   * REDPANDAJ-2DR: same malformed/E2E-encrypted-looking payload as above, but from a light client
+   * that opted into {@code want_response} — it must receive an explicit BAD_REQUEST instead of
+   * silence, so it learns the deposit failed rather than retrying blindly for hours.
+   */
+  @Test
+  public void flaschenpostPut_emptyOhIdWithInvalidContent_lightClientWantResponse_getsBadRequest() {
+    byte[] encryptedPayload = new byte[48];
+    encryptedPayload[0] = im.redpanda.flaschenpost.GMType.ACK.getId(); // 0x04
+    for (int i = 1; i < encryptedPayload.length; i++) {
+      encryptedPayload[i] = (byte) (0x40 + i);
+    }
+
+    FlaschenpostPut putMsg =
+        FlaschenpostPut.newBuilder()
+            .setContent(copyFrom(encryptedPayload))
+            .setOhId(ByteString.EMPTY)
+            .setWantResponse(true)
+            .build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9012, ctx.getNodeId());
+    peer.setConnected(true);
+    peer.setLightClient(true);
+    peer.writeBuffer = ByteBuffer.allocate(8192);
+    ctx.getPeerList().add(peer);
+
+    int consumed = proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+    assertEquals(1 + 4 + putData.length, consumed);
+
+    ByteBuffer buf = peer.writeBuffer;
+    buf.flip();
+    assertEquals(Command.FLASCHENPOST_PUT_RES, buf.get());
+    int len = buf.getInt();
+    byte[] payload = new byte[len];
+    buf.get(payload);
+    try {
+      assertEquals(
+          im.redpanda.outbound.v1.Status.BAD_REQUEST,
+          im.redpanda.outbound.v1.FlaschenpostPutResponse.parseFrom(payload).getStatus());
+    } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  /**
+   * REDPANDAJ-2DR: a valid GMAck sent legacy-style (no oh_id) must still be processed normally by
+   * GMParser and must NOT be rejected as BAD_REQUEST — only genuinely malformed/unrecognized
+   * content triggers the new pre-check.
+   */
+  @Test
+  public void flaschenpostPut_emptyOhIdWithValidAck_isNotRejected() {
+    byte[] ackBytes = buildAckPayload(123);
+    FlaschenpostPut putMsg =
+        FlaschenpostPut.newBuilder()
+            .setContent(copyFrom(ackBytes))
+            .setOhId(ByteString.EMPTY)
+            .setWantResponse(true)
+            .build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9013, ctx.getNodeId());
+    peer.setConnected(true);
+    peer.setLightClient(true);
+    peer.writeBuffer = ByteBuffer.allocate(8192);
+    ctx.getPeerList().add(peer);
+
+    int consumed = proc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+    assertEquals(1 + 4 + putData.length, consumed);
+
+    // A valid (if legacy) ACK never reaches respondToDeposit at all — no FlaschenpostPutResponse
+    // is written, matching pre-existing legacy fire-and-forget behavior.
+    assertEquals(0, peer.writeBuffer.position());
+  }
+
   // --- MS02b: opt-in deposit status responses (want_response) ---
 
   /** Light client with want_response gets an OK FlaschenpostPutResponse on successful deposit. */

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorFlaschenpostPutTest.java
@@ -219,6 +219,46 @@ public class InboundCommandProcessorFlaschenpostPutTest {
   }
 
   /**
+   * REDPANDAJ-2DR (Copilot review finding): the empty-oh_id BAD_REQUEST pre-check must be scoped to
+   * {@code oh_id.isEmpty()}, not merely "the MS01 direct-deposit block was skipped" — a non-empty
+   * oh_id also falls through to the legacy path when {@code outboundService} is null (server
+   * misconfiguration), and that pre-existing fallthrough behavior must be preserved unconditionally
+   * rather than being newly rejected as if oh_id were absent.
+   */
+  @Test
+  public void flaschenpostPut_withOhIdButNullOutboundService_invalidContentIsNotRejected() {
+    ServerContext noServiceCtx = ServerContext.buildDefaultServerContext();
+    InboundCommandProcessor noServiceProc = new InboundCommandProcessor(noServiceCtx);
+
+    byte[] ohId = sampleOhId();
+    // Content that is not a valid GM frame at all (unknown type byte) — would trip the new
+    // isValidFrame pre-check if it were wrongly applied here.
+    byte[] invalidContent = new byte[] {(byte) 0x2a, 1, 2, 3};
+
+    FlaschenpostPut putMsg =
+        FlaschenpostPut.newBuilder()
+            .setContent(copyFrom(invalidContent))
+            .setOhId(ByteString.copyFrom(ohId))
+            .setWantResponse(true)
+            .build();
+    byte[] putData = putMsg.toByteArray();
+
+    Peer peer = new Peer("127.0.0.1", 9014, noServiceCtx.getNodeId());
+    peer.setConnected(true);
+    peer.setLightClient(true);
+    peer.writeBuffer = ByteBuffer.allocate(8192);
+    noServiceCtx.getPeerList().add(peer);
+
+    int consumed = noServiceProc.parseCommand(Command.FLASCHENPOST_PUT, buildFrame(putData), peer);
+
+    assertEquals(1 + 4 + putData.length, consumed);
+    // respondToDeposit requires a non-null outboundService, so no response is written either way
+    // — but the point of this test is that reaching that point never throws or misclassifies a
+    // non-empty oh_id as the empty-oh_id legacy case.
+    assertEquals(0, peer.writeBuffer.position());
+  }
+
+  /**
    * When {@code oh_id} is absent and the content is a valid GarlicMessage with a destination that
    * matches a registered OH, {@code tryDepositToLocalOh} deposits the message and returns early.
    */

--- a/src/test/java/im/redpanda/core/ParseCommandTest.java
+++ b/src/test/java/im/redpanda/core/ParseCommandTest.java
@@ -38,6 +38,11 @@ public class ParseCommandTest {
     Peer peerForDebug = getPeerForDebug();
     serverContext.getPeerList().add(peerForDebug);
     peerForDebug.setConnected(true);
+    // loopCommands only compacts the buffer it still owns via peer.readBuffer (REDPANDAJ-2DR
+    // hardening: a handler that disconnects the peer already returns/nulls peer.readBuffer, so
+    // compacting a stale local reference afterwards would corrupt a buffer some other peer may
+    // already have borrowed from the pool). Wire it up the same way ConnectionReaderThread does.
+    peerForDebug.readBuffer = allocate;
     processor.loopCommands(peerForDebug, allocate);
 
     // lets go to read mode and check for remaining bytes
@@ -49,6 +54,7 @@ public class ParseCommandTest {
     allocate.put(Command.SEND_PEERLIST);
     allocate.putInt(1);
 
+    peerForDebug.readBuffer = allocate;
     processor.loopCommands(peerForDebug, allocate);
 
     // lets go to read mode and check for remaining bytes
@@ -67,6 +73,7 @@ public class ParseCommandTest {
     allocate.putInt(1);
 
     peerForDebug.setConnected(true);
+    peerForDebug.readBuffer = allocate;
     processor.loopCommands(peerForDebug, allocate);
 
     // lets go to read mode and check for remaining bytes
@@ -74,6 +81,43 @@ public class ParseCommandTest {
 
     assertThat(allocate.get()).isEqualTo(Command.SEND_PEERLIST);
     assertThat(allocate.getInt()).isEqualTo(1);
+  }
+
+  /**
+   * REDPANDAJ-2DR (Copilot review finding): {@code loopCommands}'s {@code finally} block must not
+   * blindly {@code compact()} the buffer once a handler has disconnected the peer mid-loop. {@link
+   * Peer#disconnect(String)} already resets the buffer to (position=0, limit=capacity) and returns
+   * that exact instance to {@link ByteBufferPool} — potentially to a different peer/thread already
+   * — so compacting it afterwards would corrupt whatever state the new owner sees. This drives a
+   * real disconnecting handler (negative update content length) through the actual loop instead of
+   * asserting on the guard directly.
+   */
+  @Test
+  public void loopCommands_doesNotTouchBufferAfterHandlerDisconnectsPeer() {
+    ServerContext serverContext = new ServerContext();
+    InboundCommandProcessor processor = new InboundCommandProcessor(serverContext);
+
+    ByteBuffer buffer = ByteBufferPool.borrowObject(1024);
+    buffer.put(Command.UPDATE_ANSWER_CONTENT);
+    buffer.putLong(Updater.MIN_UPDATE_TIMESTAMP_MS + 1_000_000L);
+    buffer.putInt(-1); // network-controlled negative length -> handler disconnects the peer
+    buffer.put(new byte[NodeId.SIGNATURE_LEN]);
+
+    Peer peer = getPeerForDebug();
+    serverContext.getPeerList().add(peer);
+    peer.setConnected(true);
+    peer.readBuffer = buffer;
+
+    processor.loopCommands(peer, buffer);
+
+    assertThat(peer.isConnected()).isFalse();
+    assertThat(peer.readBuffer)
+        .as("Peer.disconnect() must have returned the buffer, clearing the field")
+        .isNull();
+    // If loopCommands had wrongly compact()-ed the buffer after disconnect() already reset and
+    // returned it, position would be pulled up towards capacity instead of staying at 0.
+    assertThat(buffer.position()).isEqualTo(0);
+    assertThat(buffer.limit()).isEqualTo(buffer.capacity());
   }
 
   @Test

--- a/src/test/java/im/redpanda/flaschenpost/GMParserAdditionalTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/GMParserAdditionalTest.java
@@ -119,10 +119,82 @@ public class GMParserAdditionalTest {
     }
   }
 
-  @Test(expected = RuntimeException.class)
-  public void parseUnknownTypeThrows() {
+  @Test
+  public void parseUnknownTypeDrops() {
+    // An unknown type byte from the network must be dropped (null), not thrown — otherwise the
+    // exception unwinds the reader loop and the connection keeps retrying (Sentry REDPANDAJ-2DR).
     byte[] content = new byte[] {(byte) 99, 0, 0, 0};
-    GMParser.parse(ServerContext.buildDefaultServerContext(), content);
+    assertNull(GMParser.parse(ServerContext.buildDefaultServerContext(), content));
+  }
+
+  @Test
+  public void parseAckTypeWithGarbagePayloadDrops() {
+    // Reproduces REDPANDAJ-2DR: an end-to-end encrypted client payload whose first byte is 0x04
+    // (== GMType.ACK) followed by ciphertext. GMAck.parseContent throws on the bad length; parse
+    // must catch it, drop the packet and return null instead of unwinding the reader loop.
+    byte[] content =
+        new byte[] {GMType.ACK.getId(), (byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef, 0x2a};
+    assertNull(GMParser.parse(ServerContext.buildDefaultServerContext(), content));
+  }
+
+  @Test
+  public void parseAckTypeOnlyDrops() {
+    // A truncated ACK (type byte only, no length/ackid) must also be dropped, not throw.
+    byte[] content = new byte[] {GMType.ACK.getId()};
+    assertNull(GMParser.parse(ServerContext.buildDefaultServerContext(), content));
+  }
+
+  // --- REDPANDAJ-2DR: isValidFrame pre-check used by the FlaschenpostPut legacy path ---
+
+  @Test
+  public void isValidFrame_nullOrEmptyContent_isFalse() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    assertFalse(GMParser.isValidFrame(serverContext, null));
+    assertFalse(GMParser.isValidFrame(serverContext, new byte[0]));
+  }
+
+  @Test
+  public void isValidFrame_unknownTypeByte_isFalse() {
+    byte[] content = new byte[] {(byte) 99, 0, 0, 0};
+    assertFalse(GMParser.isValidFrame(ServerContext.buildDefaultServerContext(), content));
+  }
+
+  @Test
+  public void isValidFrame_malformedAck_isFalse() {
+    // Same shape as the REDPANDAJ-2DR reproduction: an E2E-encrypted payload whose first byte
+    // collides with GMType.ACK, followed by ciphertext that is not a valid GMAck body.
+    byte[] content =
+        new byte[] {GMType.ACK.getId(), (byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef, 0x2a};
+    assertFalse(GMParser.isValidFrame(ServerContext.buildDefaultServerContext(), content));
+  }
+
+  @Test
+  public void isValidFrame_truncatedAck_isFalse() {
+    byte[] content = new byte[] {GMType.ACK.getId()};
+    assertFalse(GMParser.isValidFrame(ServerContext.buildDefaultServerContext(), content));
+  }
+
+  @Test
+  public void isValidFrame_wellFormedAck_isTrue() {
+    ByteBuffer ack = ByteBuffer.allocate(1 + 4 + 4);
+    ack.put(GMType.ACK.getId());
+    ack.putInt(4);
+    ack.putInt(42);
+    assertTrue(GMParser.isValidFrame(ServerContext.buildDefaultServerContext(), ack.array()));
+  }
+
+  @Test
+  public void isValidFrame_wellFormedGarlicMessage_isTrue() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    byte[] content = garlicMessageBytes(serverContext, serverContext.getNodeId());
+    assertTrue(GMParser.isValidFrame(serverContext, content));
+  }
+
+  @Test
+  public void isValidFrame_malformedGarlicMessage_isFalse() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    byte[] content = new byte[] {GMType.GARLIC_MESSAGE.getId(), 0, 0, 0, 5, 1, 2}; // truncated
+    assertFalse(GMParser.isValidFrame(serverContext, content));
   }
 
   @Test


### PR DESCRIPTION
## Summary
Fixes the root cause of Sentry issue **REDPANDAJ-2DR** (`RuntimeException: len of GMAck wrong....490270178`, 605 events), per the backend part of the fix direction in `plans/sentry-rca-2026-07-13.md`, Section 1.

Root cause (RCA): a light client sends a `FlaschenpostPut` with an empty `oh_id` and content that is an E2E-encrypted client payload whose first byte (`0x04`) happens to collide with `GMType.ACK`. The legacy path (no explicit `oh_id`) falls through to `GMParser.parse`, which mistook the payload for a `GMAck`, and `GMAck.parseContent` threw on the bogus length. That `RuntimeException` unwound `InboundCommandProcessor.loopCommands`, skipping `readBuffer.compact()`, and the client's blind retries (every 30s for ~8h) turned into a fresh Sentry event each time.

## Changes
- **`InboundCommandProcessor.loopCommands`**: wrap the command loop in `try/finally` so `readBuffer.compact()` always runs, even if a handler throws — an escaping exception can no longer leave the read buffer in an inconsistent state.
- **`GMParser.parse`**: the `ACK` branch and the unknown-type branch now defensively drop malformed/unrecognized content (log + return `null`) instead of throwing, so a single bad frame can never bubble an exception into the reader loop.
- **`GMParser.isValidFrame`** (new): a side-effect-free structural pre-check (no dedup-store insert, no job lookups, no forwarding) — used by `InboundCommandProcessor.handleFlaschenpostPut` on the legacy (empty `oh_id`) path to distinguish "genuinely malformed/unrecognized content" from "valid but already-processed" content.
- **`handleFlaschenpostPut`**: a `FlaschenpostPut` with empty `oh_id` whose content is not a valid GM frame is now rejected explicitly with `BAD_REQUEST` (opt-in response only, per existing `respondToDeposit` convention) instead of being silently dropped — so a well-behaved sender learns the deposit failed instead of retrying blindly for hours.

Scope: backend only (redpandaj). The corresponding mobile-side fix (don't send a Direct-Deposit with empty `oh_id`) is being handled separately per the RCA.

## Test plan
- [x] Added/updated unit tests in `GMParserAdditionalTest` (parse defensiveness + new `isValidFrame` cases: null/empty, unknown type, malformed/truncated ACK, malformed Garlic message, well-formed ACK/Garlic message) and `InboundCommandProcessorFlaschenpostPutTest` (REDPANDAJ-2DR regression: malformed content doesn't throw; light client with `want_response` gets `BAD_REQUEST`; a valid legacy ACK is still processed normally, not rejected).
- [x] `mvn verify` passed twice in a row locally (318 tests, 0 failures, 1 skipped both runs).

Refs: Sentry REDPANDAJ-2DR, `plans/sentry-rca-2026-07-13.md`