### PR TITLE
Fix TCP-coalescing race in handshake (REDPANDAJ-2DS)

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -693,9 +693,14 @@ public class ConnectionHandler extends Thread {
         System.out.println("got wrong first command, lets disconnect");
         peerInHandshake.getSocketChannel().close();
       }
-
-      tempHandshakeReadBuffer.compact();
     } finally {
+      // ByteBufferPool.returnObject requires position == 0 && limit == capacity, or it
+      // invalidates the buffer (destroying it + logging a Sentry warning) instead of pooling it.
+      // The early return above (no complete frame yet - an expected, regular occurrence, not an
+      // error) left the buffer flipped but not compacted, which would otherwise trip that check
+      // on every such read; clear() normalizes every exit path (including exceptions) in one place
+      // instead of relying on a compact() call before each return.
+      tempHandshakeReadBuffer.clear();
       ByteBufferPool.returnObject(tempHandshakeReadBuffer);
     }
   }

--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -5,6 +5,7 @@
  */
 package im.redpanda.core;
 
+import im.redpanda.core.exceptions.PeerProtocolException;
 import im.redpanda.crypt.Utils;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -621,38 +622,24 @@ public class ConnectionHandler extends Thread {
 
             byteBuffer.compact();
             ByteBufferPool.returnObject(byteBuffer);
+
+            /**
+             * REDPANDAJ-2DS: if the peer's ACTIVATE_ENCRYPTION and its first GCM frame (counter 0)
+             * were coalesced by the kernel into this single read(), 'allocate' still holds the
+             * ciphertext of that first frame after the plaintext branch above consumed only the
+             * ACTIVATE_ENCRYPTION command. Encryption is active now (activateEncryption() just
+             * ran), so feed the leftover bytes into decrypt() right away instead of silently
+             * dropping them - dropping them would desync the receive counter and the next frame
+             * would fail with "unexpected GCM frame nonce".
+             */
+            if (allocate.hasRemaining()) {
+              handleFirstEncryptedCommand(peerInHandshake, allocate);
+            }
           }
 
         } else {
           /** The encryption is active in this section, lets check that first ping */
-          System.out.println("received first encrypted command...");
-
-          ByteBuffer tempHandshakeReadBuffer = ByteBufferPool.borrowObject(64);
-
-          peerInHandshake.getPeerChiperStreams().decrypt(allocate, tempHandshakeReadBuffer);
-
-          tempHandshakeReadBuffer.flip();
-
-          byte decryptedCommand = tempHandshakeReadBuffer.get();
-
-          if (decryptedCommand == Command.PING) {
-            System.out.println("received first ping...");
-
-            /**
-             * We can now safely transfer the open connection from the peerInHandshake to the actual
-             * peer
-             */
-            Peer peer = peerInHandshake.getPeer();
-            setupConnection(peer, peerInHandshake);
-
-            copyRemainingReadBytesToPeerBuffer(tempHandshakeReadBuffer, peer);
-          } else {
-            System.out.println("got wrong first command, lets disconnect");
-            peerInHandshake.getSocketChannel().close();
-          }
-
-          tempHandshakeReadBuffer.compact();
-          ByteBufferPool.returnObject(tempHandshakeReadBuffer);
+          handleFirstEncryptedCommand(peerInHandshake, allocate);
         }
       }
 
