### PR TITLE
fix(concurrency): eliminate races behind 2026-07-19 Sentry exceptions

### DIFF
--- a/src/main/java/im/redpanda/jobs/KademliaInsertJob.java
+++ b/src/main/java/im/redpanda/jobs/KademliaInsertJob.java
@@ -8,7 +8,8 @@ import im.redpanda.kademlia.PeerComparator;
 import im.redpanda.proto.KademliaStore;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 
@@ -20,7 +21,10 @@ public class KademliaInsertJob extends Job {
   private static final int SUCCESS = 1;
 
   private final KadContent kadContent;
-  private TreeMap<Peer, Integer> peers = null;
+
+  // ConcurrentSkipListMap: ack() is called from network threads while work()
+  // iterates this map on a job thread (Sentry REDPANDAJ-2E1)
+  private ConcurrentNavigableMap<Peer, Integer> peers = null;
 
   public KademliaInsertJob(ServerContext serverContext, KadContent kadContent) {
     super(serverContext);
@@ -37,7 +41,7 @@ public class KademliaInsertJob extends Job {
     serverContext.getKadStoreManager().put(kadContent);
 
     // lets sort the peers by the destination key
-    peers = new TreeMap<>(new PeerComparator(kadContent.getId()));
+    peers = new ConcurrentSkipListMap<>(new PeerComparator(kadContent.getId()));
 
     // insert all nodes
     Lock lock = peerList.getReadWriteLock().readLock();

--- a/src/main/java/im/redpanda/jobs/KademliaSearchJob.java
+++ b/src/main/java/im/redpanda/jobs/KademliaSearchJob.java
@@ -14,7 +14,8 @@ import im.redpanda.proto.KademliaIdProto;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -40,7 +41,10 @@ public class KademliaSearchJob extends Job {
   private static final int SUCCESS = 1;
 
   private final KademliaId id;
-  private TreeMap<Peer, Integer> peers = null;
+
+  // ConcurrentSkipListMap: ack() is called from network threads while work()
+  // iterates this map on a job thread (Sentry REDPANDAJ-2E9)
+  private ConcurrentNavigableMap<Peer, Integer> peers = null;
   private final ArrayList<KadContent> contents = new ArrayList<>();
 
   public KademliaSearchJob(ServerContext serverContext, KademliaId id) {
@@ -76,7 +80,7 @@ public class KademliaSearchJob extends Job {
     }
 
     // key is not blacklisted, lets sort the peers by the destination key
-    peers = new TreeMap<>(new PeerComparator(id));
+    peers = new ConcurrentSkipListMap<>(new PeerComparator(id));
 
     PeerList peerList = serverContext.getPeerList();
 
@@ -198,23 +202,26 @@ public class KademliaSearchJob extends Job {
 
   protected ArrayList<KadContent> success() {
 
-    if (contents.isEmpty()) {
-      return null;
+    synchronized (contents) {
+      if (contents.isEmpty()) {
+        return null;
+      }
+
+      // lets get the newest one!
+      contents.sort(
+          (o1, o2) ->
+              o1.getTimestamp() < o2.getTimestamp()
+                  ? -1
+                  : o1.getTimestamp() > o2.getTimestamp() ? 1 : 0);
+
+      return contents;
     }
-
-    // lets get the newest one!
-    contents.sort(
-        (o1, o2) ->
-            o1.getTimestamp() < o1.getTimestamp()
-                ? -1
-                : o1.getTimestamp() > o1.getTimestamp() ? 1 : 0);
-
-    return contents;
   }
 
   public void ack(KadContent c, Peer p) {
-    // todo: concurrency?
-    contents.add(c);
+    synchronized (contents) {
+      contents.add(c);
+    }
     peers.put(p, SUCCESS);
   }
 

--- a/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
+++ b/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
@@ -141,21 +141,22 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
           continue;
         }
 
-        if (currentLength == 0) {
-          Node targetNode = serverContext.getNodeStore().getNodeGraph().getEdgeTarget(edge);
-          Peer targetPeer = serverContext.getPeerList().get(targetNode.getNodeId().getKademliaId());
-          if (targetPeer == null || !targetPeer.isConnected()) {
-            continue;
-          }
-        }
-
+        // the edge may have been removed from the graph since we copied the
+        // edge list, check membership before resolving its target
+        // (Sentry REDPANDAJ-2DW, REDPANDAJ-2E5)
         if (!nodeGraph.containsEdge(edge)) {
           continue;
         }
         Node target = nodeGraph.getEdgeTarget(edge);
-
-        if (nodes.contains(target)) {
+        if (target == null || nodes.contains(target)) {
           continue;
+        }
+
+        if (currentLength == 0) {
+          Peer targetPeer = serverContext.getPeerList().get(target.getNodeId().getKademliaId());
+          if (targetPeer == null || !targetPeer.isConnected()) {
+            continue;
+          }
         }
 
         currentNode = target;

--- a/src/main/java/im/redpanda/store/NodeStore.java
+++ b/src/main/java/im/redpanda/store/NodeStore.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import lombok.Getter;
@@ -218,18 +219,26 @@ public class NodeStore {
 
   public void maintainNodes() {
 
-    decayRandomEdge();
+    // all graph mutations have to run under the write lock, otherwise jobs
+    // holding the lock (e.g. PeerPerformanceTestGarlicMessageJob) can observe
+    // edges vanishing mid-iteration (Sentry REDPANDAJ-2DW)
+    readWriteLock.writeLock().lock();
+    try {
+      decayRandomEdge();
 
-    addServerEdges();
+      addServerEdges();
 
-    removeNodeIfNoGoodLinkAvailable();
+      removeNodeIfNoGoodLinkAvailable();
 
-    removeBadScoredNode();
+      removeBadScoredNode();
 
-    addRandomNodeToGraph();
+      addRandomNodeToGraph();
 
-    if (nodeGraph.edgeSet().size() < MAX_EDGES_IN_GRAPH) {
-      addRandomEdgeIfWaitedEnough();
+      if (nodeGraph.edgeSet().size() < MAX_EDGES_IN_GRAPH) {
+        addRandomEdgeIfWaitedEnough();
+      }
+    } finally {
+      readWriteLock.writeLock().unlock();
     }
   }
 
@@ -285,7 +294,18 @@ public class NodeStore {
     if (nodeGraph.outgoingEdgesOf(serverNode).size() < 15
         || nodeGraph.incomingEdgesOf(serverNode).size() < 15) {
 
-      for (Peer peer : serverContext.getPeerList().getPeerArrayList()) {
+      // snapshot under the peer list read lock, the live list is modified by
+      // network threads (Sentry REDPANDAJ-2DZ)
+      ArrayList<Peer> peersSnapshot;
+      Lock peerListLock = serverContext.getPeerList().getReadWriteLock().readLock();
+      peerListLock.lock();
+      try {
+        peersSnapshot = new ArrayList<>(serverContext.getPeerList().getPeerArrayList());
+      } finally {
+        peerListLock.unlock();
+      }
+
+      for (Peer peer : peersSnapshot) {
         if (!peer.isConnected()
             || peer.getNode() == null
             || !nodeGraph.containsVertex(peer.getNode())) {


### PR DESCRIPTION
## Summary

Fixes the five Java-side exception groups Sentry collected over the last night (all on release `ac5423c`):

| Sentry issue | Exception | Root cause |
|---|---|---|
| REDPANDAJ-2E1 (98 ev) | CME in `KademliaInsertJob.work` | `ack()` writes to the `peers` TreeMap from network threads while `work()` iterates it on a job thread |
| REDPANDAJ-2E9 | CME in `KademliaSearchJob.work` | same pattern |
| REDPANDAJ-2DZ | CME in `NodeStore.addServerEdges` | iterated the live peer list without the peer-list read lock |
| REDPANDAJ-2DW (181 ev) | `IllegalArgumentException: no such edge in graph: (null : null)` | `maintainNodes()` mutates the node graph without the NodeStore write lock, so the garlic path calculation saw edges vanish; additionally `getEdgeTarget(edge)` ran before the `containsEdge` guard |
| REDPANDAJ-2E5 | NPE `targetNode is null` in `calculatePathOrAbort` | same ordering problem |

## Changes

- `KademliaInsertJob`/`KademliaSearchJob`: `peers` is now a `ConcurrentSkipListMap` (weakly consistent iteration, no CME); `contents` guarded with `synchronized`; drive-by fix of the `o1`/`o1` typo in the timestamp comparator that made the sort a no-op.
- `NodeStore.maintainNodes()`: whole maintenance pass now runs under the store's write lock. Lock order stays NodeStore → PeerList (same as the garlic job), no reverse order exists in the codebase.
- `NodeStore.addServerEdges()`: iterates a snapshot taken under the peer-list read lock; the lock is released before mutating the graph.
- `PeerPerformanceTestGarlicMessageJob.calculatePathOrAbort()`: `containsEdge` check moved before `getEdgeTarget`, target null-checked, duplicate graph lookup removed.

## Test plan

- `mvn test` green locally (JDK 21).
- After merge: testnet deploy via auto-updater, then watch Sentry — the five issues auto-resolve via the `Fixes` commit footers and should not regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHDH2f2Mc2aib3evJP1oda