### PR TITLE
Offload update-receive disk I/O off the ConnectionReaderThread (REDPANDAJ-2DQ)

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionReaderThread.java
+++ b/src/main/java/im/redpanda/core/ConnectionReaderThread.java
@@ -568,11 +568,15 @@ public class ConnectionReaderThread implements Runnable {
       long diff = System.currentTimeMillis() - a;
 
       if (diff > 5000L) {
-        // Enriched with the last command byte and peer so the event is self-explanatory without
-        // having to correlate timestamps against other log lines (REDPANDAJ-2DQ).
+        // Enriched with the peer and the last successfully-parsed command byte (unsigned, since
+        // command bytes go up to 141 and print negative as a plain signed byte) so the event is
+        // self-explanatory without having to correlate timestamps against other log lines
+        // (REDPANDAJ-2DQ). Note peer.lastCommand reflects the last command parsed in this read
+        // batch, which is the stalling one only if a single command was processed; if several
+        // commands were parsed in one read(), an earlier one in the same batch may be the culprit.
         Log.sentry(
-            "command took over 5 seconds to parse: %d ms, last command byte: %d, peer: %s"
-                .formatted(diff, peer.lastCommand, peer));
+            "command took over 5 seconds to parse: %d ms, last parsed command byte: %d, peer: %s"
+                .formatted(diff, Byte.toUnsignedInt(peer.lastCommand), peer));
       }
 
       ConnectionHandler.doneRead.add(peer);

--- a/src/main/java/im/redpanda/core/ConnectionReaderThread.java
+++ b/src/main/java/im/redpanda/core/ConnectionReaderThread.java
@@ -568,7 +568,11 @@ public class ConnectionReaderThread implements Runnable {
       long diff = System.currentTimeMillis() - a;
 
       if (diff > 5000L) {
-        Log.sentry("command took over 5 seconds to parse: %s".formatted(diff));
+        // Enriched with the last command byte and peer so the event is self-explanatory without
+        // having to correlate timestamps against other log lines (REDPANDAJ-2DQ).
+        Log.sentry(
+            "command took over 5 seconds to parse: %d ms, last command byte: %d, peer: %s"
+                .formatted(diff, peer.lastCommand, peer));
       }
 
       ConnectionHandler.doneRead.add(peer);

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -644,6 +644,10 @@ public class InboundCommandProcessor {
                 try {
                   Thread.sleep(2000);
                 } catch (InterruptedException e) {
+                  // Preserve the interrupt status and skip the restart instead of silently
+                  // continuing as if the delay had completed normally (e.g. on shutdown).
+                  Thread.currentThread().interrupt();
+                  return;
                 }
                 restartAction.run();
               });