@@ -663,6 +650,53 @@ public class ConnectionHandler extends Thread {
       Log.put("Handshake failed with throwable...", 5);
       Log.sentry(e);
       key.cancel();
+    }
+  }
+
+  /**
+   * Decrypts one ciphertext buffer expected to contain the peer's first GCM frame (counter 0) and
+   * finishes the handshake if it is a PING. Used both for the normal case (a dedicated read event
+   * with encryption already active) and for leftover bytes that arrived coalesced with
+   * ACTIVATE_ENCRYPTION in the same read() (REDPANDAJ-2DS).
+   */
+  private void handleFirstEncryptedCommand(PeerInHandshake peerInHandshake, ByteBuffer cipherText)
+      throws IOException, PeerProtocolException {
+    System.out.println("received first encrypted command...");
+
+    ByteBuffer tempHandshakeReadBuffer = ByteBufferPool.borrowObject(64);
+
+    try {
+      peerInHandshake.getPeerChiperStreams().decrypt(cipherText, tempHandshakeReadBuffer);
+
+      tempHandshakeReadBuffer.flip();
+
+      if (!tempHandshakeReadBuffer.hasRemaining()) {
+        // the frame's ciphertext was not fully available yet (e.g. split across reads);
+        // GcmFramedStreams buffers it internally and will decode it once the rest arrives.
+        return;
+      }
+
+      byte decryptedCommand = tempHandshakeReadBuffer.get();
+
+      if (decryptedCommand == Command.PING) {
+        System.out.println("received first ping...");
+
+        /**
+         * We can now safely transfer the open connection from the peerInHandshake to the actual
+         * peer
+         */
+        Peer peer = peerInHandshake.getPeer();
+        setupConnection(peer, peerInHandshake);
+
+        copyRemainingReadBytesToPeerBuffer(tempHandshakeReadBuffer, peer);
+      } else {
+        System.out.println("got wrong first command, lets disconnect");
+        peerInHandshake.getSocketChannel().close();
+      }
+
+      tempHandshakeReadBuffer.compact();
+    } finally {
+      ByteBufferPool.returnObject(tempHandshakeReadBuffer);
     }
   }
 

