### PR TITLE
fix(flaschenpost): retry parked deposits instead of dropping on OH resolve failure

### DIFF
--- a/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
+++ b/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
@@ -178,7 +178,15 @@ public final class OhForwarder {
       log.debug("pending-deposit buffer full, dropping without retry");
       return false;
     }
-    new RetryDepositJob(serverContext, deposit).start();
+    try {
+      new RetryDepositJob(serverContext, deposit).start();
+    } catch (RuntimeException e) {
+      // scheduling failed (e.g. executor shutting down) — undo the reservation so the buffer
+      // cannot leak full, and let the caller fall back to the immediate final drop
+      pendingRetries.decrementAndGet();
+      log.debug("failed to schedule deposit retry, dropping: {}", e.getMessage());
+      return false;
+    }
     return true;
   }
 

--- a/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
+++ b/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
@@ -5,11 +5,14 @@ import im.redpanda.core.Node;
 import im.redpanda.core.Peer;
 import im.redpanda.core.PeerList;
 import im.redpanda.core.ServerContext;
+import im.redpanda.jobs.Job;
 import im.redpanda.jobs.OhResolveJob;
 import im.redpanda.kademlia.PeerComparator;
+import im.redpanda.outbound.OutboundService;
 import im.redpanda.store.NodeEdge;
 import java.util.ArrayList;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,6 +30,36 @@ public final class OhForwarder {
 
   /** Maximum number of node-to-node forwards before a packet is dropped. */
   public static final int MAX_HOPS = 3;
+
+  /**
+   * Delay before the single retry of a deposit whose first host resolution failed. Chosen to cover
+   * the observed race window: a light client whose OH registration was cut off re-registers after
+   * its 10 s response timeout, so by retry time the OH is registered (and announced) again.
+   */
+  static final long RETRY_DELAY_MS = 15_000;
+
+  /**
+   * Cap on concurrently parked deposits awaiting their retry. Each payload is at most {@link
+   * im.redpanda.outbound.OutboundMailboxStore#MAX_ITEM_BYTES} (pre-checked by the caller), so the
+   * buffer is memory-bounded at ~4 MiB; the single fixed-delay retry doubles as the TTL.
+   */
+  static final int MAX_PENDING_RETRIES = 64;
+
+  /** Number of currently parked deposits. Package-private for tests. */
+  static final AtomicInteger pendingRetries = new AtomicInteger();
+
+  /**
+   * Everything needed to re-attempt a deposit after a failed host resolution. {@code returnPath}
+   * keeps the raw wire bytes (forwarded verbatim), {@code ackPath} the parsed copy that decides
+   * whether a drop can R-ACK (both may be {@code null}).
+   */
+  record PendingDeposit(
+      byte[] ohId,
+      byte[] content,
+      int hopCount,
+      byte[] sessionTag,
+      byte[] returnPath,
+      ReturnPath ackPath) {}
 
   private OhForwarder() {}
 
@@ -88,22 +121,14 @@ public final class OhForwarder {
     // the wire (routeToNode below); this parsed copy only decides whether an async drop can ack.
     // A malformed/absent block yields null → keep the pre-MS06 silent-drop behavior.
     ReturnPath ackPath = parseAckPath(returnPath);
+    PendingDeposit deposit =
+        new PendingDeposit(ohId, content, hopCount, sessionTag, returnPath, ackPath);
     OhResolveJob.resolve(
         serverContext,
         ohId,
-        record -> {
-          byte[] nodeIdBytes = record.getNodeId().toByteArray();
-          routeToNode(
-              serverContext,
-              new KademliaId(nodeIdBytes),
-              ohId,
-              content,
-              hopCount,
-              sessionTag,
-              returnPath,
-              ackPath);
-        },
-        () -> onResolveFailed(serverContext, ackPath));
+        record ->
+            routeToNode(serverContext, new KademliaId(record.getNodeId().toByteArray()), deposit),
+        () -> onResolveFailed(serverContext, deposit, false));
     return true;
   }
 