@@ -876,7 +880,10 @@ public class InboundCommandProcessor {
     try (FileOutputStream fos = new FileOutputStream(updateApkPath().toFile())) {
       fos.write(data);
     } catch (IOException e) {
+      // Do not persist the new timestamp/signature if the apk was not actually written: that
+      // would make LocalSettings claim an update is installed while the file is missing/corrupt.
       e.printStackTrace();
+      return;
     }
     serverContext.getLocalSettings().setUpdateAndroidTimestamp(othersTimestamp);
     serverContext.getLocalSettings().setUpdateAndroidSignature(signature);

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -52,6 +52,14 @@ public class InboundCommandProcessor {
    */
   static Runnable restartAction = () -> System.exit(0);
 
+  /**
+   * Test-only hook invoked with the thread that performs the update install disk I/O ({@link
+   * #installJarUpdate} / {@link #installApkUpdate}); lets tests assert the write actually runs off
+   * the calling (ConnectionReaderThread, in production) thread (REDPANDAJ-2DQ). No-op in
+   * production.
+   */
+  static java.util.function.Consumer<Thread> installThreadHookForTests = t -> {};
+
   /** System property overriding {@link #updateJarPath()}; used by tests to avoid CWD sharing. */
   private static final String JAR_PATH_PROPERTY = "redpanda.update.jar.path";
 
@@ -587,47 +595,63 @@ public class InboundCommandProcessor {
         return consumedBytes;
       }
 
-      try (FileOutputStream fos = new FileOutputStream("tmp_redpanda.jar")) {
-        fos.write(data);
-      } catch (IOException e) {
-        Log.sentry(e);
-        return consumedBytes;
-      }
-
-      try {
-        // Install the update
-        // Save to 'update' file so the shell script can pick it up and restart
-        Files.move(
-            Path.of("tmp_redpanda.jar"), Path.of("update"), StandardCopyOption.REPLACE_EXISTING);
-
-        // Update local settings
-        serverContext.getLocalSettings().setUpdateTimestamp(othersTimestamp);
-        serverContext.getLocalSettings().setUpdateSignature(signatureBytes);
-        serverContext.getLocalSettings().save(serverContext.getPort());
-
-        System.out.println(
-            "Update successfully verified and saved to 'update'. New timestamp: "
-                + othersTimestamp);
-        System.out.println("Stopping server to apply update...");
-
-        // Exit asynchronously to allow current method to return and log to be written
-        // Exit asynchronously to allow current method to return and log to be written
-        Thread.ofVirtual()
-            .start(
-                () -> {
-                  try {
-                    Thread.sleep(2000);
-                  } catch (InterruptedException e) {
-                  }
-                  restartAction.run();
-                });
-
-      } catch (IOException e) {
-        Log.sentry(e);
-        System.out.println("Failed to install update: " + e.getMessage());
-      }
+      // Writing the (potentially tens-of-MB) jar to disk, moving it into place and persisting
+      // settings are blocking disk I/O; offload it to the thread pool so the ConnectionReaderThread
+      // is not stalled while it happens (REDPANDAJ-2DQ), matching the request-side handlers (see
+      // handleUpdateRequestContent above). Everything the reader thread would otherwise need to
+      // read from the connection buffer has already been captured above (othersTimestamp,
+      // signatureBytes, data), so nothing here races the reader moving on to the next command.
+      ConnectionReaderThread.threadPool.submit(
+          () -> installJarUpdate(othersTimestamp, signatureBytes, data));
     }
     return consumedBytes;
+  }
+
+  /**
+   * Writes a verified jar update to disk, installs it and triggers the restart. Runs on {@link
+   * ConnectionReaderThread#threadPool}, off the ConnectionReaderThread (REDPANDAJ-2DQ) — keep the
+   * write, move, settings save and restart trigger together and in this order so the process never
+   * restarts (or persists a timestamp/signature) before the jar is actually in place.
+   */
+  private void installJarUpdate(long othersTimestamp, byte[] signatureBytes, byte[] data) {
+    installThreadHookForTests.accept(Thread.currentThread());
+    try (FileOutputStream fos = new FileOutputStream("tmp_redpanda.jar")) {
+      fos.write(data);
+    } catch (IOException e) {
+      Log.sentry(e);
+      return;
+    }
+
+    try {
+      // Install the update
+      // Save to 'update' file so the shell script can pick it up and restart
+      Files.move(
+          Path.of("tmp_redpanda.jar"), Path.of("update"), StandardCopyOption.REPLACE_EXISTING);
+
+      // Update local settings
+      serverContext.getLocalSettings().setUpdateTimestamp(othersTimestamp);
+      serverContext.getLocalSettings().setUpdateSignature(signatureBytes);
+      serverContext.getLocalSettings().save(serverContext.getPort());
+
+      System.out.println(
+          "Update successfully verified and saved to 'update'. New timestamp: " + othersTimestamp);
+      System.out.println("Stopping server to apply update...");
+
+      // Exit asynchronously to allow current method to return and log to be written
+      Thread.ofVirtual()
+          .start(
+              () -> {
+                try {
+                  Thread.sleep(2000);
+                } catch (InterruptedException e) {
+                }
+                restartAction.run();
+              });
+
+    } catch (IOException e) {
+      Log.sentry(e);
+      System.out.println("Failed to install update: " + e.getMessage());
+    }
   }
 
   private int handleAndroidUpdateRequestTimestamp(Peer peer) {
@@ -833,16 +857,30 @@ public class InboundCommandProcessor {
         return consumedBytes;
       }
 
-      try (FileOutputStream fos = new FileOutputStream(updateApkPath().toFile())) {
-        fos.write(data);
-      } catch (IOException e) {
-        e.printStackTrace();
-      }
-      serverContext.getLocalSettings().setUpdateAndroidTimestamp(othersTimestamp);
-      serverContext.getLocalSettings().setUpdateAndroidSignature(signature);
-      serverContext.getLocalSettings().save(serverContext.getPort());
+      // Writing the apk to disk and persisting settings is blocking disk I/O; offload it to the
+      // thread pool so the ConnectionReaderThread is not stalled while it happens (REDPANDAJ-2DQ),
+      // matching the request-side handlers. othersTimestamp/signature/data are already captured
+      // above so nothing here races the reader moving on to the next command.
+      ConnectionReaderThread.threadPool.submit(
+          () -> installApkUpdate(othersTimestamp, signature, data));
     }
     return consumedBytes;