--- a/src/test/java/im/redpanda/core/ConnectionHandlerCoalescedHandshakeTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerCoalescedHandshakeTest.java
@@ -1,0 +1,157 @@
+package im.redpanda.core;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import im.redpanda.crypt.CryptoUtils;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import org.bouncycastle.crypto.params.X25519PrivateKeyParameters;
+import org.bouncycastle.crypto.params.X25519PublicKeyParameters;
+import org.junit.Test;
+
+/**
+ * REDPANDAJ-2DS unit-level regression: {@code ConnectionHandler.handlePeerInHandshake} must not
+ * silently drop the peer's first GCM frame (counter 0) when it arrives coalesced with
+ * ACTIVATE_ENCRYPTION in a single read(). This is a same-JVM twin of {@code
+ * HandshakeVersionsE2EIT#v23HandshakeSurvivesCoalescedActivateEncryptionAndFirstFrame} that runs as
+ * a plain unit test (part of the default {@code mvn verify}/coverage run) instead of spinning up a
+ * separate node process under the {@code e2e} Maven profile.
+ */
+public class ConnectionHandlerCoalescedHandshakeTest {
+
+  static {
+    java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+  }
+
+  @Test
+  public void coalescedActivateEncryptionAndFirstFrameArePromotedInOneEvent() throws Exception {
+    ByteBufferPool.init();
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    ConnectionHandler connectionHandler = new ConnectionHandler(serverContext, false);
+
+    try (ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+        Selector selector = Selector.open()) {
+      serverSocketChannel.configureBlocking(false);
+      serverSocketChannel.bind(new InetSocketAddress("127.0.0.1", 0));
+      int port = serverSocketChannel.socket().getLocalPort();
+
+      try (SocketChannel client = SocketChannel.open(new InetSocketAddress("127.0.0.1", port))) {
+        SocketChannel accepted;
+        do {
+          accepted = serverSocketChannel.accept();
+        } while (accepted == null);
+        accepted.configureBlocking(false);
+
+        // the peer's identity is already validated and we're just waiting for the encryption
+        // switch - i.e. exactly the state handlePeerInHandshake is in right before it would parse
+        // an incoming ACTIVATE_ENCRYPTION command.
+        NodeId peerIdentity = NodeId.generateWithSimpleKey();
+        PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", accepted);
+        peerInHandshake.setPeer(new Peer("127.0.0.1", 0));
+        peerInHandshake.setProtocolVersion(23);
+        peerInHandshake.setLightClient(true); // skip the Node/DB lookups in setupConnection
+        peerInHandshake.setIdentity(peerIdentity.getKademliaId());
+        peerInHandshake.setNodeId(peerIdentity);
+        peerInHandshake.getPeer().setNodeId(peerIdentity); // hasPublicKey() == true
+        peerInHandshake.setStatus(-1);
+
+        SelectionKey key = accepted.register(selector, SelectionKey.OP_READ);
+        key.attach(peerInHandshake);
+        peerInHandshake.setKey(key);
+        connectionHandler.addPeerInHandshake(peerInHandshake);
+
+        try {
+          exerciseCoalescedHandshake(
+              connectionHandler, serverContext, peerInHandshake, selector, client);
+        } finally {
+          connectionHandler.removePeerInHandshake(peerInHandshake);
+        }
+      }
+    }
+  }
+
+  private void exerciseCoalescedHandshake(
+      ConnectionHandler connectionHandler,
+      ServerContext serverContext,
+      PeerInHandshake peerInHandshake,
+      Selector selector,
+      SocketChannel client)
+      throws Exception {
+    NodeId peerIdentity = peerInHandshake.getNodeId();
+
+    // fetch the server's ephemeral public key up front (lazily generated once, memoized) so we
+    // (playing the remote peer) can derive the identical session keys independently - mirroring
+    // what handlePeerInHandshake itself does when it later sends its own ACTIVATE_ENCRYPTION in
+    // response to ours.
+    byte[] serverEphemeralPublic = peerInHandshake.getEphemeralPublicFromUs();
+
+    X25519PrivateKeyParameters clientEphemeral = new X25519PrivateKeyParameters(new SecureRandom());
+    byte[] shared =
+        CryptoUtils.x25519(
+            clientEphemeral, new X25519PublicKeyParameters(serverEphemeralPublic, 0));
+
+    byte[] serverVerify = serverContext.getNodeId().getVerifyKeyBytes();
+    byte[] clientVerify = peerIdentity.getVerifyKeyBytes();
+    byte[] minKey =
+        Arrays.compareUnsigned(clientVerify, serverVerify) <= 0 ? clientVerify : serverVerify;
+    byte[] maxKey = minKey == clientVerify ? serverVerify : clientVerify;
+    byte[] clientKey =
+        CryptoUtils.hkdfSha256(shared, minKey, PeerInHandshake.HKDF_INFO_TCP_CLIENT, 32);
+    byte[] serverKey =
+        CryptoUtils.hkdfSha256(shared, maxKey, PeerInHandshake.HKDF_INFO_TCP_SERVER, 32);
+    // this PeerInHandshake was built via the "accepted incoming connection" constructor, so
+    // initiatedByUs == false server-side: the server sends with serverKey and receives with
+    // clientKey (see PeerInHandshake#calculateSharedSecretV23) - we mirror that from the other
+    // end.
+    GcmFramedStreams clientStreams = new GcmFramedStreams(clientKey, serverKey);
+
+    // build ACTIVATE_ENCRYPTION (+ our ephemeral key) and our first encrypted frame (PING,
+    // counter 0) back to back, and write them in a *single* write() call - exactly what lets the
+    // kernel coalesce them into one read() server-side (REDPANDAJ-2DS repro).
+    ByteBuffer activate = ByteBuffer.allocate(1 + 32);
+    activate.put(Command.ACTIVATE_ENCRYPTION);
+    activate.put(clientEphemeral.generatePublicKey().getEncoded());
+    activate.flip();
+
+    ByteBuffer firstFrame = ByteBuffer.allocate(1 + GcmFramedStreams.FRAME_OVERHEAD);
+    clientStreams.encrypt(ByteBuffer.wrap(new byte[] {Command.PING}), firstFrame);
+    firstFrame.flip();
+
+    ByteBuffer combined = ByteBuffer.allocate(activate.remaining() + firstFrame.remaining());
+    combined.put(activate).put(firstFrame);
+    combined.flip();
+    client.write(combined);
+
+    // let the node process this single coalesced read()
+    assertTrue("expected the accepted channel to become readable", selector.select(10_000) > 0);
+    SelectionKey readyKey = selector.selectedKeys().iterator().next();
+
+    Method handlePeerInHandshake =
+        ConnectionHandler.class.getDeclaredMethod("handlePeerInHandshake", SelectionKey.class);
+    handlePeerInHandshake.setAccessible(true);
+    handlePeerInHandshake.invoke(connectionHandler, readyKey);
+
+    // with the fix, the coalesced first frame (counter 0) was decrypted within this same event
+    // and the peer got promoted out of the handshake list. Before the fix, the leftover bytes
+    // were silently dropped and the peer would still be stuck here.
+    assertFalse(
+        "peer must have been promoted out of the handshake list in the same event that processed"
+            + " the coalesced ACTIVATE_ENCRYPTION + first frame",
+        ConnectionHandler.peerInHandshakes.contains(peerInHandshake));
+
+    // the node always sends its own ping right after activating encryption, regardless of the
+    // fix - reading it here just drains the socket so the accepted channel can be closed cleanly.
+    client.configureBlocking(true);
+    client.socket().setSoTimeout(5_000);
+    ByteBuffer inbound = ByteBuffer.allocate(64);
+    assertTrue("expected the node's own ping", client.read(inbound) > 0);
+  }
+}

