### PR TITLE
fix(flaschenpost): shrink first-contact message-drop window

### DIFF
--- a/src/main/java/im/redpanda/App.java
+++ b/src/main/java/im/redpanda/App.java
@@ -169,7 +169,8 @@ public class App {
     new OhAnnounceJob(serverContext).start();
     serverContext
         .getOutboundService()
-        .setOhRegisteredListener(ohId -> OhAnnounceJob.announceSoon(serverContext, ohId));
+        .setOhRegisteredListener(
+            ohId -> OhAnnounceJob.announceNewRegistration(serverContext, ohId));
   }
 
   private static void initLogger() {

--- a/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
+++ b/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
@@ -75,9 +75,19 @@ public final class OhForwarder {
       byte[] sessionTag,
       byte[] returnPath) {
     if (hopCount >= MAX_HOPS) {
+      // Hop-limit drop. This is the ONLY drop point that returns false, i.e. reports the drop
+      // back to the synchronous caller. The caller (InboundCommandProcessor#handleFlaschenpostPut)
+      // is still able to answer the peer here and sends the HANDLE_EXPIRED R-ACK itself, so we
+      // MUST NOT ack here — doing so would double-ack the packet. All drops that happen inside the
+      // asynchronous resolve callbacks below (resolve failure, no route) are the opposite case: the
+      // caller has already answered OK and can no longer ack, so those paths ack here instead.
       log.debug("dropping FlaschenpostPut for unknown OH at hop limit {}", hopCount);
       return false;
     }
+    // Parse the MS06 return path once for the R-ACK. The raw bytes are still forwarded verbatim on
+    // the wire (routeToNode below); this parsed copy only decides whether an async drop can ack.
+    // A malformed/absent block yields null → keep the pre-MS06 silent-drop behavior.
+    ReturnPath ackPath = parseAckPath(returnPath);
     OhResolveJob.resolve(
         serverContext,
         ohId,
@@ -90,10 +100,36 @@ public final class OhForwarder {
               content,
               hopCount,
               sessionTag,
-              returnPath);
+              returnPath,
+              ackPath);
         },
-        () -> log.debug("OH host resolution failed, dropping forwarded deposit"));
+        () -> onResolveFailed(serverContext, ackPath));
     return true;
+  }
+
+  /**
+   * Parses the raw return-path bytes into a {@link ReturnPath} for R-ACK purposes. Returns {@code
+   * null} when no return path was carried or the block is malformed — in both cases the caller
+   * keeps the silent-drop behavior (there is nobody safe to ack).
+   */
+  static ReturnPath parseAckPath(byte[] returnPath) {
+    if (returnPath == null || returnPath.length == 0) {
+      return null;
+    }
+    return ReturnPath.parseExact(returnPath);
+  }
+
+  /**
+   * Async resolve-failure drop: the sender was already answered OK by the caller, so without this
+   * R-ACK it would wait out its full R-ACK timeout. Sends exactly one {@code HANDLE_EXPIRED} ack
+   * when the deposit carried a valid return path (see the double-ack invariant in {@link
+   * #forward(ServerContext, byte[], byte[], int, byte[], byte[])}); otherwise a plain silent drop.
+   */
+  static void onResolveFailed(ServerContext serverContext, ReturnPath ackPath) {
+    log.debug("OH host resolution failed, dropping forwarded deposit");
+    if (ackPath != null) {
+      RoutingAckSender.send(serverContext, ackPath, RoutingAckSender.STATUS_HANDLE_EXPIRED);
+    }
   }
 
   /**
@@ -107,10 +143,19 @@ public final class OhForwarder {
       byte[] content,
       int hopCount,
       byte[] sessionTag,
-      byte[] returnPath) {
+      byte[] returnPath,
+      ReturnPath ackPath) {
     Peer nextPeer = selectNextPeer(serverContext, targetNodeId);
     if (nextPeer != null) {
       GMParser.sendFpToPeer(nextPeer, content, ohId, hopCount + 1, sessionTag, returnPath);
+      return;
+    }
+    // Resolved the host node but found no usable next hop: another async drop after the caller
+    // already answered OK. Ack HANDLE_EXPIRED (best available status) so the sender does not wait
+    // out its timeout. This runs only on the resolve-SUCCESS branch, mutually exclusive with the
+    // resolve-failure ack in onResolveFailed, so still exactly one ack per packet.
+    if (ackPath != null) {
+      RoutingAckSender.send(serverContext, ackPath, RoutingAckSender.STATUS_HANDLE_EXPIRED);
     }
   }
 

--- a/src/main/java/im/redpanda/jobs/OhAnnounceJob.java
+++ b/src/main/java/im/redpanda/jobs/OhAnnounceJob.java
@@ -29,6 +29,23 @@ public class OhAnnounceJob extends Job {
   /** Maximum randomized stagger for a single announce within one job run. */
   static final long ANNOUNCE_STAGGER_MS = Duration.ofSeconds(30).toMillis();
 