+  }
+
+  /**
+   * Writes a verified apk update to disk and persists the new timestamp/signature. Runs on {@link
+   * ConnectionReaderThread#threadPool}, off the ConnectionReaderThread (REDPANDAJ-2DQ).
+   */
+  private void installApkUpdate(long othersTimestamp, byte[] signature, byte[] data) {
+    installThreadHookForTests.accept(Thread.currentThread());
+    try (FileOutputStream fos = new FileOutputStream(updateApkPath().toFile())) {
+      fos.write(data);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    serverContext.getLocalSettings().setUpdateAndroidTimestamp(othersTimestamp);
+    serverContext.getLocalSettings().setUpdateAndroidSignature(signature);
+    serverContext.getLocalSettings().save(serverContext.getPort());
   }
 
   private void handleJobAck(byte[] payload, Peer peer) throws InvalidProtocolBufferException {

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorUpdateHardeningTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorUpdateHardeningTest.java
@@ -42,6 +42,7 @@ public class InboundCommandProcessorUpdateHardeningTest {
   public void cleanup() {
     Updater.resetPublicUpdaterKeyForTests();
     InboundCommandProcessor.restartAction = () -> System.exit(0);
+    InboundCommandProcessor.installThreadHookForTests = t -> {};
     new File("tmp_redpanda.jar").delete();
     new File("update").delete();
     new File(ConnectionReaderThread.ANDROID_UPDATE_FILE).delete();
@@ -188,6 +189,84 @@ public class InboundCommandProcessorUpdateHardeningTest {
     // JVM (this test process) is still alive to observe it.
     awaitCondition(() -> restartCount.get() == 1, 5000);
     assertEquals(1, restartCount.get());
+  }
+
+  @Test
+  public void validUpdate_offloadsDiskWriteToThreadPool() throws Exception {
+    // Regression test for REDPANDAJ-2DQ: handleUpdateAnswerContent used to do its
+    // FileOutputStream/Files.move/LocalSettings.save work synchronously on the calling thread
+    // (the ConnectionReaderThread in production), which could stall the reader for as long as the
+    // disk write takes. Assert the write happens off the calling thread.
+    NodeId testKey = new NodeId();
+    Updater.setPublicUpdaterKeyForTests(testKey);
+
+    // Must not fall through to the default restartAction (System.exit(0)) — this test's install
+    // really does succeed and reach the restart trigger 2s later, on a background thread that
+    // outlives this test method. If we returned before it fires, @After's cleanup() would already
+    // have reset restartAction back to the System.exit(0) default by the time it does, killing the
+    // Surefire fork mid-suite — so, like validUpdate_installs_andInvokesRestartAction, we must wait
+    // for it here instead of just no-op-ing and returning early.
+    AtomicInteger restartCount = new AtomicInteger();
+    InboundCommandProcessor.restartAction = restartCount::incrementAndGet;
+
+    java.util.concurrent.atomic.AtomicReference<Thread> writerThread =
+        new java.util.concurrent.atomic.AtomicReference<>();
+    InboundCommandProcessor.installThreadHookForTests = writerThread::set;
+
+    byte[] data = "fake-jar-bytes-for-offload-check".getBytes();
+    long othersTs = Updater.MIN_UPDATE_TIMESTAMP_MS + 1_000_000L;
+    ByteBuffer toHash = ByteBuffer.allocate(8 + data.length);
+    toHash.putLong(othersTs);
+    toHash.put(data);
+    byte[] sig = testKey.sign(toHash.array());
+
+    ByteBuffer in = buildUpdateAnswerContent(othersTs, sig, data);
+
+    Thread callingThread = Thread.currentThread();
+    int consumed = proc.parseCommand(Command.UPDATE_ANSWER_CONTENT, in, newPeer(8814));
+    assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
+
+    File updateFile = new File("update");
+    awaitCondition(updateFile::exists, 5000);
+    awaitCondition(() -> writerThread.get() != null, 5000);
+
+    assertFalse(
+        "the jar write/install must not run on the calling (reader) thread",
+        callingThread.equals(writerThread.get()));
+
+    // Wait for the delayed restart trigger too (see comment above) so cleanup() doesn't race it.
+    awaitCondition(() -> restartCount.get() == 1, 5000);
+    assertEquals(1, restartCount.get());
+  }
+
+  @Test
+  public void androidValidUpdate_installsAsynchronously() throws Exception {
+    // Android analog of validUpdate_installs_andInvokesRestartAction: no positive-path test
+    // existed for handleAndroidUpdateAnswerContent before REDPANDAJ-2DQ moved its disk write off
+    // the ConnectionReaderThread; assert the eventual side effects (apk file + settings) land.
+    NodeId testKey = new NodeId();
+    Updater.setPublicUpdaterKeyForTests(testKey);
+
+    byte[] data = "fake-apk-bytes".getBytes();
+    long othersTs = Updater.MIN_UPDATE_TIMESTAMP_MS + 1_000_000L;
+    ByteBuffer toHash = ByteBuffer.allocate(8 + data.length);
+    toHash.putLong(othersTs);
+    toHash.put(data);
+    byte[] sig = testKey.sign(toHash.array());
+
+    ByteBuffer in = buildUpdateAnswerContent(othersTs, sig, data);
+
+    int consumed = proc.parseCommand(Command.ANDROID_UPDATE_ANSWER_CONTENT, in, newPeer(8815));
+    assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
+
+    File apkFile = new File(ConnectionReaderThread.ANDROID_UPDATE_FILE);
+    awaitCondition(apkFile::exists, 5000);
+    assertTrue(
+        "installed apk file must contain the received data",
+        java.util.Arrays.equals(data, Files.readAllBytes(apkFile.toPath())));
+
+    awaitCondition(() -> ctx.getLocalSettings().getUpdateAndroidTimestamp() == othersTs, 5000);
+    assertTrue(java.util.Arrays.equals(sig, ctx.getLocalSettings().getUpdateAndroidSignature()));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes Sentry issue **REDPANDAJ-2DQ** (`command took over 5 seconds to parse: 7481`, single event on the testnet Raspi). Root cause and analysis: `plans/sentry-rca-2026-07-13.md`, section 3.

`handleUpdateAnswerContent` and `handleAndroidUpdateAnswerContent` wrote the received jar/apk (`FileOutputStream` + `Files.move` + `LocalSettings.save`) and, for the jar, triggered the restart synchronously on the `ConnectionReaderThread` that owns the connection — unlike the request-side handlers (`handleUpdateRequestContent`, `handleAndroidUpdateRequestContent`), which already offload their disk reads to `ConnectionReaderThread.threadPool`. On slow storage (the RCA's working theory: a ~35MB jar written to an SD card during the 2026-07-12 testnet deploy) this can stall the reader thread well past the 5-second logging threshold.

- Moved the write/move/settings-save (and, for the jar, the restart trigger) into a private helper (`installJarUpdate` / `installApkUpdate`) submitted to `threadPool`, matching the existing request-side pattern.
- Everything the handler needs from the connection buffer (timestamp, signature, data) is already read into local variables before the async submission, so nothing races the reader thread moving on to the next command.
- The write, move, settings save and restart trigger stay together and in order inside the async task, so the process never restarts (or persists a new timestamp/signature) before the update is actually in place on disk.
- Enriched the `"command took over 5 seconds to parse"` log in `ConnectionReaderThread` with the last command byte and peer, so future events are self-explanatory.

## Tests

- Added a test-only `installThreadHookForTests` seam (mirrors the existing `restartAction` test seam) plus:
  - `validUpdate_offloadsDiskWriteToThreadPool` — regression test asserting the jar write actually runs off the calling thread.
  - `androidValidUpdate_installsAsynchronously` — first positive-path install test for the Android APK receive handler (previously only its rejection paths were covered).
- `mvn verify` passes twice in a row locally (308 tests, 0 failures).

## Test plan

- [x] `mvn verify` green, twice in a row, locally
- [ ] CI green