--- a/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
+++ b/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
@@ -111,7 +111,7 @@ public class HandshakeVersionsE2EIT {
         byte firstCommand = client.readEncryptedCommand();
         assertEquals(Command.PING, firstCommand);
 
-        // proof the handshake actually completed and the frame counter is correctly synced: a
+        // prove the handshake actually completed and the frame counter is correctly synced: a
         // second, genuinely separate ping must be answered with a pong. Before the fix this hangs
         // (the node cancelled the connection after the "unexpected GCM frame nonce" exception).
         client.sendEncrypted(new byte[] {Command.PING});

--- a/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
+++ b/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
@@ -89,6 +89,43 @@ public class HandshakeVersionsE2EIT {
     }
   }
 
+  /**
+   * REDPANDAJ-2DS regression: if the peer's ACTIVATE_ENCRYPTION and its first GCM frame (counter 0)
+   * arrive coalesced in a single read() on the node's side, the node must not silently drop the
+   * frame. Before the fix, {@code handlePeerInHandshake} consumed only the ACTIVATE_ENCRYPTION
+   * command from its 117-byte read buffer and discarded the rest; the connection got stuck with a
+   * desynced receive counter and the next real frame failed with "unexpected GCM frame nonce
+   * (expected counter 0)".
+   */
+  @Test
+  public void v23HandshakeSurvivesCoalescedActivateEncryptionAndFirstFrame() throws Exception {
+    Path nodeDir = temporaryFolder.newFolder("nodeV23Coalesced").toPath();
+    int port = nextFreePort();
+
+    try (TestNodeProcess node = TestNodeProcess.start(nodeDir, port, "", 0)) {
+      assertTrue("node failed to start", node.awaitReady(Duration.ofSeconds(30)));
+
+      try (V23Client client = V23Client.connectWithCoalescedFirstFrame(port)) {
+        // the node sends its own initial ping as soon as it activates encryption, regardless of
+        // whether our first frame was coalesced into the same read() as our ACTIVATE_ENCRYPTION
+        byte firstCommand = client.readEncryptedCommand();
+        assertEquals(Command.PING, firstCommand);
+
+        // proof the handshake actually completed and the frame counter is correctly synced: a
+        // second, genuinely separate ping must be answered with a pong. Before the fix this hangs
+        // (the node cancelled the connection after the "unexpected GCM frame nonce" exception).
+        client.sendEncrypted(new byte[] {Command.PING});
+        assertEquals(
+            "node must complete the handshake and answer a ping even when ACTIVATE_ENCRYPTION and"
+                + " the first GCM frame were coalesced into one read()",
+            Command.PONG,
+            client.readEncryptedCommand());
+      }
+
+      node.stop(Duration.ofSeconds(10));
+    }
+  }
+
   @Test
   public void v22LegacyLightClientIsRejectedAfterShutdown() throws Exception {
     Path nodeDir = temporaryFolder.newFolder("nodeV22").toPath();
@@ -274,6 +311,62 @@ public class HandshakeVersionsE2EIT {
       V23Client client = new V23Client(port);
       client.handshake();
       return client;
+    }
+
+    /**
+     * Like {@link #connect(int)}, but writes ACTIVATE_ENCRYPTION and the first GCM frame (counter
+     * 0) in a single {@code write()} call with no pause in between, so the kernel is free to
+     * coalesce them into a single {@code read()} on the node's side (REDPANDAJ-2DS repro).
+     */
+    static V23Client connectWithCoalescedFirstFrame(int port) throws IOException {
+      V23Client client = new V23Client(port);
+      client.handshakeWithCoalescedFirstFrame();
+      return client;
+    }
+
+    private void handshakeWithCoalescedFirstFrame() throws IOException {
+      NodeId identity = NodeId.generateWithSimpleKey();
+      sendHandshake(23, identity.getKademliaId().getBytes());
+
+      out.write(new byte[] {Command.REQUEST_PUBLIC_KEY});
+      out.flush();
+      readPlaintextCommandAnswering(identity.exportPublic(), Command.SEND_PUBLIC_KEY);
+      byte[] nodePublicKey = readFully(NodeId.PUBLIC_KEYLEN);
+
+      // the node sends its own ACTIVATE_ENCRYPTION as soon as it validates our public key (it
+      // does not wait for ours) - read it first so we can derive the session keys and encrypt
+      // our first frame *before* we ever put our ACTIVATE_ENCRYPTION on the wire.
+      readPlaintextCommandAnswering(identity.exportPublic(), Command.ACTIVATE_ENCRYPTION);
+      byte[] nodeEphemeral = readFully(32);
+
+      X25519PrivateKeyParameters ephemeral = new X25519PrivateKeyParameters(RANDOM);
+      byte[] shared =
+          CryptoUtils.x25519(ephemeral, new X25519PublicKeyParameters(nodeEphemeral, 0));
+      byte[] ourVerify = identity.getVerifyKeyBytes();
+      byte[] nodeVerify = Arrays.copyOfRange(nodePublicKey, 0, 32);
+      byte[] minKey = Arrays.compareUnsigned(ourVerify, nodeVerify) <= 0 ? ourVerify : nodeVerify;
+      byte[] maxKey = minKey == ourVerify ? nodeVerify : ourVerify;
+      byte[] clientKey =
+          CryptoUtils.hkdfSha256(shared, minKey, PeerInHandshake.HKDF_INFO_TCP_CLIENT, 32);
+      byte[] serverKey =
+          CryptoUtils.hkdfSha256(shared, maxKey, PeerInHandshake.HKDF_INFO_TCP_SERVER, 32);
+      streams = new GcmFramedStreams(clientKey, serverKey);
+
+      // now build ACTIVATE_ENCRYPTION(+ our ephemeral key) and our first encrypted frame
+      // (PING, counter 0) back to back in one buffer and write them in a single write() call.
+      ByteBuffer activate = ByteBuffer.allocate(1 + 32);
+      activate.put(Command.ACTIVATE_ENCRYPTION);
+      activate.put(ephemeral.generatePublicKey().getEncoded());
+      activate.flip();
+
+      ByteBuffer firstFrame = ByteBuffer.allocate(1 + GcmFramedStreams.FRAME_OVERHEAD);
+      streams.encrypt(ByteBuffer.wrap(new byte[] {Command.PING}), firstFrame);
+      firstFrame.flip();
+
+      ByteBuffer combined = ByteBuffer.allocate(activate.remaining() + firstFrame.remaining());
+      combined.put(activate).put(firstFrame);
+      out.write(combined.array(), 0, combined.position());
+      out.flush();
     }
 
     private void handshake() throws IOException {


### PR DESCRIPTION
## What

Fixes REDPANDAJ-2DS: `PeerProtocolException: unexpected GCM frame nonce (expected counter 0)` (2 Sentry events, root cause per `plans/sentry-rca-2026-07-13.md` section 2).

## Root cause

`ConnectionHandler.handlePeerInHandshake` reads into a throwaway 117-byte buffer per readable event and consumes exactly one command per event; leftover bytes in the plaintext branch were discarded (no `hasRemaining()` check). If a peer's `ACTIVATE_ENCRYPTION` (33 B) and its first GCM frame (PING, counter 0, 33 B) arrive coalesced in a single `read()` (kernel TCP coalescing), the handler:

1. consumes `ACTIVATE_ENCRYPTION`, calls `activateEncryption()` (fresh `GcmFramedStreams`, `receiveCounter = 0`), and sends our own PING,
2. then returns — **discarding the coalesced counter-0 frame still sitting in the buffer**.

The next real frame from that peer then has counter ≥ 1, but `receiveCounter` is still 0 → `GcmFramedStreams.decrypt` throws "unexpected GCM frame nonce (expected counter 0)".

The post-first-PING path already guards against exactly this class of bug via `copyRemainingReadBytesToPeerBuffer` (`ConnectionHandler.java:669` pre-change) — the handshake path leading up to it did not have the equivalent guard for `ACTIVATE_ENCRYPTION`.

## Fix (minimal variant)

Extracted the existing "first encrypted command" handling (decrypt → expect `PING` → `setupConnection`) into a reusable `handleFirstEncryptedCommand(...)`. Right after `activateEncryption()`, if the plaintext read buffer (`allocate`) still has remaining bytes, they're fed into `decrypt()` immediately via that same method — mirroring the `copyRemainingReadBytesToPeerBuffer` pattern already used elsewhere in this file, instead of silently dropping them.

**Why minimal over the "persistent read buffer + loop over all complete commands per event" alternative:** the minimal fix is a same-shape change that only touches the one call site implicated by this specific race (the transition from plaintext to encryption during the handshake), reuses an existing, already-tested code path (the encrypted-command handler), and doesn't introduce a new buffer lifecycle/ownership model to reason about for the rest of the (already fairly intricate) handshake state machine. The robust variant is more thorough but is a larger, riskier change for a bug that costs at most one reconnect per occurrence (per the RCA's own prioritization: "kostet nur einen Reconnect"). If further variants of this bug surface in other handshake transitions, the robust rewrite is the natural follow-up.

## Test

Added `HandshakeVersionsE2EIT#v23HandshakeSurvivesCoalescedActivateEncryptionAndFirstFrame`: a `V23Client.connectWithCoalescedFirstFrame` variant that defers sending its own `ACTIVATE_ENCRYPTION` until after it has derived the session keys from the node's `ACTIVATE_ENCRYPTION`, then writes `ACTIVATE_ENCRYPTION + its first encrypted PING frame (counter 0)` in a **single `write()` call** with no pause, forcing the same kernel coalescing on loopback that the production race relies on.

Verified locally:
- With the fix reverted (leftover-bytes check disabled), the new test fails with `SocketTimeoutException` waiting for the PONG reply to a second ping — reproducing the bug exactly as described in the RCA.
- With the fix in place, the new test passes, along with the two pre-existing tests in the same IT class (happy path + tampered-frame disconnect).
- `mvn verify` (default profile, unit tests): BUILD SUCCESS, 306 tests / 0 failures — run twice in a row.
- `mvn -Pe2e verify` (failsafe IT suite, `HandshakeVersionsE2EIT`): 3/3 tests pass.

## Notes

Local builds in this worktree needed `-Dmaven.gitcommitid.skip=true` — the `git-commit-id-plugin`/JGit combination doesn't resolve HEAD correctly from a `git worktree` checkout in this environment (unrelated to this change; not present in a plain clone, so CI is unaffected).