+  /**
+   * Maximum randomized stagger for the very first announce of a <em>freshly registered</em> OH.
+   *
+   * <p>Deliberately tiny (a couple of seconds) so the first deposits for a brand-new handle become
+   * resolvable quickly instead of losing them into the up-to-{@link #ANNOUNCE_STAGGER_MS} window (a
+   * sender that reaches the host node before its announce lands is answered OK and then silently
+   * dropped, so it waits out its full R-ACK timeout).
+   *
+   * <p>Anti-profiling note: the full {@link #ANNOUNCE_STAGGER_MS} stagger exists to hide the timing
+   * of the <em>periodic</em> re-announces — a stable set of OHs re-announcing on a schedule is a
+   * fingerprint. A single fresh registration's announce timing reveals nothing the host node did
+   * not already learn from the registration itself, so a prompt announce here is safe. The periodic
+   * re-announce path ({@link #work()} → {@link #announceSoon(ServerContext, byte[])}) MUST keep the
+   * full stagger.
+   */
+  static final long NEW_REGISTRATION_STAGGER_MS = Duration.ofSeconds(2).toMillis();
+
   /** First run shortly after startup (jobs run immediately otherwise). */
   private static final long INITIAL_DELAY_MS = Duration.ofSeconds(20).toMillis();
 
