### PR TITLE
fix(outbound): clamp negative fetch cursors to 0 (T40 follow-up)

### DIFF
--- a/src/main/java/im/redpanda/outbound/OutboundService.java
+++ b/src/main/java/im/redpanda/outbound/OutboundService.java
@@ -230,14 +230,14 @@ public class OutboundService {
     // T40 stale-cursor heal: the signature above covers the client's original cursor (do not touch
     // the signed byte layout). After verification, guard against a cursor higher than any sequence
     // ever assigned for this OH — the fingerprint of a pre-persistence node restart that rewound
-    // the
-    // mailbox sequence. No deposit can then satisfy seq > cursor, so fetch stays stuck returning 0
-    // items forever. Reset to 0 and redeliver whatever survives; the light client deduplicates by
-    // message_id and blindly adopts next_cursor, so broken channels self-heal without an app
-    // update.
+    // the mailbox sequence. No deposit can then satisfy seq > cursor, so fetch stays stuck
+    // returning 0 items forever. Reset to 0 and redeliver whatever survives; the light client
+    // deduplicates by message_id and blindly adopts next_cursor, so broken channels self-heal
+    // without an app update. A negative cursor is equally out of range (it would leak "-" into the
+    // composite item keys) and clamps to 0 the same way.
     long cursor = req.getCursor();
     long lastAssigned = mailboxStore.lastAssignedSeq(ohId);
-    if (cursor > lastAssigned) {
+    if (cursor < 0 || cursor > lastAssigned) {
       cursor = 0;
     }
 

--- a/src/test/java/im/redpanda/outbound/OutboundServiceIntegrationTest.java
+++ b/src/test/java/im/redpanda/outbound/OutboundServiceIntegrationTest.java
@@ -382,6 +382,24 @@ public class OutboundServiceIntegrationTest {
     assertThat(atWatermark.getNextCursor()).isEqualTo(2L);
   }
 
+  @Test
+  public void testFetch_negativeCursor_clampsToZero() throws Exception {
+    byte[] ohId = clientNode.getKademliaId().getBytes();
+    service.handleRegister(peer, createSignedRegisterRequest());
+    readRegisterResponse();
+
+    service.depositMessage(ohId, MSG1.getBytes(StandardCharsets.UTF_8));
+
+    // A negative cursor is out of range and must behave like cursor 0, never leak into the
+    // composite item keys.
+    service.handleFetch(peer, createSignedFetchRequest(-5));
+    FetchResponse res = readFetchResponse();
+    assertThat(res.getStatus()).isEqualTo(Status.OK);
+    assertThat(res.getItemsCount()).isEqualTo(1);
+    assertThat(res.getItems(0).getSequenceId()).isEqualTo(1L);
+    assertThat(res.getNextCursor()).isEqualTo(1L);
+  }
+
   // --- MS02 AC: AckFetch deletes items with sequence_id <= acked_sequence_id ---
 
   @Test


### PR DESCRIPTION
Follow-up to #258: the Copilot-review fix (negative-cursor clamp + test) was pushed while auto-merge fired on the previous head, so it missed the merge commit. Cherry-picked verbatim (tests: 22/22 OutboundServiceIntegrationTest green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHDH2f2Mc2aib3evJP1oda