### PR TITLE
Fix stale readBuffer reference corrupting ByteBufferPool on grow (REDPANDAJ-2DT/2DV)

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionReaderThread.java
+++ b/src/main/java/im/redpanda/core/ConnectionReaderThread.java
@@ -352,10 +352,15 @@ public class ConnectionReaderThread implements Runnable {
       peer.readBuffer = ByteBufferPool.borrowObject(myReaderBuffer.position());
     }
 
-    ByteBuffer readBuffer = peer.readBuffer;
-
     /** Decrypt all bytes from the readBufferCrypted to the readBuffer */
     peer.decryptInputData(myReaderBuffer);
+
+    // decryptInputData() may have grown the plaintext buffer: it returns the old, now-stale
+    // buffer instance to the ByteBufferPool and stores a larger one in peer.readBuffer. We must
+    // therefore read peer.readBuffer AFTER decrypting — using a reference captured beforehand
+    // would hand a pooled/reused buffer to loopCommands, whose flip()/compact() then corrupts
+    // pool state (observed as an invalid ByteBuffer[pos=0 lim=0] on the next borrowObject).
+    ByteBuffer readBuffer = peer.readBuffer;
 
     inboundProcessor.loopCommands(peer, readBuffer);
 

--- a/src/test/java/im/redpanda/core/PeerTest.java
+++ b/src/test/java/im/redpanda/core/PeerTest.java
@@ -192,6 +192,57 @@ public class PeerTest {
     assertThat(peer.readBuffer.getLong()).isEqualTo(longToTest);
   }
 
+  /**
+   * Regression for REDPANDAJ-2DT / REDPANDAJ-2DV: when {@code decryptInputData} must grow the
+   * plaintext buffer it returns the old, too-small buffer instance to the {@link ByteBufferPool}
+   * and stores a new, larger one in {@code peer.readBuffer}. A caller (ConnectionReaderThread) that
+   * captured a reference to {@code peer.readBuffer} <em>before</em> the call must therefore re-read
+   * the field afterwards — continuing to use the stale reference flips/compacts a buffer that is
+   * already idle in the pool, corrupting it to {@code pos=0 lim=0} and surfacing later as
+   * "borrowObject found an invalid ByteBuffer". This test pins the swap-and-return contract that
+   * the fix relies on.
+   */
+  @Test
+  public void decryptInputDataGrow_swapsReadBufferAndReturnsOldInstanceToPool()
+      throws PeerProtocolException,
+          NoSuchPaddingException,
+          NoSuchAlgorithmException,
+          NoSuchProviderException,
+          InvalidAlgorithmParameterException,
+          InvalidKeyException {
+    Peer peer = new Peer("ip", 59558, new NodeId());
+
+    setUpTestCipherStreams(peer);
+
+    peer.readBuffer = ByteBufferPool.borrowObject(16);
+    // Mimic ConnectionReaderThread.readConnection capturing the reference before decrypting.
+    ByteBuffer staleReferenceBeforeDecrypt = peer.readBuffer;
+    assertThat(staleReferenceBeforeDecrypt.remaining()).isEqualTo(16);
+
+    long longToTest = new Random().nextLong();
+    ByteBuffer bufferIn = ByteBuffer.allocate(60);
+    bufferIn.putLong(longToTest);
+    bufferIn.putLong(longToTest);
+    bufferIn.putLong(longToTest);
+    ByteBuffer bufferOut = ByteBuffer.allocate(60);
+    bufferIn.flip();
+    peer.getPeerChiperStreams().encrypt(bufferIn, bufferOut);
+
+    peer.decryptInputData(bufferOut);
+
+    // The buffer had to grow, so peer.readBuffer must now be a different, larger instance...
+    assertThat(peer.readBuffer)
+        .as("decryptInputData must swap in a larger buffer on growth")
+        .isNotSameAs(staleReferenceBeforeDecrypt);
+    assertThat(peer.readBuffer.capacity()).isGreaterThan(staleReferenceBeforeDecrypt.capacity());
+
+    // ...and the old instance must have been handed back to the pool in a valid, idle state
+    // (pos=0, lim=cap). The bug corrupted exactly this buffer via a stale caller reference.
+    assertThat(staleReferenceBeforeDecrypt.position()).isEqualTo(0);
+    assertThat(staleReferenceBeforeDecrypt.limit())
+        .isEqualTo(staleReferenceBeforeDecrypt.capacity());
+  }
+
   private void setUpTestCipherStreams(Peer peer)
       throws NoSuchAlgorithmException,
           NoSuchProviderException,


### PR DESCRIPTION
## Problem
Sentry **REDPANDAJ-2DT** (29 events) and duplicate **REDPANDAJ-2DV** (cap=16):
`borrowObject found an invalid ByteBuffer: java.nio.HeapByteBuffer[pos=0 lim=0 cap=1024]`

## Root cause
`ConnectionReaderThread.readConnection` captured `peer.readBuffer` into a local variable **before** calling `Peer.decryptInputData()`. When the decrypted plaintext exceeds the buffer capacity, `decryptInputData` grows the buffer: it returns the old (too-small) instance to the `ByteBufferPool` and stores a new, larger buffer in `peer.readBuffer`.

The stale local reference was then passed to `loopCommands()`, whose `readBuffer.flip()` mutated a buffer that was **already idle in the pool**, flipping it from `pos=0 lim=cap` to `pos=0 lim=0`. The next `borrowObject()` on that key then detected the corruption and logged the Sentry message. (The `cap=16` duplicate is the same bug when the readBuffer started at the smallest pool key.)

This only fires on the buffer-grow path, matching the low, intermittent event count.

## Fix
Read `peer.readBuffer` **after** `decryptInputData` so `loopCommands` always operates on the current buffer instance, never one that was already handed back to the pool. One-line reorder plus an explanatory comment.

## Test
Added `PeerTest.decryptInputDataGrow_swapsReadBufferAndReturnsOldInstanceToPool` pinning the grow-path swap/return contract the fix relies on. Targeted run: `PeerTest, ByteBufferPoolTest, ConnectionReaderThreadTest, ParseCommandTest` — 19 run, 0 failures.

Fixes REDPANDAJ-2DT
Fixes REDPANDAJ-2DV

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhBG4xBs5hrsyUi8tGYPvc