### PR TITLE
fix(core): ConcurrentModificationException in LocalSettings.save (Sentry REDPANDAJ-2E6)

### DIFF
--- a/src/main/java/im/redpanda/core/SystemUpTimeData.java
+++ b/src/main/java/im/redpanda/core/SystemUpTimeData.java
@@ -25,14 +25,14 @@ public class SystemUpTimeData implements Serializable {
     upHits = new TreeSet<>();
   }
 
-  public void reportNow() {
+  public synchronized void reportNow() {
     clearTooOldHits();
     log.info("current uptime: " + getUptimePercent());
     upHits.add(ceilToLastFullHour(System.currentTimeMillis()));
     log.info("current uptime: " + getUptimePercent() + " after update");
   }
 
-  public void clearTooOldHits() {
+  public synchronized void clearTooOldHits() {
     while (!upHits.isEmpty()
         && upHits.getFirst()
             < System.currentTimeMillis() - Duration.ofDays(UPTIME_WINDOW_IN_DAYS).toMillis()) {
@@ -40,8 +40,17 @@ public class SystemUpTimeData implements Serializable {
     }
   }
 
-  public double getUptimePercent() {
+  public synchronized double getUptimePercent() {
     return (double) upHits.size() / MAX_HITS_IN_WINDOW;
+  }
+
+  /**
+   * Serialization must hold the same lock as the mutators: SaveJobs writes this object from the
+   * jobs pool while UpTimeReporterJob updates {@code upHits} concurrently (REDPANDAJ-2E6).
+   */
+  @Serial
+  private synchronized void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
+    out.defaultWriteObject();
   }
 
   public int getUptimePercentAsInt() {

--- a/src/test/java/im/redpanda/core/SystemUpTimeDataTest.java
+++ b/src/test/java/im/redpanda/core/SystemUpTimeDataTest.java
@@ -2,6 +2,9 @@ package im.redpanda.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.time.Duration;
 import java.util.TreeSet;
 import org.junit.Test;
 
@@ -29,6 +32,28 @@ public class SystemUpTimeDataTest {
     systemUpTimeData.reportNow();
     systemUpTimeData.clearTooOldHits();
     assertThat(systemUpTimeData.getUptimePercent()).isGreaterThan(0d);
+  }
+
+  @Test
+  public void serializeWhileMutating_doesNotThrow() throws Exception {
+    TreeSet<Long> hits = new TreeSet<>();
+    long oldBase = System.currentTimeMillis() - Duration.ofDays(30).toMillis();
+    for (long i = 0; i < 200_000; i++) {
+      hits.add(oldBase + i);
+    }
+    SystemUpTimeData systemUpTimeData = new SystemUpTimeData(hits);
+
+    Thread mutator = new Thread(systemUpTimeData::clearTooOldHits);
+    mutator.start();
+    try {
+      while (mutator.isAlive()) {
+        try (ObjectOutputStream out = new ObjectOutputStream(OutputStream.nullOutputStream())) {
+          out.writeObject(systemUpTimeData);
+        }
+      }
+    } finally {
+      mutator.join();
+    }
   }
 
   @Test

--- a/src/test/java/im/redpanda/core/SystemUpTimeDataTest.java
+++ b/src/test/java/im/redpanda/core/SystemUpTimeDataTest.java
@@ -34,7 +34,7 @@ public class SystemUpTimeDataTest {
     assertThat(systemUpTimeData.getUptimePercent()).isGreaterThan(0d);
   }
 
-  @Test
+  @Test(timeout = 60_000)
   public void serializeWhileMutating_doesNotThrow() throws Exception {
     TreeSet<Long> hits = new TreeSet<>();
     long oldBase = System.currentTimeMillis() - Duration.ofDays(30).toMillis();


### PR DESCRIPTION
## Problem
Sentry [REDPANDAJ-2E6](https://redpanda-project.sentry.io/issues/REDPANDAJ-2E6): `ConcurrentModificationException` in `LocalSettings.save` — `SaveJobs` serializes `LocalSettings` (including `SystemUpTimeData.upHits`, a `TreeSet`) on one jobs-pool worker while `UpTimeReporterJob` mutates the set on another (`reportNow`/`clearTooOldHits`), so `TreeSet.writeObject` iterates a map that changes under it.

## Fix
Synchronize the mutators and a custom `writeObject` on the `SystemUpTimeData` instance monitor, so serialization sees a consistent snapshot. Serialized form and `serialVersionUID` unchanged — old save files load as before.

## Test
New regression test `serializeWhileMutating_doesNotThrow`: seeds 200k stale hits, clears them on one thread while serializing on another. Reproduces the CME reliably without the fix, passes with it (verified locally both ways).

Fixes REDPANDAJ-2E6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHDH2f2Mc2aib3evJP1oda