### PR TITLE
feat(outbound): Connection-Notify — Subscribe + one-way Notify over the peer connection (T38)

### DIFF
--- a/milestones/ms02_reliable_delivery.md
+++ b/milestones/ms02_reliable_delivery.md
@@ -121,7 +121,65 @@ message AckFetchResponse {
 - [x] Mailbox-Overflow (>500 Items) setzt `mailbox_overflow = true` in der nächsten `FetchResponse`
 - [x] Signing-Bytes für `AckFetch` sind dokumentiert: `[CMD_BYTE | oh_id | acked_sequence_id(8) | timestamp(8) | nonce]`
 
+## Connection-Notify (2026-07-17)
+
+Node meldet neue Mailbox-Post in Echtzeit über die **bestehende Peer-Verbindung** — kein Push, kein
+Drittanbieter, unabhängig von MS07. Vollständige Spec + Decisions: siehe
+[Master-Spec MS02 → Connection-Notify](../ms02_reliable_delivery.md#connection-notify-2026-07-17).
+
+### Neue Commands
+
+```
+Client → Node:  [159 OUTBOUND_SUBSCRIBE_REQ] [4 len] [SubscribeRequest]
+Node → Client:  [160 OUTBOUND_SUBSCRIBE_RES] [4 len] [SubscribeResponse]
+Node → Client:  [161 OUTBOUND_NOTIFY]        [4 len] [Notify]   (one-way, nur oh_id)
+```
+
+**Signing-Bytes Subscribe** (0x02-Präfix wird von `OutboundAuth` ergänzt):
+`[CMD_BYTE=159 | oh_id | timestamp_ms(8, big-endian) | nonce]` — verifiziert gegen den beim Register
+hinterlegten OH-Pubkey, gleiche Timestamp-/Replay-Prüfung wie Fetch.
+
+### Protobuf (`outbound.proto`)
+
+```protobuf
+message SubscribeRequest {
+  bytes oh_id = 1;
+  int64 timestamp_ms = 2;
+  bytes nonce = 3;
+  bytes signature = 4;
+}
+
+message SubscribeResponse {
+  Status status = 1;
+  int64 server_time_ms = 2;
+}
+
+message Notify {
+  bytes oh_id = 1;   // one-way node → client, kein Payload
+}
+```
+
+### Backend Changes
+
+| File | Action |
+|------|--------|
+| `Command.java` | `OUTBOUND_SUBSCRIBE_REQ=159`, `OUTBOUND_SUBSCRIBE_RES=160`, `OUTBOUND_NOTIFY=161` |
+| `OutboundService.java` | `handleSubscribe()` (Auth wie Fetch), In-Memory-Subscription-Registry (`oh_id → Peer`, Cleanup bei Disconnect), Notify im `depositMessage`-Choke-Point |
+| `InboundCommandProcessor.java` | `OUTBOUND_SUBSCRIBE_REQ` als Payload-Command registrieren |
+| **New**: `OutboundSubscribeNotifyTest.java` | Auth (gültig/ungültig/Replay/NOT_FOUND), Notify an abonnierte vs. nicht-abonnierte Mailbox, Disconnect-Cleanup, Idempotenz |
+
+### Acceptance Criteria (Connection-Notify)
+
+- [ ] `Subscribe` prüft Ownership wie Fetch (valid → `OK`, bad sig → `INVALID_SIGNATURE`, Replay →
+  `REPLAY`, unbekannte oh_id → `NOT_FOUND`)
+- [ ] Deposit in abonnierte Mailbox sendet genau ein `Notify(oh_id)`
+- [ ] Deposit in **nicht**-abonnierte Mailbox sendet kein `Notify` (opt-in)
+- [ ] Disconnect entfernt die Subscription (kein Notify an / kein Leak toter Peers)
+- [ ] Re-Subscribe idempotent; mehrere OHs pro Verbindung
+
 ## Open Questions
 
 1. Soll `AckFetch` ein eigener Command sein oder als Flag auf `FetchRequest` piggybacked?
 2. Soll der Overflow-Counter pro OH persistent sein, oder reicht ein transientes Flag?
+3. ~~Overflow-Notify in Echtzeit?~~ **Beantwortet 2026-07-17: Overflow bleibt in `FetchResponse`;
+   Connection-Notify macht das Ankunfts-Signal echtzeitfähig (Master-Spec Decision 5).**

--- a/milestones/ms02_reliable_delivery.md
+++ b/milestones/ms02_reliable_delivery.md
@@ -124,8 +124,9 @@ message AckFetchResponse {
 ## Connection-Notify (2026-07-17)
 
 Node meldet neue Mailbox-Post in Echtzeit über die **bestehende Peer-Verbindung** — kein Push, kein
-Drittanbieter, unabhängig von MS07. Vollständige Spec + Decisions: siehe
-[Master-Spec MS02 → Connection-Notify](../ms02_reliable_delivery.md#connection-notify-2026-07-17).
+Drittanbieter, unabhängig von MS07. Vollständige Spec + Decisions: siehe Master-Spec MS02 →
+Connection-Notify
+([docs](https://github.com/redPanda-project/docs/blob/main/docs/milestones/ms02_reliable_delivery.md#connection-notify-2026-07-17)).
 
 ### Neue Commands
 

--- a/src/main/java/im/redpanda/core/Command.java
+++ b/src/main/java/im/redpanda/core/Command.java
@@ -48,4 +48,12 @@ public final class Command {
   public static final byte OUTBOUND_ACK_FETCH_REQ = (byte) 156;
   public static final byte OUTBOUND_ACK_FETCH_RES = (byte) 157;
   public static final byte FLASCHENPOST_PUT_RES = (byte) 158;
+
+  // Connection-Notify (T38): opt-in "new mail" signal over the existing peer connection.
+  // Subscribe is a signed request/response (ownership proof reuses the Fetch signing scheme);
+  // Notify is a one-way node → client message carrying only the oh_id. Never sent to clients
+  // that did not subscribe (unknown commands desync their read loop).
+  public static final byte OUTBOUND_SUBSCRIBE_REQ = (byte) 159;
+  public static final byte OUTBOUND_SUBSCRIBE_RES = (byte) 160;
+  public static final byte OUTBOUND_NOTIFY = (byte) 161;
 }

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -19,6 +19,7 @@ import im.redpanda.outbound.v1.AckFetchRequest;
 import im.redpanda.outbound.v1.FetchRequest;
 import im.redpanda.outbound.v1.RegisterOhRequest;
 import im.redpanda.outbound.v1.RevokeOhRequest;
+import im.redpanda.outbound.v1.SubscribeRequest;
 import im.redpanda.proto.*;
 import im.redpanda.proto.FlaschenpostPut;
 import java.io.File;
@@ -161,6 +162,15 @@ public class InboundCommandProcessor {
         (peer, buf, payload) -> {
           int len = (payload != null) ? payload.length : 0;
           outboundService.handleAckFetch(peer, AckFetchRequest.parseFrom(payload));
+          return 1 + 4 + len;
+        });
+    // Connection-Notify (T38): opt-in subscribe. OUTBOUND_SUBSCRIBE_RES/OUTBOUND_NOTIFY are only
+    // ever written back to the client, never parsed here.
+    commandHandlers.put(
+        Command.OUTBOUND_SUBSCRIBE_REQ,
+        (peer, buf, payload) -> {
+          int len = (payload != null) ? payload.length : 0;
+          outboundService.handleSubscribe(peer, SubscribeRequest.parseFrom(payload));
           return 1 + 4 + len;
         });
 
@@ -323,7 +333,8 @@ public class InboundCommandProcessor {
         || command == Command.OUTBOUND_REGISTER_OH_REQ
         || command == Command.OUTBOUND_FETCH_REQ
         || command == Command.OUTBOUND_REVOKE_OH_REQ
-        || command == Command.OUTBOUND_ACK_FETCH_REQ;
+        || command == Command.OUTBOUND_ACK_FETCH_REQ
+        || command == Command.OUTBOUND_SUBSCRIBE_REQ;
   }
 
   private byte[] readMessage(ByteBuffer readBuffer) {

--- a/src/main/java/im/redpanda/outbound/OutboundService.java
+++ b/src/main/java/im/redpanda/outbound/OutboundService.java
@@ -3,6 +3,7 @@ package im.redpanda.outbound;
 import com.google.protobuf.ByteString;
 import im.redpanda.core.Command;
 import im.redpanda.core.Peer;
+import im.redpanda.crypt.Utils;
 import im.redpanda.outbound.OutboundAuth.AuthResult;
 import im.redpanda.outbound.OutboundHandleStore.HandleRecord;
 import im.redpanda.outbound.v1.AckFetchRequest;
@@ -11,11 +12,15 @@ import im.redpanda.outbound.v1.FetchRequest;
 import im.redpanda.outbound.v1.FetchResponse;
 import im.redpanda.outbound.v1.FlaschenpostPutResponse;
 import im.redpanda.outbound.v1.MailItem;
+import im.redpanda.outbound.v1.Notify;
 import im.redpanda.outbound.v1.RegisterOhRequest;
 import im.redpanda.outbound.v1.RegisterOhResponse;
 import im.redpanda.outbound.v1.RevokeOhRequest;
 import im.redpanda.outbound.v1.RevokeOhResponse;
 import im.redpanda.outbound.v1.Status;
+import im.redpanda.outbound.v1.SubscribeRequest;
+import im.redpanda.outbound.v1.SubscribeResponse;
+import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.ArrayDeque;
@@ -24,6 +29,7 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class OutboundService {
 
@@ -85,6 +91,19 @@ public class OutboundService {
    */
   private final Map<Peer, Deque<Long>> registerHistory =
       Collections.synchronizedMap(new WeakHashMap<>());
+
+  /**
+   * Connection-Notify (T38) subscription registry: oh_id (hex) → the peer connection that proved
+   * ownership via a signed {@link SubscribeRequest}. The value is a {@link WeakReference} so a
+   * disconnected peer's binding vanishes with the {@code Peer} object (same self-cleaning rationale
+   * as {@link #registerHistory}) — no persisted subscription state, no dead-peer leak. The deposit
+   * side additionally prunes any binding whose peer is gone or no longer connected, so a Notify is
+   * never sent to a disconnected client. Re-subscribe is idempotent (overwrites the same key);
+   * multiple OHs may map to the same peer, and an oh_id is bound to at most one connection
+   * (last-writer-wins — the OH owner controls this via its signing key).
+   */
+  private final ConcurrentHashMap<String, WeakReference<Peer>> subscriptions =
+      new ConcurrentHashMap<>();
 
   public OutboundService(OutboundHandleStore handleStore, OutboundMailboxStore mailboxStore) {
     this.handleStore = handleStore;
@@ -262,6 +281,87 @@ public class OutboundService {
   }
 
   /**
+   * Connection-Notify (T38): handles a Subscribe request. Verifies OH ownership exactly like {@link
+   * #handleFetch} (Ed25519 signature against the stored OH key, same timestamp/replay handling),
+   * then binds {@code oh_id → this peer connection} so future deposits into that mailbox trigger a
+   * one-way {@link Notify}. The binding is in-memory only and ends when the peer disconnects; a
+   * repeated subscribe is idempotent.
+   *
+   * <p>Signing bytes: {@code [CMD_BYTE | oh_id | timestamp(8) | nonce]} — prefixed with the MS03
+   * version byte by {@link OutboundAuth} for Ed25519 verification (same layout as Revoke).
+   */
+  public void handleSubscribe(Peer peer, SubscribeRequest req) {
+    long now = System.currentTimeMillis();
+    byte[] ohId = req.getOhId().toByteArray();
+    byte[] nonce = req.getNonce().toByteArray();
+    long timestamp = req.getTimestampMs();
+
+    // Input validation
+    if (outOfRange(ohId.length, MIN_OH_ID_BYTES, MAX_OH_ID_BYTES)
+        || outOfRange(nonce.length, MIN_NONCE_BYTES, MAX_NONCE_BYTES)) {
+      sendSubscribeResponse(peer, Status.BAD_REQUEST);
+      return;
+    }
+
+    HandleRecord handle = handleStore.get(ohId);
+    if (handle == null || handle.getExpiresAtMs() < now) {
+      sendSubscribeResponse(peer, Status.NOT_FOUND);
+      return;
+    }
+
+    ByteBuffer signBuf = ByteBuffer.allocate(1 + ohId.length + 8 + nonce.length);
+    signBuf.put(Command.OUTBOUND_SUBSCRIBE_REQ);
+    signBuf.put(ohId);
+    signBuf.putLong(timestamp);
+    signBuf.put(nonce);
+
+    AuthResult result =
+        auth.verify(
+            handle.getOhAuthPublicKey(),
+            signBuf.array(),
+            req.getSignature().toByteArray(),
+            timestamp,
+            ohId,
+            nonce);
+
+    if (result != AuthResult.OK) {
+      sendSubscribeResponse(peer, mapAuthToStatus(result));
+      return;
+    }
+
+    // Bind oh_id → this connection (idempotent overwrite; last-writer-wins across connections).
+    subscriptions.put(Utils.bytesToHexString(ohId), new WeakReference<>(peer));
+    sendSubscribeResponse(peer, Status.OK);
+  }
+
+  /**
+   * Connection-Notify (T38): fire-and-forget one-way {@link Notify} to the connection subscribed
+   * for {@code ohId}, if any. Called after every successful deposit (all deposit paths funnel
+   * through {@link #depositMessage}). Strictly opt-in: only a peer that sent a valid {@link
+   * SubscribeRequest} is in the registry, so existing clients never receive command 161. Any send
+   * failure is swallowed — a deposit must never be affected by notification delivery. Prunes the
+   * binding if its peer has been garbage-collected or is no longer connected.
+   */
+  private void notifySubscriber(byte[] ohId) {
+    try {
+      String key = Utils.bytesToHexString(ohId);
+      WeakReference<Peer> ref = subscriptions.get(key);
+      if (ref == null) {
+        return;
+      }
+      Peer peer = ref.get();
+      if (peer == null || !peer.isConnected()) {
+        subscriptions.remove(key);
+        return;
+      }
+      Notify notify = Notify.newBuilder().setOhId(ByteString.copyFrom(ohId)).build();
+      writeResponse(peer, Command.OUTBOUND_NOTIFY, notify.toByteArray());
+    } catch (RuntimeException e) {
+      logger.warn("Connection-Notify: failed to notify subscriber", e);
+    }
+  }
+
+  /**
    * Handles an AckFetch request: verifies the signature, deletes all mailbox items with sequence_id
    * &lt;= acked_sequence_id, and responds with OK.
    *
@@ -369,11 +469,18 @@ public class OutboundService {
             .setPayload(ByteString.copyFrom(payload))
             .setSessionTag(ByteString.copyFrom(sessionTag))
             .build();
-    return switch (mailboxStore.addMessage(ohId, item)) {
-      case ADDED -> DepositResult.DEPOSITED;
-      case REJECTED_ITEM_TOO_LARGE -> DepositResult.BAD_REQUEST;
-      case REJECTED_MAILBOX_FULL, REJECTED_BYTE_QUOTA -> DepositResult.QUOTA_EXCEEDED;
-    };
+    DepositResult result =
+        switch (mailboxStore.addMessage(ohId, item)) {
+          case ADDED -> DepositResult.DEPOSITED;
+          case REJECTED_ITEM_TOO_LARGE -> DepositResult.BAD_REQUEST;
+          case REJECTED_MAILBOX_FULL, REJECTED_BYTE_QUOTA -> DepositResult.QUOTA_EXCEEDED;
+        };
+    // Connection-Notify (T38): signal the subscribed connection (if any) that new mail arrived.
+    // Only on an actual deposit — a rejected deposit stores nothing, so there is nothing to fetch.
+    if (result == DepositResult.DEPOSITED) {
+      notifySubscriber(ohId);
+    }
+    return result;
   }
 
   /**
@@ -490,6 +597,15 @@ public class OutboundService {
             .setServerTimeMs(System.currentTimeMillis())
             .build();
     writeResponse(peer, Command.OUTBOUND_REVOKE_OH_RES, res.toByteArray());
+  }
+
+  private void sendSubscribeResponse(Peer peer, Status status) {
+    SubscribeResponse res =
+        SubscribeResponse.newBuilder()
+            .setStatus(status)
+            .setServerTimeMs(System.currentTimeMillis())
+            .build();
+    writeResponse(peer, Command.OUTBOUND_SUBSCRIBE_RES, res.toByteArray());
   }
 
   private void sendAckFetchResponse(Peer peer, Status status) {

--- a/src/main/java/im/redpanda/outbound/OutboundService.java
+++ b/src/main/java/im/redpanda/outbound/OutboundService.java
@@ -351,7 +351,9 @@ public class OutboundService {
       }
       Peer peer = ref.get();
       if (peer == null || !peer.isConnected()) {
-        subscriptions.remove(key);
+        // Conditional remove: only drop the exact stale entry we inspected, so a concurrent
+        // re-subscribe that already replaced the binding for this oh_id is not clobbered (ABA).
+        subscriptions.remove(key, ref);
         return;
       }
       Notify notify = Notify.newBuilder().setOhId(ByteString.copyFrom(ohId)).build();

--- a/src/main/proto/outbound.proto
+++ b/src/main/proto/outbound.proto
@@ -131,3 +131,29 @@ message RevokeOhResponse {
   Status status = 1;
   int64 server_time_ms = 2;
 }
+
+// Connection-Notify (T38): opt-in real-time "new mail" signal over the existing peer connection.
+// Subscribe proves OH ownership exactly like FetchRequest — Ed25519 signature verified against the
+// oh_auth_public_key stored at register, same OutboundAuth timestamp/replay handling. The node then
+// binds oh_id → this peer connection (in-memory only, dropped on disconnect). On every successful
+// deposit into a subscribed mailbox the node sends a one-way Notify carrying only the oh_id; the
+// client reacts with a normal signed FetchRequest (cursor/ack/dedup/decrypt unchanged).
+//   Signing bytes: [CMD_BYTE=159 | oh_id | timestamp_ms(8) | nonce]  (0x02 version prefix applied
+//   by OutboundAuth, like every signed outbound command).
+message SubscribeRequest {
+  bytes oh_id = 1;
+  int64 timestamp_ms = 2;
+  bytes nonce = 3;
+  bytes signature = 4;
+}
+
+message SubscribeResponse {
+  Status status = 1;
+  int64 server_time_ms = 2;
+}
+
+// One-way node → client (command 161). Carries ONLY the oh_id — no payload, no metadata, no
+// sequence id: the client already has a fully signed fetch path and uses it to learn what changed.
+message Notify {
+  bytes oh_id = 1;
+}

--- a/src/test/java/im/redpanda/outbound/OutboundSubscribeNotifyTest.java
+++ b/src/test/java/im/redpanda/outbound/OutboundSubscribeNotifyTest.java
@@ -1,0 +1,260 @@
+package im.redpanda.outbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.ByteString;
+import im.redpanda.core.Command;
+import im.redpanda.core.NodeId;
+import im.redpanda.core.Peer;
+import im.redpanda.outbound.v1.Notify;
+import im.redpanda.outbound.v1.RegisterOhRequest;
+import im.redpanda.outbound.v1.Status;
+import im.redpanda.outbound.v1.SubscribeRequest;
+import im.redpanda.outbound.v1.SubscribeResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * T38 Connection-Notify: subscribe ownership proof (valid / bad signature / replay / NOT_FOUND),
+ * one-way Notify on deposit into a subscribed vs. non-subscribed mailbox, disconnect cleanup,
+ * idempotent re-subscribe, and multiple OHs per connection.
+ */
+public class OutboundSubscribeNotifyTest {
+
+  private OutboundService service;
+  private OutboundHandleStore handleStore;
+  private OutboundMailboxStore mailboxStore;
+  private Peer peer;
+  private NodeId clientNode;
+
+  @Before
+  public void setUp() {
+    handleStore = new OutboundHandleStore();
+    mailboxStore = new OutboundMailboxStore();
+    service = new OutboundService(handleStore, mailboxStore);
+
+    peer = newConnectedPeer(12345);
+    clientNode = NodeId.generateWithSimpleKey();
+  }
+
+  private static Peer newConnectedPeer(int port) {
+    Peer p = new Peer("127.0.0.1", port);
+    p.writeBuffer = ByteBuffer.allocate(8192);
+    p.writeBuffer.clear();
+    p.setConnected(true);
+    return p;
+  }
+
+  private void registerOh() throws Exception {
+    service.handleRegister(peer, createSignedRegisterRequest());
+    // consume the RegisterOhResponse so the buffer only holds later commands
+    drainBuffer(peer);
+  }
+
+  // --- Subscribe auth ---
+
+  @Test
+  public void subscribe_validSignature_returnsOkAndBinds() throws Exception {
+    registerOh();
+    service.handleSubscribe(peer, createSignedSubscribeRequest());
+    assertThat(readSubscribeResponse().getStatus()).isEqualTo(Status.OK);
+
+    // A deposit into the subscribed mailbox now emits exactly one Notify(oh_id)
+    service.depositMessage(ohId(), "hi".getBytes(StandardCharsets.UTF_8));
+    Notify notify = readNotify();
+    assertThat(notify.getOhId().toByteArray()).isEqualTo(ohId());
+    assertNoMoreData(peer);
+  }
+
+  @Test
+  public void subscribe_badSignature_returnsInvalidSignature_noNotify() throws Exception {
+    registerOh();
+    SubscribeRequest tampered =
+        createSignedSubscribeRequest().toBuilder()
+            .setSignature(ByteString.copyFrom(new byte[64]))
+            .build();
+    service.handleSubscribe(peer, tampered);
+    assertThat(readSubscribeResponse().getStatus()).isEqualTo(Status.INVALID_SIGNATURE);
+
+    // Not subscribed → deposit produces no Notify
+    service.depositMessage(ohId(), "hi".getBytes(StandardCharsets.UTF_8));
+    assertNoMoreData(peer);
+  }
+
+  @Test
+  public void subscribe_replayedNonce_returnsReplay() throws Exception {
+    registerOh();
+    SubscribeRequest req = createSignedSubscribeRequest();
+    service.handleSubscribe(peer, req);
+    assertThat(readSubscribeResponse().getStatus()).isEqualTo(Status.OK);
+
+    // Exact same request (same nonce) → replay
+    service.handleSubscribe(peer, req);
+    assertThat(readSubscribeResponse().getStatus()).isEqualTo(Status.REPLAY);
+  }
+
+  @Test
+  public void subscribe_unknownOhId_returnsNotFound() throws Exception {
+    // No register → handle store has no record for this oh_id
+    service.handleSubscribe(peer, createSignedSubscribeRequest());
+    assertThat(readSubscribeResponse().getStatus()).isEqualTo(Status.NOT_FOUND);
+  }
+
+  // --- Notify opt-in semantics ---
+
+  @Test
+  public void deposit_intoNonSubscribedMailbox_sendsNoNotify() throws Exception {
+    registerOh(); // registered but never subscribed
+    service.depositMessage(ohId(), "hi".getBytes(StandardCharsets.UTF_8));
+    assertNoMoreData(peer);
+  }
+
+  @Test
+  public void resubscribe_isIdempotent_stillOneNotify() throws Exception {
+    registerOh();
+    service.handleSubscribe(peer, createSignedSubscribeRequest());
+    assertThat(readSubscribeResponse().getStatus()).isEqualTo(Status.OK);
+    service.handleSubscribe(peer, createSignedSubscribeRequest());
+    assertThat(readSubscribeResponse().getStatus()).isEqualTo(Status.OK);
+
+    service.depositMessage(ohId(), "hi".getBytes(StandardCharsets.UTF_8));
+    assertThat(readNotify().getOhId().toByteArray()).isEqualTo(ohId());
+    assertNoMoreData(peer); // exactly one notify, not two
+  }
+
+  @Test
+  public void disconnect_removesSubscription_noNotify() throws Exception {
+    registerOh();
+    service.handleSubscribe(peer, createSignedSubscribeRequest());
+    assertThat(readSubscribeResponse().getStatus()).isEqualTo(Status.OK);
+
+    // Peer disconnects: deposit must not notify (and the binding is pruned lazily)
+    peer.setConnected(false);
+    service.depositMessage(ohId(), "hi".getBytes(StandardCharsets.UTF_8));
+    peer.writeBuffer.flip();
+    assertThat(peer.writeBuffer.hasRemaining()).as("no Notify to a disconnected peer").isFalse();
+  }
+
+  @Test
+  public void multipleOhsPerConnection_eachNotified() throws Exception {
+    // OH #1 (the shared clientNode) + a second OH on the same connection
+    registerOh();
+    service.handleSubscribe(peer, createSignedSubscribeRequest());
+    assertThat(readSubscribeResponse().getStatus()).isEqualTo(Status.OK);
+
+    NodeId other = NodeId.generateWithSimpleKey();
+    byte[] otherOhId = other.getKademliaId().getBytes();
+    service.handleRegister(peer, createSignedRegisterRequest(other));
+    drainBuffer(peer);
+    service.handleSubscribe(peer, createSignedSubscribeRequest(other));
+    assertThat(readSubscribeResponse().getStatus()).isEqualTo(Status.OK);
+
+    service.depositMessage(otherOhId, "b".getBytes(StandardCharsets.UTF_8));
+    assertThat(readNotify().getOhId().toByteArray()).isEqualTo(otherOhId);
+
+    service.depositMessage(ohId(), "a".getBytes(StandardCharsets.UTF_8));
+    assertThat(readNotify().getOhId().toByteArray()).isEqualTo(ohId());
+  }
+
+  // --- helpers ---
+
+  private byte[] ohId() {
+    return clientNode.getKademliaId().getBytes();
+  }
+
+  private static void drainBuffer(Peer p) {
+    p.writeBuffer.clear();
+  }
+
+  private static void assertNoMoreData(Peer p) {
+    p.writeBuffer.flip();
+    boolean remaining = p.writeBuffer.hasRemaining();
+    p.writeBuffer.compact();
+    assertThat(remaining).as("no extra command written").isFalse();
+  }
+
+  private SubscribeResponse readSubscribeResponse() throws Exception {
+    peer.writeBuffer.flip();
+    byte cmd = peer.writeBuffer.get();
+    assertThat(cmd).isEqualTo(Command.OUTBOUND_SUBSCRIBE_RES);
+    int len = peer.writeBuffer.getInt();
+    byte[] data = new byte[len];
+    peer.writeBuffer.get(data);
+    peer.writeBuffer.compact();
+    return SubscribeResponse.parseFrom(data);
+  }
+
+  private Notify readNotify() throws Exception {
+    peer.writeBuffer.flip();
+    byte cmd = peer.writeBuffer.get();
+    assertThat(cmd).isEqualTo(Command.OUTBOUND_NOTIFY);
+    int len = peer.writeBuffer.getInt();
+    byte[] data = new byte[len];
+    peer.writeBuffer.get(data);
+    peer.writeBuffer.compact();
+    return Notify.parseFrom(data);
+  }
+
+  // --- request builders / signing ---
+
+  private RegisterOhRequest createSignedRegisterRequest() {
+    return createSignedRegisterRequest(clientNode);
+  }
+
+  private RegisterOhRequest createSignedRegisterRequest(NodeId node) {
+    long now = System.currentTimeMillis();
+    long expires = now + 60_000;
+    byte[] id = node.getKademliaId().getBytes();
+    byte[] nonce = randomNonce();
+
+    ByteBuffer buf = ByteBuffer.allocate(2 + id.length + 8 + 8 + nonce.length);
+    buf.put(OutboundAuth.SIGNING_VERSION_ED25519);
+    buf.put(Command.OUTBOUND_REGISTER_OH_REQ);
+    buf.put(id);
+    buf.putLong(expires);
+    buf.putLong(now);
+    buf.put(nonce);
+
+    return RegisterOhRequest.newBuilder()
+        .setOhId(ByteString.copyFrom(id))
+        .setOhAuthPublicKey(ByteString.copyFrom(node.getVerifyKeyBytes()))
+        .setRequestedExpiresAt(expires)
+        .setTimestampMs(now)
+        .setNonce(ByteString.copyFrom(nonce))
+        .setSignature(ByteString.copyFrom(node.sign(buf.array())))
+        .build();
+  }
+
+  private SubscribeRequest createSignedSubscribeRequest() {
+    return createSignedSubscribeRequest(clientNode);
+  }
+
+  private SubscribeRequest createSignedSubscribeRequest(NodeId node) {
+    long now = System.currentTimeMillis();
+    byte[] id = node.getKademliaId().getBytes();
+    byte[] nonce = randomNonce();
+
+    ByteBuffer buf = ByteBuffer.allocate(2 + id.length + 8 + nonce.length);
+    buf.put(OutboundAuth.SIGNING_VERSION_ED25519);
+    buf.put(Command.OUTBOUND_SUBSCRIBE_REQ);
+    buf.put(id);
+    buf.putLong(now);
+    buf.put(nonce);
+
+    return SubscribeRequest.newBuilder()
+        .setOhId(ByteString.copyFrom(id))
+        .setTimestampMs(now)
+        .setNonce(ByteString.copyFrom(nonce))
+        .setSignature(ByteString.copyFrom(node.sign(buf.array())))
+        .build();
+  }
+
+  private static byte[] randomNonce() {
+    byte[] n = new byte[8];
+    new SecureRandom().nextBytes(n);
+    return n;
+  }
+}


### PR DESCRIPTION
## T38 Phase 2 — redpandaj backend

Real-time "you have new mail" over the **existing peer connection** — no third-party push, independent of MS07/D1–D6. The node signals a subscribed client the instant something is deposited into its mailbox; the client then runs a normal signed fetch (cursor/ack/dedup/decrypt unchanged). Spec: docs [#38](https://github.com/redPanda-project/docs/pull/38) (merged).

### Wire additions (opt-in)
| Byte | Command | Direction |
|------|---------|-----------|
| 159 | `OUTBOUND_SUBSCRIBE_REQ` | Client → Node |
| 160 | `OUTBOUND_SUBSCRIBE_RES` | Node → Client |
| 161 | `OUTBOUND_NOTIFY` | Node → Client (one-way, only oh_id) |

New protobuf messages `SubscribeRequest` / `SubscribeResponse` / `Notify` in `outbound.proto`.

### Behaviour
- **Subscribe** proves OH ownership exactly like Fetch: Ed25519 signature verified against the `oh_auth_public_key` stored at register, same `OutboundAuth` timestamp/replay handling. Signing bytes `[CMD_BYTE=159 | oh_id | timestamp_ms(8) | nonce]`. Errors mirror Fetch: `BAD_REQUEST` / `NOT_FOUND` / `INVALID_SIGNATURE` / `INVALID_TIMESTAMP` / `REPLAY`.
- **Registry** `ConcurrentHashMap<ohIdHex, WeakReference<Peer>>` — in-memory only, no persistence. A dead peer's binding vanishes with the `Peer` (same self-cleaning rationale as the existing `registerHistory`) and is pruned on the deposit path when the peer is gone/disconnected → no notify to, and no leak of, a dead peer. Idempotent re-subscribe; multiple OHs per connection; last-writer-wins across connections.
- **Notify** fires at the `depositMessage` choke point, so **every** deposit path (direct `FlaschenpostPut`, `OhForwarder` forwarding, garlic deliver, R-ACK) triggers it uniformly. A rejected deposit stores nothing and triggers no notify. Fire-and-forget: a send failure never affects the deposit.
- **Strictly opt-in**: only a peer that sent a valid `Subscribe` is in the registry, so existing clients never receive command 161 (which would desync their read loop). Zero behaviour change for existing clients.

### Answers MS02 Open Question 3
Real-time overflow: overflow stays in `FetchResponse`; the `Notify` command makes the message-*arrival* signal real-time (docs Decision 5).

### Tests
`OutboundSubscribeNotifyTest` (8): subscribe valid → OK + notify on deposit; bad signature → `INVALID_SIGNATURE` + no notify; replayed nonce → `REPLAY`; unknown oh_id → `NOT_FOUND`; deposit into non-subscribed mailbox → no notify; idempotent re-subscribe → exactly one notify; disconnect → no notify (cleanup); multiple OHs per connection each notified. `mvn verify` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LR2drH8EDWLv7hUEboMa4a