@@ -60,24 +77,57 @@ public class OhAnnounceJob extends Job {
   }
 
   /**
-   * Schedules a single announce for {@code ohId} after a randomized delay (anti-profiling stagger).
-   * Also used directly after a successful RegisterOh so fresh handles become resolvable without
-   * waiting for the next periodic run.
+   * Schedules a single announce for {@code ohId} using the full {@link #ANNOUNCE_STAGGER_MS}
+   * anti-profiling stagger. This is the periodic re-announce path; for a freshly registered handle
+   * use {@link #announceNewRegistration(ServerContext, byte[])} instead so the first deposits are
+   * not lost while the announce is still staggered.
    */
   public static void announceSoon(ServerContext serverContext, byte[] ohId) {
-    new SingleAnnounceJob(serverContext, ohId).start();
+    new SingleAnnounceJob(serverContext, ohId, ANNOUNCE_STAGGER_MS).start();
+  }
+
+  /**
+   * Schedules the very first announce for a newly registered OH with only a small jitter ({@link
+   * #NEW_REGISTRATION_STAGGER_MS}) so fresh handles become resolvable promptly instead of waiting
+   * out the full stagger (and dropping the sender's first deposits). See {@link
+   * #NEW_REGISTRATION_STAGGER_MS} for why the short stagger is safe here while the periodic
+   * re-announce must keep the full one.
+   */
+  public static void announceNewRegistration(ServerContext serverContext, byte[] ohId) {
+    new SingleAnnounceJob(serverContext, ohId, NEW_REGISTRATION_STAGGER_MS).start();
   }
 
   /** One-shot job that builds and inserts the announce record after its randomized delay. */
   static class SingleAnnounceJob extends Job {
 
     private final byte[] ohId;
+    private final long maxStaggerMs;
+    private final long delayMs;
 
-    SingleAnnounceJob(ServerContext serverContext, byte[] ohId) {
+    SingleAnnounceJob(ServerContext serverContext, byte[] ohId, long maxStaggerMs) {
+      // sample the randomized delay first, then hand it to the primary constructor (super(...)
+      // must be the first statement, so the sampling cannot live inline below)
+      this(serverContext, ohId, maxStaggerMs, rand.nextLong(maxStaggerMs + 1));
+    }
+
+    /** Visible for testing: constructs the job with an explicit (already sampled) delay. */
+    SingleAnnounceJob(ServerContext serverContext, byte[] ohId, long maxStaggerMs, long delayMs) {
       // skipImminentRun=true → the single work() run happens after the randomized delay,
-      // sampled uniformly from [0, ANNOUNCE_STAGGER_MS]
-      super(serverContext, rand.nextLong(ANNOUNCE_STAGGER_MS + 1), false, true);
+      // sampled uniformly from [0, maxStaggerMs]
+      super(serverContext, delayMs, false, true);
       this.ohId = ohId;
+      this.maxStaggerMs = maxStaggerMs;
+      this.delayMs = delayMs;
+    }
+
+    /** Visible for testing: the randomized delay this announce was scheduled with. */
+    long getDelayMs() {
+      return delayMs;
+    }
+
+    /** Visible for testing: the stagger bound this announce was created with. */
+    long getMaxStaggerMs() {
+      return maxStaggerMs;
     }
 
     @Override

--- a/src/test/java/im/redpanda/flaschenpost/OhForwarderTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/OhForwarderTest.java
@@ -35,6 +35,8 @@ public class OhForwarderTest {
   private ServerContext nodeA;
 
   private InboundCommandProcessor processorA;
+  private OutboundHandleStore handleStoreA;
+  private OutboundMailboxStore mailboxA;
 
   /** Host node B — hosts the OH mailbox. */
   private ServerContext nodeB;
@@ -48,8 +50,9 @@ public class OhForwarderTest {
   @Before
   public void setUp() {
     nodeA = ServerContext.buildDefaultServerContext();
-    nodeA.setOutboundService(
-        new OutboundService(new OutboundHandleStore(), new OutboundMailboxStore()));
+    handleStoreA = new OutboundHandleStore();
+    mailboxA = new OutboundMailboxStore();
+    nodeA.setOutboundService(new OutboundService(handleStoreA, mailboxA));
     processorA = new InboundCommandProcessor(nodeA);
 
     nodeB = ServerContext.buildDefaultServerContext();
@@ -169,6 +172,96 @@ public class OhForwarderTest {
   public void routeToNode_withoutDirectPeer_dropsWhenNoCloserCandidate() {
     // No peers at all — routing must simply drop without throwing
     OhForwarder.routeToNode(
-        nodeA, NodeId.generateWithSimpleKey().getKademliaId(), ohId, new byte[8], 0, null, null);
+        nodeA,
+        NodeId.generateWithSimpleKey().getKademliaId(),
+        ohId,
+        new byte[8],
+        0,
+        null,
+        null,
+        null);
+  }
+
+  // --- MS06 R-ACK on async drop (first-delivery-latency) ---
+
+  /** Registers an ack-OH mailbox on node A and returns a hop_count=0 return path for it. */
+  private ReturnPath registerLocalAckPathA() {
+    byte[] ackOhId = new byte[KademliaId.ID_LENGTH_BYTES];
+    RANDOM.nextBytes(ackOhId);
+    long now = System.currentTimeMillis();
+    handleStoreA.put(
+        ackOhId, new OutboundHandleStore.HandleRecord(new byte[65], now, now + 60_000));
+    byte[] ackSessionTag = new byte[OutboundService.SESSION_TAG_BYTES];
+    RANDOM.nextBytes(ackSessionTag);
+    return new ReturnPath(ackOhId, ackSessionTag, List.of());
+  }
+
+  /** Fetches the single R-ACK deposited into node A's ack-OH mailbox, asserting exactly one. */
+  private im.redpanda.outbound.v1.RoutingAck fetchSingleAckA(ReturnPath ackPath) throws Exception {
+    List<MailItem> items = mailboxA.fetchMessages(ackPath.ackOhId(), 10, 0);
+    assertThat(items).hasSize(1);
+    return im.redpanda.outbound.v1.RoutingAck.parseFrom(items.get(0).getPayload().toByteArray());
+  }
+
+  @Test
+  public void resolveFailure_withReturnPath_sendsExactlyOneHandleExpiredAck() throws Exception {
+    ReturnPath ackPath = registerLocalAckPathA();
+
+    // simulate the async resolve-failure callback directly (a real DHT search would only fail
+    // after a randomized network round-trip — the callback is the unit under test)
+    OhForwarder.onResolveFailed(nodeA, ackPath);
+
+    im.redpanda.outbound.v1.RoutingAck rAck = fetchSingleAckA(ackPath);
+    assertThat(rAck.getStatus()).isEqualTo(RoutingAckSender.STATUS_HANDLE_EXPIRED);
+  }
+
+  @Test
+  public void resolveFailure_withoutReturnPath_isPlainDrop() {
+    // parseAckPath returns null for absent / empty return paths → no ack, no exception
+    assertThat(OhForwarder.parseAckPath(null)).isNull();
+    assertThat(OhForwarder.parseAckPath(new byte[0])).isNull();
+    OhForwarder.onResolveFailed(nodeA, null); // must not throw and must deposit nothing
+  }
+
+  @Test
+  public void parseAckPath_malformedReturnPath_isNullSoDropStaysSilent() {
+    // a structurally invalid return-path block must NOT ack (nobody safe to ack) — plain drop
+    assertThat(OhForwarder.parseAckPath(new byte[] {1, 2, 3})).isNull();
+    OhForwarder.onResolveFailed(nodeA, OhForwarder.parseAckPath(new byte[] {1, 2, 3}));
+  }
+
+  @Test
+  public void noRoute_withReturnPath_sendsExactlyOneHandleExpiredAck() throws Exception {
+    ReturnPath ackPath = registerLocalAckPathA();
+
+    // resolve succeeded but there is no peer to forward toward → async no-route drop must ack
+    OhForwarder.routeToNode(
+        nodeA,
+        NodeId.generateWithSimpleKey().getKademliaId(),
+        ohId,
+        new byte[8],
+        0,
+        null,
+        null,
+        ackPath);
+
+    im.redpanda.outbound.v1.RoutingAck rAck = fetchSingleAckA(ackPath);
+    assertThat(rAck.getStatus()).isEqualTo(RoutingAckSender.STATUS_HANDLE_EXPIRED);
+  }
+
+  @Test
+  public void hopLimitDrop_doesNotAck_soCallerAcksWithoutDoubleAck() throws Exception {
+    // a valid, LOCALLY resolvable ack path so any accidental ack would land where we can see it
+    ReturnPath ackPath = registerLocalAckPathA();
+
+    boolean accepted =
+        OhForwarder.forward(
+            nodeA, ohId, new byte[8], OhForwarder.MAX_HOPS, null, ackPath.serialize());
+
+    // forward must report the drop (false) so the caller acks; it must NOT ack here itself
+    assertThat(accepted).isFalse();
+    assertThat(mailboxA.fetchMessages(ackPath.ackOhId(), 10, 0))
+        .as("hop-limit drop must not ack — the caller does")
+        .isEmpty();
   }
 }

--- a/src/test/java/im/redpanda/jobs/OhAnnounceJobTest.java
+++ b/src/test/java/im/redpanda/jobs/OhAnnounceJobTest.java
@@ -1,0 +1,60 @@
+package im.redpanda.jobs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import im.redpanda.core.ServerContext;
+import im.redpanda.jobs.OhAnnounceJob.SingleAnnounceJob;
+import java.security.SecureRandom;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * First-delivery-latency: a freshly registered OH must announce promptly (small jitter) so the
+ * first deposits are not lost, while the periodic re-announce keeps the full anti-profiling
+ * stagger. Verifies the two announce paths are scheduled with the correct stagger bound.
+ */
+public class OhAnnounceJobTest {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private ServerContext serverContext;
+  private byte[] ohId;
+
+  @Before
+  public void setUp() {
+    serverContext = ServerContext.buildDefaultServerContext();
+    ohId = new byte[20];
+    RANDOM.nextBytes(ohId);
+  }
+
+  @Test
+  public void newRegistrationStagger_isShortAndStrictlyBelowFullStagger() {
+    assertThat(OhAnnounceJob.NEW_REGISTRATION_STAGGER_MS).isEqualTo(2_000L);
+    assertThat(OhAnnounceJob.ANNOUNCE_STAGGER_MS).isEqualTo(30_000L);
+    assertThat(OhAnnounceJob.NEW_REGISTRATION_STAGGER_MS)
+        .as("a fresh registration must announce faster than the periodic re-announce")
+        .isLessThan(OhAnnounceJob.ANNOUNCE_STAGGER_MS);
+  }
+
+  @Test
+  public void newRegistration_isScheduledWithinTheShortStagger() {
+    // sample many times: a new registration is never scheduled beyond the short stagger bound
+    for (int i = 0; i < 1_000; i++) {
+      SingleAnnounceJob job =
+          new SingleAnnounceJob(serverContext, ohId, OhAnnounceJob.NEW_REGISTRATION_STAGGER_MS);
+      assertThat(job.getMaxStaggerMs()).isEqualTo(OhAnnounceJob.NEW_REGISTRATION_STAGGER_MS);
+      assertThat(job.getDelayMs()).isBetween(0L, OhAnnounceJob.NEW_REGISTRATION_STAGGER_MS);
+    }
+  }
+
+  @Test
+  public void periodicReAnnounce_keepsTheFullStagger() {
+    // the periodic path is scheduled with the full anti-profiling stagger bound
+    for (int i = 0; i < 1_000; i++) {
+      SingleAnnounceJob job =
+          new SingleAnnounceJob(serverContext, ohId, OhAnnounceJob.ANNOUNCE_STAGGER_MS);
+      assertThat(job.getMaxStaggerMs()).isEqualTo(OhAnnounceJob.ANNOUNCE_STAGGER_MS);
+      assertThat(job.getDelayMs()).isBetween(0L, OhAnnounceJob.ANNOUNCE_STAGGER_MS);
+    }
+  }
+}

--- a/src/test/java/im/redpanda/jobs/OhAnnounceJobTest.java
+++ b/src/test/java/im/redpanda/jobs/OhAnnounceJobTest.java
@@ -2,6 +2,7 @@ package im.redpanda.jobs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import im.redpanda.core.KademliaId;
 import im.redpanda.core.ServerContext;
 import im.redpanda.jobs.OhAnnounceJob.SingleAnnounceJob;
 import java.security.SecureRandom;
@@ -23,7 +24,7 @@ public class OhAnnounceJobTest {
   @Before
   public void setUp() {
     serverContext = ServerContext.buildDefaultServerContext();
-    ohId = new byte[20];
+    ohId = new byte[KademliaId.ID_LENGTH_BYTES];
     RANDOM.nextBytes(ohId);
   }
 


### PR DESCRIPTION
Two related first-delivery-latency fixes for freshly registered Outbound Handles (OHs). Both shrink the window in which a fresh OH's first deposits are silently lost, forcing senders to wait out the full 90 s R-ACK timeout (live smoke test showed 2-3 attempts needed for first delivery on the 3-node testnet).

## Task A — prompt first announce for newly registered OHs
`App.java` now wires the `OhRegisteredListener` to `OhAnnounceJob.announceNewRegistration`, which schedules the first announce with a small **0-2 s** jitter (`NEW_REGISTRATION_STAGGER_MS`) instead of the **0-30 s** anti-profiling stagger (`ANNOUNCE_STAGGER_MS`).

The periodic re-announce path (`work()` -> `announceSoon`) keeps the full 30 s stagger — that is where the anti-profiling property matters (a stable set of OHs re-announcing on a schedule is fingerprintable). A single fresh registration's announce timing reveals nothing the host node did not already learn from the registration itself; the reasoning is documented in the Javadoc.

## Task B — R-ACK instead of silent drop on OH resolve failure
`OhForwarder`'s asynchronous drops (resolve failure, and the newly-covered no-route case) now send exactly one `HANDLE_EXPIRED` routing ack via `RoutingAckSender` when the deposit carried a valid MS06 return path. Previously these only logged, so the sender — already answered OK by the caller — waited out its timeout.

**Double-ack invariant (documented in comments):** the hop-limit drop is the only path that returns `false` to the synchronous caller (`InboundCommandProcessor`), which acks it itself — `OhForwarder` must not ack there. All async drops happen after the caller answered OK and can no longer ack, so those ack in the forwarder. The resolve success/failure callbacks are mutually exclusive (`OhResolveJob` guarantees exactly one fires), so at most one ack per packet. A malformed or absent return path yields a plain silent drop (nobody safe to ack).

## Tests
- `OhAnnounceJobTest` (new): new-registration announce is scheduled within the short 0-2 s stagger; periodic path keeps the full 0-30 s stagger; short stagger is strictly below the full one.
- `OhForwarderTest` (extended): resolve-failure with a return path sends exactly one `HANDLE_EXPIRED` ack; without a return path (and with a malformed one) it stays a plain drop; the no-route case acks; the hop-limit drop does **not** ack (no double-ack — the caller acks).

Full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhBG4xBs5hrsyUi8tGYPvc