### PR TITLE
fix(outbound): persist mailbox sequence counters and heal stale fetch cursors (T40)

### DIFF
--- a/src/main/java/im/redpanda/outbound/OutboundMailboxStore.java
+++ b/src/main/java/im/redpanda/outbound/OutboundMailboxStore.java
@@ -209,8 +209,12 @@ public class OutboundMailboxStore {
     usedBytes.addAndGet(serialized.length);
     if (db != null) {
       // T40: persist the just-assigned sequence id so the counter survives a restart even after
-      // the item is later acked and deleted. Rides the same commit as the item write.
-      seqCountersPersisted.put(ohKey, seqId);
+      // the item is later acked and deleted. Rides the same commit as the item write. The null
+      // check covers a partially failed init() (db opened, map creation failed) — the store then
+      // degrades to the pre-T40 in-memory counter behavior instead of throwing.
+      if (seqCountersPersisted != null) {
+        seqCountersPersisted.put(ohKey, seqId);
+      }
       db.commit();
     }
     return AddResult.ADDED;

--- a/src/main/java/im/redpanda/outbound/OutboundMailboxStore.java
+++ b/src/main/java/im/redpanda/outbound/OutboundMailboxStore.java
@@ -38,6 +38,15 @@ public class OutboundMailboxStore {
   private final ConcurrentHashMap<String, AtomicLong> seqCounters = new ConcurrentHashMap<>();
 
   /**
+   * Persisted last-assigned sequence id per mailbox: ohId_hex → last assigned sequence id (T40).
+   * Written through on every assignment so the sequence keeps climbing across a node restart even
+   * after all items of a mailbox have been acked and deleted. Without it the counter would restart
+   * at 1 and any light client holding a higher persisted cursor would never see later deposits.
+   * {@code null} in the in-memory-only (test) mode where {@code db == null}.
+   */
+  private Map<String, Long> seqCountersPersisted;
+
+  /**
    * In-memory byte usage per mailbox: ohId_hex → total stored bytes (serialized MailItem sizes).
    * Rebuilt from the persisted map on startup, updated on every add/delete.
    */
@@ -91,14 +100,25 @@ public class OutboundMailboxStore {
     init();
   }
 
+  /** Test constructor: file-backed store at an explicit path (restart/persistence tests). */
+  OutboundMailboxStore(String dbPath) {
+    this.dbPath = dbPath;
+    init();
+  }
+
   @SuppressWarnings("unchecked")
   private void init() {
     if (dbPath == null) return;
     try {
-      Files.createDirectories(Path.of("data"));
+      Path parent = Path.of(dbPath).getParent();
+      if (parent != null) {
+        Files.createDirectories(parent);
+      }
       db = DBMaker.fileDB(dbPath).transactionEnable().make();
       mailboxItems =
           db.treeMap("mailboxItemsV2", Serializer.STRING, Serializer.BYTE_ARRAY).createOrOpen();
+      seqCountersPersisted =
+          db.hashMap("seqCountersV1", Serializer.STRING, Serializer.LONG).createOrOpen();
       // Restore in-memory sequence and byte counters from persisted entries
       for (Map.Entry<String, byte[]> entry : mailboxItems.entrySet()) {
         String key = entry.getKey();
@@ -113,6 +133,17 @@ public class OutboundMailboxStore {
               .computeIfAbsent(ohKey, k -> new AtomicLong(0L))
               .addAndGet(entry.getValue().length);
         }
+      }
+      // T40: restore the sequence counter from the persisted last-assigned id as well. This is the
+      // second, authoritative input: max(persistedLastAssigned + 1, maxSurvivingItemSeq + 1). A
+      // fully-acked mailbox has no surviving items, so only the persisted value keeps the sequence
+      // from restarting at 1 after a restart.
+      for (Map.Entry<String, Long> entry : seqCountersPersisted.entrySet()) {
+        String ohKey = entry.getKey();
+        long lastAssigned = entry.getValue();
+        seqCounters
+            .computeIfAbsent(ohKey, k -> new AtomicLong(1L))
+            .updateAndGet(current -> Math.max(current, lastAssigned + 1));
       }
     } catch (Exception e) {
       Log.sentry(e);
@@ -176,7 +207,12 @@ public class OutboundMailboxStore {
     nextSeqId(ohKey);
     mailboxItems.put(itemKey(ohKey, seqId), serialized);
     usedBytes.addAndGet(serialized.length);
-    if (db != null) db.commit();
+    if (db != null) {
+      // T40: persist the just-assigned sequence id so the counter survives a restart even after
+      // the item is later acked and deleted. Rides the same commit as the item write.
+      seqCountersPersisted.put(ohKey, seqId);
+      db.commit();
+    }
     return AddResult.ADDED;
   }
 
@@ -246,7 +282,27 @@ public class OutboundMailboxStore {
     }
     overflowFlags.remove(ohIdHex);
     byteCounters.remove(ohIdHex);
-    if (db != null && changed) db.commit();
+    // T40: this is the handle-expiry path — the whole mailbox is gone and the client is forced
+    // through NOT_FOUND, which resets its cursor to 0 on re-register. Drop the sequence counter so
+    // a re-registered mailbox starts fresh at 1. Only removed here, never anywhere else.
+    seqCounters.remove(ohIdHex);
+    boolean counterRemoved = false;
+    if (seqCountersPersisted != null) {
+      counterRemoved = seqCountersPersisted.remove(ohIdHex) != null;
+    }
+    if (db != null && (changed || counterRemoved)) db.commit();
+  }
+
+  /**
+   * T40: the last sequence id ever assigned for this OH (0 if none). Used by the fetch handler to
+   * detect a stale client cursor that is higher than anything ever stored — a symptom of a
+   * pre-persistence node restart — and heal it by resetting to 0.
+   */
+  public synchronized long lastAssignedSeq(byte[] ohId) {
+    String ohKey = Utils.bytesToHexString(ohId);
+    AtomicLong counter = seqCounters.get(ohKey);
+    // seqCounters holds the next (1-based) id to assign, so last assigned = next - 1.
+    return counter == null ? 0L : counter.get() - 1;
   }
 
   /** Reduces the in-memory byte counter for an OH, never going below zero. */

--- a/src/main/java/im/redpanda/outbound/OutboundService.java
+++ b/src/main/java/im/redpanda/outbound/OutboundService.java
@@ -227,11 +227,25 @@ public class OutboundService {
       return;
     }
 
-    // Fetch logic — cursor is now afterSequence
-    List<MailItem> items = mailboxStore.fetchMessages(ohId, req.getLimit(), req.getCursor());
-    // next_cursor = highest sequence_id returned, or current cursor if no items
-    long nextCursor =
-        items.isEmpty() ? req.getCursor() : items.get(items.size() - 1).getSequenceId();
+    // T40 stale-cursor heal: the signature above covers the client's original cursor (do not touch
+    // the signed byte layout). After verification, guard against a cursor higher than any sequence
+    // ever assigned for this OH — the fingerprint of a pre-persistence node restart that rewound
+    // the
+    // mailbox sequence. No deposit can then satisfy seq > cursor, so fetch stays stuck returning 0
+    // items forever. Reset to 0 and redeliver whatever survives; the light client deduplicates by
+    // message_id and blindly adopts next_cursor, so broken channels self-heal without an app
+    // update.
+    long cursor = req.getCursor();
+    long lastAssigned = mailboxStore.lastAssignedSeq(ohId);
+    if (cursor > lastAssigned) {
+      cursor = 0;
+    }
+
+    // Fetch logic — cursor is now afterSequence (the effective, possibly healed, cursor)
+    List<MailItem> items = mailboxStore.fetchMessages(ohId, req.getLimit(), cursor);
+    // next_cursor = highest sequence_id returned, or the EFFECTIVE cursor if no items (never the
+    // raw request cursor — echoing the stale high value would defeat the heal above).
+    long nextCursor = items.isEmpty() ? cursor : items.get(items.size() - 1).getSequenceId();
     boolean overflow = mailboxStore.checkAndClearOverflow(ohId);
     sendFetchResponse(peer, Status.OK, nextCursor, items, overflow);
   }

--- a/src/test/java/im/redpanda/outbound/OutboundMailboxStoreTest.java
+++ b/src/test/java/im/redpanda/outbound/OutboundMailboxStoreTest.java
@@ -4,12 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.ByteString;
 import im.redpanda.outbound.v1.MailItem;
+import java.io.File;
 import java.util.List;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class OutboundMailboxStoreTest {
+
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
   private OutboundMailboxStore store;
   private byte[] ohId;
@@ -18,6 +23,10 @@ public class OutboundMailboxStoreTest {
   public void setUp() {
     store = new OutboundMailboxStore(); // Uses in-memory
     ohId = Hex.decode("123456");
+  }
+
+  private static MailItem msg(String payload) {
+    return MailItem.newBuilder().setPayload(ByteString.copyFromUtf8(payload)).build();
   }
 
   // --- AC: MailItem has monotone sequence_id per OH ---
@@ -247,6 +256,83 @@ public class OutboundMailboxStoreTest {
   }
 
   // --- MS02b AC: per-mailbox byte quota independent of item count ---
+
+  // --- T40 (a): persisted sequence counter survives a restart of a fully-acked mailbox ---
+
+  @Test
+  public void addMessage_afterRestartOfFullyAckedMailbox_continuesSequence() throws Exception {
+    String path = new File(tempFolder.newFolder(), "outbound_mailbox.mapdb").getAbsolutePath();
+
+    OutboundMailboxStore first = new OutboundMailboxStore(path);
+    try {
+      first.addMessage(ohId, msg("m1"));
+      List<MailItem> stored = first.fetchMessages(ohId, 10, 0);
+      assertThat(stored).hasSize(1);
+      assertThat(stored.get(0).getSequenceId()).isEqualTo(1L);
+
+      // Ack (delete) everything — the mailbox is now empty, no surviving item carries the sequence
+      first.deleteUpTo(ohId, 1);
+      assertThat(first.fetchMessages(ohId, 10, 0)).isEmpty();
+    } finally {
+      first.close();
+    }
+
+    // Reopen on the same path: the counter must resume at 2, not restart at 1
+    OutboundMailboxStore reopened = new OutboundMailboxStore(path);
+    try {
+      reopened.addMessage(ohId, msg("m2"));
+      List<MailItem> stored = reopened.fetchMessages(ohId, 10, 0);
+      assertThat(stored).hasSize(1);
+      assertThat(stored.get(0).getSequenceId()).isEqualTo(2L);
+    } finally {
+      reopened.close();
+    }
+  }
+
+  // --- T40 cleanup: deleteAllByHexKey drops the persisted counter, next mailbox life restarts at 1
+
+  @Test
+  public void deleteAllByHexKey_resetsPersistedCounter() throws Exception {
+    String path = new File(tempFolder.newFolder(), "outbound_mailbox.mapdb").getAbsolutePath();
+
+    OutboundMailboxStore first = new OutboundMailboxStore(path);
+    try {
+      first.addMessage(ohId, msg("m1"));
+      first.addMessage(ohId, msg("m2"));
+      assertThat(first.lastAssignedSeq(ohId)).isEqualTo(2L);
+
+      // Handle-expiry cleanup path: the whole mailbox and its counter are wiped
+      first.deleteAllByHexKey(Hex.toHexString(ohId));
+      assertThat(first.lastAssignedSeq(ohId)).isZero();
+    } finally {
+      first.close();
+    }
+
+    // A fresh store on the same path assigns seq 1 again for that OH
+    OutboundMailboxStore reopened = new OutboundMailboxStore(path);
+    try {
+      reopened.addMessage(ohId, msg("m3"));
+      List<MailItem> stored = reopened.fetchMessages(ohId, 10, 0);
+      assertThat(stored).hasSize(1);
+      assertThat(stored.get(0).getSequenceId()).isEqualTo(1L);
+    } finally {
+      reopened.close();
+    }
+  }
+
+  // --- T40 (b) unit-level: lastAssignedSeq tracks the highest id ever assigned ---
+
+  @Test
+  public void lastAssignedSeq_reflectsAssignmentsAndIsZeroForUnknownOh() {
+    assertThat(store.lastAssignedSeq(ohId)).isZero();
+    store.addMessage(ohId, msg("a"));
+    assertThat(store.lastAssignedSeq(ohId)).isEqualTo(1L);
+    store.addMessage(ohId, msg("b"));
+    assertThat(store.lastAssignedSeq(ohId)).isEqualTo(2L);
+    // Deleting items does not lower the last-assigned watermark
+    store.deleteUpTo(ohId, 2);
+    assertThat(store.lastAssignedSeq(ohId)).isEqualTo(2L);
+  }
 
   @Test
   public void addMessage_byteQuotaReached_rejectsBeforeItemCap() {

--- a/src/test/java/im/redpanda/outbound/OutboundServiceIntegrationTest.java
+++ b/src/test/java/im/redpanda/outbound/OutboundServiceIntegrationTest.java
@@ -319,6 +319,69 @@ public class OutboundServiceIntegrationTest {
     assertThat(res.getNextCursor()).isZero();
   }
 
+  // --- T40 (b): stale-cursor heal in handleFetch ---
+
+  @Test
+  public void testFetch_staleCursorAboveLastAssigned_healsAndRedelivers() throws Exception {
+    byte[] ohId = clientNode.getKademliaId().getBytes();
+    service.handleRegister(peer, createSignedRegisterRequest());
+    readRegisterResponse();
+
+    // Counter is fresh: two items present, last assigned = 2
+    service.depositMessage(ohId, MSG1.getBytes(StandardCharsets.UTF_8));
+    service.depositMessage(ohId, MSG2.getBytes(StandardCharsets.UTF_8));
+
+    // A stale-high cursor (47) from a previous mailbox life — nothing was ever assigned that high.
+    // The heal resets the effective cursor to 0, so both items are redelivered.
+    service.handleFetch(peer, createSignedFetchRequest(47));
+    FetchResponse res = readFetchResponse();
+
+    assertThat(res.getStatus()).isEqualTo(Status.OK);
+    assertThat(res.getItemsCount()).isEqualTo(2);
+    assertThat(res.getItems(0).getSequenceId()).isEqualTo(1L);
+    assertThat(res.getItems(1).getSequenceId()).isEqualTo(2L);
+    assertThat(res.getNextCursor()).isEqualTo(2L);
+  }
+
+  @Test
+  public void testFetch_staleCursorEmptyMailbox_healsCursorToZero() throws Exception {
+    // Empty mailbox, counter 0 (nothing ever assigned): a stale cursor of 47 heals to 0, and the
+    // empty-result next_cursor must echo the effective cursor (0), never the raw request cursor.
+    service.handleRegister(peer, createSignedRegisterRequest());
+    readRegisterResponse();
+
+    service.handleFetch(peer, createSignedFetchRequest(47));
+    FetchResponse res = readFetchResponse();
+
+    assertThat(res.getStatus()).isEqualTo(Status.OK);
+    assertThat(res.getItemsCount()).isZero();
+    assertThat(res.getNextCursor()).isZero();
+  }
+
+  @Test
+  public void testFetch_normalCursor_notHealed() throws Exception {
+    byte[] ohId = clientNode.getKademliaId().getBytes();
+    service.handleRegister(peer, createSignedRegisterRequest());
+    readRegisterResponse();
+
+    // Items 1 and 2 present, last assigned = 2
+    service.depositMessage(ohId, MSG1.getBytes(StandardCharsets.UTF_8));
+    service.depositMessage(ohId, MSG2.getBytes(StandardCharsets.UTF_8));
+
+    // Normal in-range cursor 1 (<= lastAssigned): no heal — returns exactly item 2.
+    service.handleFetch(peer, createSignedFetchRequest(1));
+    FetchResponse res = readFetchResponse();
+    assertThat(res.getItemsCount()).isEqualTo(1);
+    assertThat(res.getItems(0).getSequenceId()).isEqualTo(2L);
+    assertThat(res.getNextCursor()).isEqualTo(2L);
+
+    // Cursor exactly at lastAssigned (2): 0 items, and the cursor is echoed unchanged (no heal).
+    service.handleFetch(peer, createSignedFetchRequest(2));
+    FetchResponse atWatermark = readFetchResponse();
+    assertThat(atWatermark.getItemsCount()).isZero();
+    assertThat(atWatermark.getNextCursor()).isEqualTo(2L);
+  }
+
   // --- MS02 AC: AckFetch deletes items with sequence_id <= acked_sequence_id ---
 
   @Test


### PR DESCRIPTION
## Problem

Mailbox fetch is cursor-based (`cursor` = afterSequence). `OutboundMailboxStore`'s sequence counters were in-memory only and rebuilt from *surviving* items on startup. Acked items are deleted, so a fully-acked mailbox restarted its sequence at 1 after a node restart — while light clients keep their high persisted cursor. `handleFetch` echoed `nextCursor = req.cursor` on empty results, so the stale cursor never healed: every later deposit (seq <= cursor) stayed invisible forever, while fetch kept returning OK/0 items. Every existing channel goes silently deaf after a node restart; only the T20 loopback self-test made it visible (Connection doctor: all stages green, loopback red).

Reproduced end-to-end with a light-client probe: loopback green → node restart → loopback dead, fetch still green.

## Fix

1. **Persist sequence counters** (`seqCountersV1` mapdb map, last assigned id per OH). Write-through in `addMessage`, riding the existing commit. Restore = max(persisted + 1, surviving-item scan + 1). Counter removed only on the handle-expiry/revoke cleanup path (`deleteAllByHexKey`) — an expired handle forces the client through NOT_FOUND which resets its cursor anyway.
2. **Stale-cursor heal in `handleFetch`** (after signature verification, signed byte layout untouched): a request cursor above `lastAssignedSeq` can only stem from a previous mailbox life — effective cursor resets to 0, surviving items are redelivered (clients dedupe by message_id), and the empty-result `nextCursor` echoes the *effective* cursor. Clients adopt `nextCursor` blindly, so already-broken channels self-heal on their next fetch without an app update.

## Tests

- `OutboundMailboxStoreTest`: restart continuity (seq resumes at 2 after ack+restart), counter cleanup on `deleteAllByHexKey`, `lastAssignedSeq` watermark.
- `OutboundServiceIntegrationTest`: stale cursor 47 → redelivery + nextCursor 2; stale cursor on empty mailbox → nextCursor 0 (not 47); normal cursors unaffected.
- Full suite: 352 run, 0 failures. Light-client restart probe against this JAR: loopback green after node restart (cursor continues 1 → 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHDH2f2Mc2aib3evJP1oda