@@ -120,42 +145,144 @@ public final class OhForwarder {
   }
 
   /**
-   * Async resolve-failure drop: the sender was already answered OK by the caller, so without this
-   * R-ACK it would wait out its full R-ACK timeout. Sends exactly one {@code HANDLE_EXPIRED} ack
+   * Async resolve-failure handling. A first failure does NOT drop: the announce record of a freshly
+   * (re-)registered OH may simply not exist yet — the observed failure mode is a light client whose
+   * registration was cut off mid-connection, re-registering ~10 s later while the sender's deposit
+   * already arrived (T32). The deposit is parked for a single delayed retry instead (bounded
+   * buffer, see {@link #MAX_PENDING_RETRIES}).
+   *
+   * <p>Only the retry's failure ({@code finalAttempt}) or a full buffer drops for real. The sender
+   * was already answered OK by the caller, so the drop sends exactly one {@code HANDLE_EXPIRED} ack
    * when the deposit carried a valid return path (see the double-ack invariant in {@link
    * #forward(ServerContext, byte[], byte[], int, byte[], byte[])}); otherwise a plain silent drop.
    */
-  static void onResolveFailed(ServerContext serverContext, ReturnPath ackPath) {
+  static void onResolveFailed(
+      ServerContext serverContext, PendingDeposit deposit, boolean finalAttempt) {
+    if (!finalAttempt && parkForRetry(serverContext, deposit)) {
+      return;
+    }
     log.debug("OH host resolution failed, dropping forwarded deposit");
-    if (ackPath != null) {
-      RoutingAckSender.send(serverContext, ackPath, RoutingAckSender.STATUS_HANDLE_EXPIRED);
+    if (deposit.ackPath() != null) {
+      RoutingAckSender.send(
+          serverContext, deposit.ackPath(), RoutingAckSender.STATUS_HANDLE_EXPIRED);
     }
   }
 
   /**
-   * Routes the packet toward {@code targetNodeId}: directly if connected, otherwise via the
-   * cheapest next hop in the weighted node graph (same selection as garlic routing).
+   * Parks the deposit for one delayed retry. Returns {@code false} when the bounded buffer is full
+   * — the caller then drops immediately (pre-retry behavior).
+   */
+  private static boolean parkForRetry(ServerContext serverContext, PendingDeposit deposit) {
+    if (pendingRetries.incrementAndGet() > MAX_PENDING_RETRIES) {
+      pendingRetries.decrementAndGet();
+      log.debug("pending-deposit buffer full, dropping without retry");
+      return false;
+    }
+    new RetryDepositJob(serverContext, deposit).start();
+    return true;
+  }
+
+  /**
+   * The delayed retry: tries the local deposit first — the observed race is the OH (re-)registering
+   * on THIS node right after the failed resolve, which needs no announce record at all — then
+   * resolves again. The second resolve failure is final.
+   */
+  static void retryDeposit(ServerContext serverContext, PendingDeposit deposit) {
+    if (depositLocally(serverContext, deposit)) {
+      return;
+    }
+    OhResolveJob.resolve(
+        serverContext,
+        deposit.ohId(),
+        record ->
+            routeToNode(serverContext, new KademliaId(record.getNodeId().toByteArray()), deposit),
+        () -> onResolveFailed(serverContext, deposit, true));
+  }
+
+  /**
+   * Attempts the local deposit for a parked or self-resolved packet. Returns {@code true} when the
+   * deposit was decided here (stored or terminally rejected, with the matching R-ACK when a return
+   * path was carried), {@code false} when the OH is unknown locally and the caller should keep
+   * resolving/routing.
+   */
+  private static boolean depositLocally(ServerContext serverContext, PendingDeposit deposit) {
+    OutboundService outboundService = serverContext.getOutboundService();
+    if (outboundService == null) {
+      return false;
+    }
+    OutboundService.DepositResult result =
+        outboundService.depositMessage(deposit.ohId(), deposit.content(), deposit.sessionTag());
+    if (result == OutboundService.DepositResult.NOT_FOUND) {
+      return false;
+    }
+    if (deposit.ackPath() != null) {
+      RoutingAckSender.send(serverContext, deposit.ackPath(), RoutingAckSender.statusFor(result));
+    }
+    return true;
+  }
+
+  /**
+   * Routes the packet toward {@code targetNodeId}: deposited locally if the record points at this
+   * node itself (the OH registered here between the local NOT_FOUND check and the resolve
+   * callback), directly if connected, otherwise via the cheapest next hop in the weighted node
+   * graph (same selection as garlic routing).
    */
   static void routeToNode(
-      ServerContext serverContext,
-      KademliaId targetNodeId,
-      byte[] ohId,
-      byte[] content,
-      int hopCount,
-      byte[] sessionTag,
-      byte[] returnPath,
-      ReturnPath ackPath) {
+      ServerContext serverContext, KademliaId targetNodeId, PendingDeposit deposit) {
+    KademliaId self = serverContext.getNonce();
+    if (self != null && targetNodeId.equals(self)) {
+      if (!depositLocally(serverContext, deposit) && deposit.ackPath() != null) {
+        // announce points at us but the OH is not registered here (expired/revoked) — final drop
+        RoutingAckSender.send(
+            serverContext, deposit.ackPath(), RoutingAckSender.STATUS_HANDLE_EXPIRED);
+      }
+      return;
+    }
     Peer nextPeer = selectNextPeer(serverContext, targetNodeId);
     if (nextPeer != null) {
-      GMParser.sendFpToPeer(nextPeer, content, ohId, hopCount + 1, sessionTag, returnPath);
+      GMParser.sendFpToPeer(
+          nextPeer,
+          deposit.content(),
+          deposit.ohId(),
+          deposit.hopCount() + 1,
+          deposit.sessionTag(),
+          deposit.returnPath());
       return;
     }
     // Resolved the host node but found no usable next hop: another async drop after the caller
     // already answered OK. Ack HANDLE_EXPIRED (best available status) so the sender does not wait
     // out its timeout. This runs only on the resolve-SUCCESS branch, mutually exclusive with the
     // resolve-failure ack in onResolveFailed, so still exactly one ack per packet.
-    if (ackPath != null) {
-      RoutingAckSender.send(serverContext, ackPath, RoutingAckSender.STATUS_HANDLE_EXPIRED);
+    if (deposit.ackPath() != null) {
+      RoutingAckSender.send(
+          serverContext, deposit.ackPath(), RoutingAckSender.STATUS_HANDLE_EXPIRED);
+    }
+  }
+
+  /** One-shot job holding a parked deposit until its single delayed retry fires. */
+  static class RetryDepositJob extends Job {
+
+    private final PendingDeposit deposit;
+
+    RetryDepositJob(ServerContext serverContext, PendingDeposit deposit) {
+      // skipImminentRun: only the delayed run does work, mirroring OhResolveJob.DelayedSearchJob
+      super(serverContext, RETRY_DELAY_MS, false, true);
+      this.deposit = deposit;
+    }
+
+    @Override
+    public void init() {
+      // no setup needed
+    }
+
+    @Override
+    public void work() {
+      try {
+        pendingRetries.decrementAndGet();
+        retryDeposit(serverContext, deposit);
+      } finally {
+        done();
+      }
     }
   }
 

--- a/src/test/java/im/redpanda/flaschenpost/OhForwarderTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/OhForwarderTest.java
@@ -172,14 +172,13 @@ public class OhForwarderTest {
   public void routeToNode_withoutDirectPeer_dropsWhenNoCloserCandidate() {
     // No peers at all — routing must simply drop without throwing
     OhForwarder.routeToNode(
-        nodeA,
-        NodeId.generateWithSimpleKey().getKademliaId(),
-        ohId,
-        new byte[8],
-        0,
-        null,
-        null,
-        null);
+        nodeA, NodeId.generateWithSimpleKey().getKademliaId(), deposit(new byte[8], null));
+  }
+
+  /** Builds a parked-deposit record as OhForwarder.forward would for the given return path. */
+  private OhForwarder.PendingDeposit deposit(byte[] content, ReturnPath ackPath) {
+    return new OhForwarder.PendingDeposit(
+        ohId, content, 0, null, ackPath == null ? null : ackPath.serialize(), ackPath);
   }
 
   // --- MS06 R-ACK on async drop (first-delivery-latency) ---
@@ -204,30 +203,33 @@ public class OhForwarderTest {
   }
 
   @Test
-  public void resolveFailure_withReturnPath_sendsExactlyOneHandleExpiredAck() throws Exception {
+  public void resolveFailure_finalAttempt_withReturnPath_sendsExactlyOneHandleExpiredAck()
+      throws Exception {
     ReturnPath ackPath = registerLocalAckPathA();
 
-    // simulate the async resolve-failure callback directly (a real DHT search would only fail
-    // after a randomized network round-trip — the callback is the unit under test)
-    OhForwarder.onResolveFailed(nodeA, ackPath);
+    // simulate the async resolve-failure callback of the RETRY directly (a real DHT search would
+    // only fail after a randomized network round-trip — the callback is the unit under test)
+    OhForwarder.onResolveFailed(nodeA, deposit(new byte[8], ackPath), true);
 
     im.redpanda.outbound.v1.RoutingAck rAck = fetchSingleAckA(ackPath);
     assertThat(rAck.getStatus()).isEqualTo(RoutingAckSender.STATUS_HANDLE_EXPIRED);
   }
 
   @Test
-  public void resolveFailure_withoutReturnPath_isPlainDrop() {
+  public void resolveFailure_finalAttempt_withoutReturnPath_isPlainDrop() {
     // parseAckPath returns null for absent / empty return paths → no ack, no exception
     assertThat(OhForwarder.parseAckPath(null)).isNull();
     assertThat(OhForwarder.parseAckPath(new byte[0])).isNull();
-    OhForwarder.onResolveFailed(nodeA, null); // must not throw and must deposit nothing
+    // must not throw and must deposit nothing
+    OhForwarder.onResolveFailed(nodeA, deposit(new byte[8], null), true);
   }
 
   @Test
   public void parseAckPath_malformedReturnPath_isNullSoDropStaysSilent() {
     // a structurally invalid return-path block must NOT ack (nobody safe to ack) — plain drop
     assertThat(OhForwarder.parseAckPath(new byte[] {1, 2, 3})).isNull();
-    OhForwarder.onResolveFailed(nodeA, OhForwarder.parseAckPath(new byte[] {1, 2, 3}));
+    OhForwarder.onResolveFailed(
+        nodeA, deposit(new byte[8], OhForwarder.parseAckPath(new byte[] {1, 2, 3})), true);
   }
 
   @Test
@@ -236,15 +238,94 @@ public class OhForwarderTest {
 
     // resolve succeeded but there is no peer to forward toward → async no-route drop must ack
     OhForwarder.routeToNode(
-        nodeA,
-        NodeId.generateWithSimpleKey().getKademliaId(),
-        ohId,
-        new byte[8],
-        0,
-        null,
-        null,
-        ackPath);
+        nodeA, NodeId.generateWithSimpleKey().getKademliaId(), deposit(new byte[8], ackPath));
 
+    im.redpanda.outbound.v1.RoutingAck rAck = fetchSingleAckA(ackPath);
+    assertThat(rAck.getStatus()).isEqualTo(RoutingAckSender.STATUS_HANDLE_EXPIRED);
+  }
+
+  // --- T32: parked retry instead of first-failure drop ---
+
+  @Test
+  public void resolveFailure_firstAttempt_parksForRetryInsteadOfDropping() throws Exception {
+    ReturnPath ackPath = registerLocalAckPathA();
+    int parkedBefore = OhForwarder.pendingRetries.get();
+
+    OhForwarder.onResolveFailed(nodeA, deposit(new byte[8], ackPath), false);
+
+    // no drop, no ack yet — the deposit is parked for the delayed retry
+    assertThat(OhForwarder.pendingRetries.get()).isEqualTo(parkedBefore + 1);
+    assertThat(mailboxA.fetchMessages(ackPath.ackOhId(), 10, 0))
+        .as("a parked deposit must not ack — only the retry outcome does")
+        .isEmpty();
+  }
+
+  @Test
+  public void retryDeposit_afterLateLocalRegistration_deliversAndAcksStored() throws Exception {
+    // T32 regression: the deposit arrived while the OH registration was lost (cut-off
+    // connection); the client re-registers on THIS node before the retry fires. The retried
+    // deposit must land locally instead of being dropped.
+    ReturnPath ackPath = registerLocalAckPathA();
+    byte[] payload = "parked message".getBytes(StandardCharsets.UTF_8);
+    OhForwarder.PendingDeposit parked = deposit(payload, ackPath);
+
+    // late (re-)registration of the target OH on node A, after the failed first resolve
+    long now = System.currentTimeMillis();
+    handleStoreA.put(ohId, new OutboundHandleStore.HandleRecord(new byte[65], now, now + 60_000));
+
+    OhForwarder.retryDeposit(nodeA, parked);
+
+    List<MailItem> items = mailboxA.fetchMessages(ohId, 10, 0);
+    assertThat(items).hasSize(1);
+    assertThat(items.get(0).getPayload().toByteArray()).isEqualTo(payload);
+    im.redpanda.outbound.v1.RoutingAck rAck = fetchSingleAckA(ackPath);
+    assertThat(rAck.getStatus()).isEqualTo(RoutingAckSender.STATUS_STORED);
+  }
+
+  @Test
+  public void resolveFailure_retryBufferFull_dropsWithHandleExpiredAck() throws Exception {
+    ReturnPath ackPath = registerLocalAckPathA();
+    int parkedBefore = OhForwarder.pendingRetries.get();
+    // fill the bounded buffer artificially (way past the cap so concurrent decrements from other
+    // tests' scheduled retries cannot un-fill it)
+    OhForwarder.pendingRetries.set(OhForwarder.MAX_PENDING_RETRIES + 1000);
+    try {
+      OhForwarder.onResolveFailed(nodeA, deposit(new byte[8], ackPath), false);
+    } finally {
+      OhForwarder.pendingRetries.set(parkedBefore);
+    }
+
+    // buffer full → immediate final drop with exactly one HANDLE_EXPIRED ack
+    im.redpanda.outbound.v1.RoutingAck rAck = fetchSingleAckA(ackPath);
+    assertThat(rAck.getStatus()).isEqualTo(RoutingAckSender.STATUS_HANDLE_EXPIRED);
+  }
+
+  @Test
+  public void routeToNode_targetIsSelf_depositsLocallyInsteadOfDropping() throws Exception {
+    // resolve returned OUR node id (the OH registered here between the caller's NOT_FOUND check
+    // and the resolve callback) — there is never a route to ourselves, so this must deposit
+    ReturnPath ackPath = registerLocalAckPathA();
+    byte[] payload = "self-resolved message".getBytes(StandardCharsets.UTF_8);
+    long now = System.currentTimeMillis();
+    handleStoreA.put(ohId, new OutboundHandleStore.HandleRecord(new byte[65], now, now + 60_000));
+
+    OhForwarder.routeToNode(nodeA, nodeA.getNonce(), deposit(payload, ackPath));
+
+    List<MailItem> items = mailboxA.fetchMessages(ohId, 10, 0);
+    assertThat(items).hasSize(1);
+    assertThat(items.get(0).getPayload().toByteArray()).isEqualTo(payload);
+    im.redpanda.outbound.v1.RoutingAck rAck = fetchSingleAckA(ackPath);
+    assertThat(rAck.getStatus()).isEqualTo(RoutingAckSender.STATUS_STORED);
+  }
+
+  @Test
+  public void routeToNode_targetIsSelf_unknownOh_acksHandleExpired() throws Exception {
+    // announce points at us but the OH is not registered here (expired/revoked) — final drop
+    ReturnPath ackPath = registerLocalAckPathA();
+
+    OhForwarder.routeToNode(nodeA, nodeA.getNonce(), deposit(new byte[8], ackPath));
+
+    assertThat(mailboxA.fetchMessages(ohId, 10, 0)).isEmpty();
     im.redpanda.outbound.v1.RoutingAck rAck = fetchSingleAckA(ackPath);
     assertThat(rAck.getStatus()).isEqualTo(RoutingAckSender.STATUS_HANDLE_EXPIRED);
   }


### PR DESCRIPTION
## Problem (T32, Emu-Duo-E2E run 8)

A deposit for an OH whose registration was just lost (client connection cut off mid-registration, e.g. by the `invalid GCM frame length` abort) is dropped for good:

1. `depositMessage` → NOT_FOUND (registration never completed)
2. `OhForwarder.forward` → `OhResolveJob` finds no announce record → `onResolveFailed` **drops immediately**
3. the client re-registers the same OH ~10 s later — too late, light clients have no deposit retry

Observed as "OH host resolution failed, dropping forwarded deposit" right before the client's "re-registered lost handle"; likely also explains the old 5-min-first-delivery finding.

## Fix (node-side, KISS, no wire change)

- **Park + single delayed retry** instead of first-failure drop: the deposit is parked for 15 s (delay = TTL) and retried once. The retry tries the **local deposit first** (the observed race: the OH re-registered on this node meanwhile — needs no announce record), then resolves again. Only the second failure drops, with the same single `HANDLE_EXPIRED` R-ACK as before.
- **Bounded buffer**: at most 64 parked deposits (each ≤ `MAX_ITEM_BYTES` ⇒ ~4 MiB worst case); a full buffer keeps the previous immediate-drop behavior.
- **Resolve-to-self**: `routeToNode` now deposits locally when the announce record points at this node itself — previously this always ended in a bogus "no peer closer than ourselves" drop.

## Tests

`OhForwarderTest`: parked-instead-of-ack on first failure, delivery + `STORED` ack after late local registration (the T32 regression), buffer-cap fallback, resolve-to-self deposit (known and unknown OH), plus the existing MS06 single-ack invariants updated to the new signatures. `mvn verify` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LR2drH8EDWLv7hUEboMa4a