### PR TITLE
feat(T43): channel rendezvous DHT record + record_store/record_lookup

### DIFF
--- a/src/main/java/im/redpanda/flaschenpost/FlaschenpostV2.java
+++ b/src/main/java/im/redpanda/flaschenpost/FlaschenpostV2.java
@@ -84,6 +84,22 @@ public final class FlaschenpostV2 {
    */
   public static final byte CMD_DELIVER_ACKED = 0x04;
 
+  /**
+   * Layer command (T43, channel rendezvous): final hop — store the carried channel-rendezvous
+   * KadContent in the DHT on behalf of a DHT-fremd light client. Layer plaintext: {@code [1 cmd][4
+   * len][KademliaStore proto]}. The node validates the record ({@code ChannelDht}) and replicates
+   * it; there is no response (best-effort, the client verifies via a later lookup).
+   */
+  public static final byte CMD_RECORD_STORE = 0x05;
+
+  /**
+   * Layer command (T43, channel rendezvous): final hop — look the channel-rendezvous record up in
+   * the DHT on behalf of a DHT-fremd light client and return it via the contained {@link
+   * ReturnPath}. Layer plaintext: {@code [1 cmd][20 kademlia_key][return_path]}. The answer is a
+   * reverse-garlic tagged deliver into the client's own OH mailbox (see {@code ReverseGarlic}).
+   */
+  public static final byte CMD_RECORD_LOOKUP = 0x06;
+
   /** Length of the reverse-garlic session tag inside a {@link #CMD_DELIVER_TAGGED} layer. */
   public static final int SESSION_TAG_LEN = 16;
 

--- a/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
+++ b/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
@@ -1,10 +1,16 @@
 package im.redpanda.flaschenpost;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import im.redpanda.core.Command;
 import im.redpanda.core.KademliaId;
 import im.redpanda.core.Peer;
 import im.redpanda.core.ServerContext;
+import im.redpanda.jobs.KademliaInsertJob;
+import im.redpanda.jobs.RecordLookupJob;
+import im.redpanda.kademlia.KadContent;
+import im.redpanda.outbound.ChannelDht;
 import im.redpanda.outbound.OutboundService;
+import im.redpanda.proto.KademliaStore;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
@@ -35,6 +41,17 @@ import lombok.extern.slf4j.Slf4j;
 public final class GarlicRouter {
 
   private static final SecureRandom RANDOM = new SecureRandom();
+
+  /**
+   * Global rate limiter for inbound channel-rendezvous record stores (T43). Stores arrive
+   * garlic-wrapped with no attributable source, so a single global cap bounds the DHT-write
+   * amplification a flood can trigger on this node.
+   */
+  private static final RecordStoreRateLimiter RECORD_STORE_RATE_LIMITER =
+      new RecordStoreRateLimiter(
+          RecordStoreRateLimiter.DEFAULT_CAPACITY,
+          RecordStoreRateLimiter.DEFAULT_REFILL_INTERVAL_MS,
+          System.currentTimeMillis());
 
   private GarlicRouter() {}
 
@@ -69,6 +86,8 @@ public final class GarlicRouter {
       case FlaschenpostV2.CMD_DELIVER -> handleDeliver(serverContext, plaintext, false);
       case FlaschenpostV2.CMD_DELIVER_TAGGED -> handleDeliver(serverContext, plaintext, true);
       case FlaschenpostV2.CMD_DELIVER_ACKED -> handleDeliverAcked(serverContext, plaintext);
+      case FlaschenpostV2.CMD_RECORD_STORE -> handleRecordStore(serverContext, plaintext);
+      case FlaschenpostV2.CMD_RECORD_LOOKUP -> handleRecordLookup(serverContext, plaintext);
       default -> log.debug("unknown flaschenpost v2 layer command {}, dropping", cmd);
     }
   }
@@ -204,6 +223,77 @@ public final class GarlicRouter {
       return;
     }
     RoutingAckSender.send(serverContext, returnPath, RoutingAckSender.statusFor(result));
+  }
+
+  /**
+   * CMD_RECORD_STORE (T43): {@code [1 cmd][4 len][KademliaStore proto][ignored padding]}. Stores a
+   * channel-rendezvous record in the DHT on behalf of a DHT-fremd client. The record content is
+   * opaque to us; we only enforce the self-certifying signature, the fixed padded size and the 48 h
+   * TTL ({@link ChannelDht}) plus a global store rate limit. Best-effort, no response — the client
+   * verifies by a later lookup. Malformed layers are dropped silently.
+   */
+  private static void handleRecordStore(ServerContext serverContext, byte[] plaintext) {
+    if (plaintext.length < 1 + 4) {
+      log.debug("flaschenpost v2 record store layer too short, dropping");
+      return;
+    }
+    ByteBuffer buffer = ByteBuffer.wrap(plaintext);
+    buffer.get(); // command byte
+    int len = buffer.getInt();
+    if (len < 0 || len > buffer.remaining()) {
+      log.debug("flaschenpost v2 record store length invalid, dropping");
+      return;
+    }
+    byte[] storeBytes = new byte[len];
+    buffer.get(storeBytes);
+
+    KademliaStore storeMsg;
+    try {
+      storeMsg = KademliaStore.parseFrom(storeBytes);
+    } catch (InvalidProtocolBufferException e) {
+      log.debug("flaschenpost v2 record store payload not parseable, dropping");
+      return;
+    }
+    KadContent record =
+        new KadContent(
+            storeMsg.getTimestamp(),
+            storeMsg.getPublicKey().toByteArray(),
+            storeMsg.getContent().toByteArray(),
+            storeMsg.getSignature().toByteArray());
+    if (!ChannelDht.isValidRecord(record, System.currentTimeMillis())) {
+      log.debug("flaschenpost v2 record store record invalid (sig/size/ttl), dropping");
+      return;
+    }
+    if (!RECORD_STORE_RATE_LIMITER.tryAcquire(System.currentTimeMillis())) {
+      log.debug("channel record store rate limit hit, dropping");
+      return;
+    }
+    // KademliaInsertJob.init() also stores locally; store here too so the record is immediately
+    // resolvable on this node even before the replication job runs.
+    serverContext.getKadStoreManager().put(record);
+    new KademliaInsertJob(serverContext, record).start();
+  }
+
+  /**
+   * CMD_RECORD_LOOKUP (T43): {@code [1 cmd][20 kademlia_key][return_path][ignored padding]}. Looks
+   * the channel-rendezvous record up in the DHT on behalf of a DHT-fremd client and returns it via
+   * the return path (reverse garlic into the client's own OH mailbox, see {@link RecordLookupJob}).
+   * The return path is only structurally validated; malformed layers are dropped silently.
+   */
+  private static void handleRecordLookup(ServerContext serverContext, byte[] plaintext) {
+    if (plaintext.length < 1 + KademliaId.ID_LENGTH_BYTES + ReturnPath.FIXED_LEN) {
+      log.debug("flaschenpost v2 record lookup layer too short, dropping");
+      return;
+    }
+    ByteBuffer buffer = ByteBuffer.wrap(plaintext);
+    buffer.get(); // command byte
+    KademliaId searchedKey = KademliaId.fromBuffer(buffer);
+    ReturnPath returnPath = ReturnPath.parse(buffer);
+    if (returnPath == null) {
+      log.debug("flaschenpost v2 record lookup return path invalid, dropping");
+      return;
+    }
+    RecordLookupJob.lookup(serverContext, searchedKey, returnPath);
   }
 
   /**

--- a/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
+++ b/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
@@ -254,24 +254,28 @@ public final class GarlicRouter {
       log.debug("flaschenpost v2 record store payload not parseable, dropping");
       return;
     }
+    long now = System.currentTimeMillis();
     KadContent record =
         new KadContent(
             storeMsg.getTimestamp(),
             storeMsg.getPublicKey().toByteArray(),
             storeMsg.getContent().toByteArray(),
             storeMsg.getSignature().toByteArray());
-    if (!ChannelDht.isValidRecord(record, System.currentTimeMillis())) {
+    if (!ChannelDht.isValidRecord(record, now)) {
       log.debug("flaschenpost v2 record store record invalid (sig/size/ttl), dropping");
       return;
     }
-    if (!RECORD_STORE_RATE_LIMITER.tryAcquire(System.currentTimeMillis())) {
+    if (!RECORD_STORE_RATE_LIMITER.tryAcquire(now)) {
       log.debug("channel record store rate limit hit, dropping");
       return;
     }
-    // KademliaInsertJob.init() also stores locally; store here too so the record is immediately
-    // resolvable on this node even before the replication job runs.
-    serverContext.getKadStoreManager().put(record);
-    new KademliaInsertJob(serverContext, record).start();
+    // Store locally first so the record is immediately resolvable on this node. Only replicate if
+    // the local put was accepted — KadStoreManager can still reject on its own timestamp bounds,
+    // and
+    // replicating a record we ourselves won't keep would be pointless.
+    if (serverContext.getKadStoreManager().put(record)) {
+      new KademliaInsertJob(serverContext, record).start();
+    }
   }
 
   /**

--- a/src/main/java/im/redpanda/flaschenpost/RecordStoreRateLimiter.java
+++ b/src/main/java/im/redpanda/flaschenpost/RecordStoreRateLimiter.java
@@ -1,0 +1,60 @@
+package im.redpanda.flaschenpost;
+
+/**
+ * T43: a simple global token-bucket rate limiter for inbound channel-rendezvous record stores.
+ *
+ * <p>Record stores arrive garlic-wrapped (see {@code GarlicRouter} record commands), so the
+ * stateless relay cannot attribute them to an authenticated source. A per-source limit is therefore
+ * not available on this path; instead a single global cap bounds the DHT-write amplification a
+ * flood of stores can cause on this node (each accepted store triggers a {@code KademliaInsertJob}
+ * that replicates to two further nodes). Excess stores are dropped silently, exactly like every
+ * other best-effort garlic layer.
+ *
+ * <p>The clock is injectable so the behaviour is deterministic under test.
+ */
+public final class RecordStoreRateLimiter {
+
+  /** Production defaults: burst of 60 stores, refilled at 1 per second (60/min steady state). */
+  public static final int DEFAULT_CAPACITY = 60;
+
+  public static final long DEFAULT_REFILL_INTERVAL_MS = 1000L;
+
+  private final int capacity;
+  private final long refillIntervalMs;
+
+  private double tokens;
+  private long lastRefillMs;
+
+  public RecordStoreRateLimiter(int capacity, long refillIntervalMs, long nowMs) {
+    if (capacity <= 0 || refillIntervalMs <= 0) {
+      throw new IllegalArgumentException("capacity and refill interval must be positive");
+    }
+    this.capacity = capacity;
+    this.refillIntervalMs = refillIntervalMs;
+    this.tokens = capacity;
+    this.lastRefillMs = nowMs;
+  }
+
+  /**
+   * Tries to consume one token for a record store at {@code nowMs}.
+   *
+   * @return {@code true} if the store is admitted, {@code false} if the bucket is empty (drop)
+   */
+  public synchronized boolean tryAcquire(long nowMs) {
+    refill(nowMs);
+    if (tokens >= 1.0) {
+      tokens -= 1.0;
+      return true;
+    }
+    return false;
+  }
+
+  private void refill(long nowMs) {
+    if (nowMs <= lastRefillMs) {
+      return;
+    }
+    double refilled = (double) (nowMs - lastRefillMs) / refillIntervalMs;
+    tokens = Math.min(capacity, tokens + refilled);
+    lastRefillMs = nowMs;
+  }
+}

--- a/src/main/java/im/redpanda/flaschenpost/ReverseGarlic.java
+++ b/src/main/java/im/redpanda/flaschenpost/ReverseGarlic.java
@@ -1,0 +1,110 @@
+package im.redpanda.flaschenpost;
+
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.ServerContext;
+import im.redpanda.outbound.OutboundService;
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.crypto.params.X25519PublicKeyParameters;
+
+/**
+ * Shared reverse-garlic dispatch: sends an arbitrary payload back to a sender through the
+ * sender-chosen {@link ReturnPath} as a standard MS04 onion whose innermost {@code
+ * CMD_DELIVER_TAGGED} layer lands in the sender's own OH mailbox under the ack session tag.
+ *
+ * <p>This is the mechanism MS06 R-ACKs use ({@link RoutingAckSender}) and that T43 reuses to return
+ * a channel-rendezvous record to a DHT-fremd light client (the answer to a {@code record_lookup}).
+ * Best-effort and fire-and-forget like the rest of the flaschenpost layer: build or routing
+ * failures are logged and dropped, there are no retries. With {@code hop_count = 0} this node acts
+ * as the final station itself (local deposit into the ack OH, MS02b-forwarding if the OH is
+ * remote).
+ */
+@Slf4j
+public final class ReverseGarlic {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private ReverseGarlic() {}
+
+  /**
+   * Sends {@code payload} back along {@code returnPath}. The payload is deposited into the ack OH
+   * as a tagged MailItem; the sender correlates it with its request via the ack session tag it
+   * chose.
+   */
+  public static void sendTaggedPayload(
+      ServerContext serverContext, ReturnPath returnPath, byte[] payload) {
+    List<ReturnPath.Hop> hops = returnPath.hops();
+    if (hops.isEmpty()) {
+      deliverLocally(serverContext, returnPath, payload);
+      return;
+    }
+    byte[] packet;
+    try {
+      packet = buildOnion(returnPath, payload);
+    } catch (GeneralSecurityException | IllegalArgumentException e) {
+      log.debug("failed to build reverse-garlic onion, dropping: {}", e.getMessage());
+      return;
+    }
+    GarlicRouter.routeToNextHop(serverContext, hops.get(0).kademliaId(), packet);
+  }
+
+  /** Deposits the payload on this node (hop_count = 0), MS02b-forwarding if the OH is remote. */
+  private static void deliverLocally(
+      ServerContext serverContext, ReturnPath returnPath, byte[] payload) {
+    OutboundService outboundService = serverContext.getOutboundService();
+    if (outboundService == null) {
+      return;
+    }
+    OutboundService.DepositResult result =
+        outboundService.depositMessage(returnPath.ackOhId(), payload, returnPath.ackSessionTag());
+    if (result == OutboundService.DepositResult.NOT_FOUND) {
+      OhForwarder.forward(
+          serverContext, returnPath.ackOhId(), payload, 0, returnPath.ackSessionTag());
+    } else if (result != OutboundService.DepositResult.DEPOSITED) {
+      log.debug("reverse-garlic payload not stored locally: {}", result);
+    }
+  }
+
+  /**
+   * Builds the packet exactly like a client-side MS04 send: innermost {@code CMD_DELIVER_TAGGED}
+   * layer for the last hop, wrapped in {@code CMD_FORWARD} layers along the return path in reverse
+   * order.
+   */
+  private static byte[] buildOnion(ReturnPath returnPath, byte[] payload)
+      throws GeneralSecurityException {
+    List<ReturnPath.Hop> hops = returnPath.hops();
+    ReturnPath.Hop last = hops.get(hops.size() - 1);
+
+    ByteBuffer deliver =
+        ByteBuffer.allocate(
+            1 + KademliaId.ID_LENGTH_BYTES + FlaschenpostV2.SESSION_TAG_LEN + 4 + payload.length);
+    deliver.put(FlaschenpostV2.CMD_DELIVER_TAGGED);
+    deliver.put(returnPath.ackOhId());
+    deliver.put(returnPath.ackSessionTag());
+    deliver.putInt(payload.length);
+    deliver.put(payload);
+
+    byte[] body =
+        FlaschenpostV2.encryptLayer(
+            new X25519PublicKeyParameters(last.encryptionPub(), 0),
+            last.kademliaId(),
+            deliver.array());
+
+    for (int i = hops.size() - 2; i >= 0; i--) {
+      ReturnPath.Hop hop = hops.get(i);
+      ByteBuffer forward = ByteBuffer.allocate(1 + KademliaId.ID_LENGTH_BYTES + body.length);
+      forward.put(FlaschenpostV2.CMD_FORWARD);
+      forward.put(hops.get(i + 1).kademliaId().getBytes());
+      forward.put(body);
+      body =
+          FlaschenpostV2.encryptLayer(
+              new X25519PublicKeyParameters(hop.encryptionPub(), 0),
+              hop.kademliaId(),
+              forward.array());
+    }
+    return FlaschenpostV2.buildPacket(RANDOM.nextInt(), hops.get(0).kademliaId(), body);
+  }
+}

--- a/src/main/java/im/redpanda/flaschenpost/RoutingAckSender.java
+++ b/src/main/java/im/redpanda/flaschenpost/RoutingAckSender.java
@@ -1,20 +1,14 @@
 package im.redpanda.flaschenpost;
 
-import im.redpanda.core.KademliaId;
 import im.redpanda.core.ServerContext;
 import im.redpanda.outbound.OutboundService;
 import im.redpanda.outbound.v1.RoutingAck;
-import java.nio.ByteBuffer;
-import java.security.GeneralSecurityException;
-import java.security.SecureRandom;
-import java.util.List;
-import lombok.extern.slf4j.Slf4j;
-import org.bouncycastle.crypto.params.X25519PublicKeyParameters;
 
 /**
  * MS06 R-ACK dispatch: builds the {@link RoutingAck} for a deposit decision and sends it back
- * through the sender-chosen {@link ReturnPath} as a standard MS04 onion (innermost layer = {@code
- * CMD_DELIVER_TAGGED} into the sender's own OH mailbox, tagged with the ack session tag).
+ * through the sender-chosen {@link ReturnPath} via {@link ReverseGarlic} (a standard MS04 onion
+ * whose innermost {@code CMD_DELIVER_TAGGED} layer lands in the sender's own OH mailbox, tagged
+ * with the ack session tag).
  *
  * <p>Best-effort and fire-and-forget like the rest of the flaschenpost layer: build or routing
  * failures are logged and dropped, there are no retries (the sender's R-ACK timeout plus MS02-style
@@ -22,7 +16,6 @@ import org.bouncycastle.crypto.params.X25519PublicKeyParameters;
  * innermost layer), so acknowledgment loops are impossible by construction. Amplification is
  * bounded at factor one: a 2048-byte acked deliver triggers at most one 2048-byte R-ACK packet.
  */
-@Slf4j
 public final class RoutingAckSender {
 
   /** RoutingAck.status: message stored in the target OH mailbox. */
@@ -36,8 +29,6 @@ public final class RoutingAckSender {
 
   /** RoutingAck.status: deposit rejected as bad request (e.g. oversized payload). */
   public static final int STATUS_REJECTED = 3;
-
-  private static final SecureRandom RANDOM = new SecureRandom();
 
   private RoutingAckSender() {}
 
@@ -56,11 +47,11 @@ public final class RoutingAckSender {
   }
 
   /**
-   * Builds the RoutingAck payload and sends it along the return path. With hops the packet is a
-   * standard MS04 onion routed toward the first hop; without hops ({@code hop_count = 0}) this node
-   * acts as the final station itself: local deposit into the ack OH, falling back to the MS02b
-   * forward toward its host node. The forwarded deposit carries no return path — R-ACKs are never
-   * acknowledged.
+   * Builds the RoutingAck payload and sends it along the return path via {@link ReverseGarlic}.
+   * With hops the packet is a standard MS04 onion routed toward the first hop; without hops ({@code
+   * hop_count = 0}) the depositing node acts as the final station itself (local deposit into the
+   * ack OH, MS02b-forwarding if remote). The forwarded deposit carries no return path — R-ACKs are
+   * never acknowledged.
    */
   public static void send(ServerContext serverContext, ReturnPath returnPath, int status) {
     byte[] rAck =
@@ -69,76 +60,6 @@ public final class RoutingAckSender {
             .setStatus(status)
             .build()
             .toByteArray();
-
-    List<ReturnPath.Hop> hops = returnPath.hops();
-    if (hops.isEmpty()) {
-      deliverLocally(serverContext, returnPath, rAck);
-      return;
-    }
-
-    byte[] packet;
-    try {
-      packet = buildAckOnion(returnPath, rAck);
-    } catch (GeneralSecurityException | IllegalArgumentException e) {
-      log.debug("failed to build R-ACK onion, dropping: {}", e.getMessage());
-      return;
-    }
-    GarlicRouter.routeToNextHop(serverContext, hops.get(0).kademliaId(), packet);
-  }
-
-  /** Deposits the R-ACK on this node (hop_count = 0), MS02b-forwarding if the OH is remote. */
-  private static void deliverLocally(
-      ServerContext serverContext, ReturnPath returnPath, byte[] rAck) {
-    OutboundService outboundService = serverContext.getOutboundService();
-    if (outboundService == null) {
-      return;
-    }
-    OutboundService.DepositResult result =
-        outboundService.depositMessage(returnPath.ackOhId(), rAck, returnPath.ackSessionTag());
-    if (result == OutboundService.DepositResult.NOT_FOUND) {
-      OhForwarder.forward(serverContext, returnPath.ackOhId(), rAck, 0, returnPath.ackSessionTag());
-    } else if (result != OutboundService.DepositResult.DEPOSITED) {
-      log.debug("R-ACK not stored locally: {}", result);
-    }
-  }
-
-  /**
-   * Builds the R-ACK packet exactly like a client-side MS04 send: innermost {@code
-   * CMD_DELIVER_TAGGED} layer for the last hop, wrapped in {@code CMD_FORWARD} layers along the
-   * return path in reverse order.
-   */
-  private static byte[] buildAckOnion(ReturnPath returnPath, byte[] rAck)
-      throws GeneralSecurityException {
-    List<ReturnPath.Hop> hops = returnPath.hops();
-    ReturnPath.Hop last = hops.get(hops.size() - 1);
-
-    ByteBuffer deliver =
-        ByteBuffer.allocate(
-            1 + KademliaId.ID_LENGTH_BYTES + FlaschenpostV2.SESSION_TAG_LEN + 4 + rAck.length);
-    deliver.put(FlaschenpostV2.CMD_DELIVER_TAGGED);
-    deliver.put(returnPath.ackOhId());
-    deliver.put(returnPath.ackSessionTag());
-    deliver.putInt(rAck.length);
-    deliver.put(rAck);
-
-    byte[] body =
-        FlaschenpostV2.encryptLayer(
-            new X25519PublicKeyParameters(last.encryptionPub(), 0),
-            last.kademliaId(),
-            deliver.array());
-
-    for (int i = hops.size() - 2; i >= 0; i--) {
-      ReturnPath.Hop hop = hops.get(i);
-      ByteBuffer forward = ByteBuffer.allocate(1 + KademliaId.ID_LENGTH_BYTES + body.length);
-      forward.put(FlaschenpostV2.CMD_FORWARD);
-      forward.put(hops.get(i + 1).kademliaId().getBytes());
-      forward.put(body);
-      body =
-          FlaschenpostV2.encryptLayer(
-              new X25519PublicKeyParameters(hop.encryptionPub(), 0),
-              hop.kademliaId(),
-              forward.array());
-    }
-    return FlaschenpostV2.buildPacket(RANDOM.nextInt(), hops.get(0).kademliaId(), body);
+    ReverseGarlic.sendTaggedPayload(serverContext, returnPath, rAck);
   }
 }

--- a/src/main/java/im/redpanda/jobs/RecordLookupJob.java
+++ b/src/main/java/im/redpanda/jobs/RecordLookupJob.java
@@ -1,0 +1,144 @@
+package im.redpanda.jobs;
+
+import static com.google.protobuf.ByteString.copyFrom;
+
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.ServerContext;
+import im.redpanda.flaschenpost.ReturnPath;
+import im.redpanda.flaschenpost.ReverseGarlic;
+import im.redpanda.kademlia.KadContent;
+import im.redpanda.outbound.ChannelDht;
+import im.redpanda.proto.KademliaStore;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * T43: resolves a channel-rendezvous record on behalf of a DHT-fremd light client and returns it
+ * via the client-chosen {@link ReturnPath} (reverse garlic). Mirrors {@link OhResolveJob}: the
+ * local KadStore is checked first (no delay, a local read leaks nothing), otherwise a randomized
+ * delayed DHT search is issued. Whatever the outcome, exactly one reverse-garlic answer is sent so
+ * the client never waits out a timeout for a record that simply does not exist yet.
+ *
+ * <p>The answer payload is framed as {@code [1 status][KademliaStore proto if found]}: {@code
+ * status = 1} carries the newest valid record ({@link ChannelDht#extractNewest}) so the client can
+ * re-verify it self-certifyingly and decrypt it; {@code status = 0} means "no record", nothing
+ * follows.
+ */
+public class RecordLookupJob extends KademliaSearchJob {
+
+  private static final Logger logger = LogManager.getLogger();
+
+  /** Answer status byte: no valid record found for the key. */
+  public static final byte RESPONSE_NOT_FOUND = 0x00;
+
+  /** Answer status byte: a valid record follows as a serialized {@link KademliaStore}. */
+  public static final byte RESPONSE_FOUND = 0x01;
+
+  /** Upper bound for the randomized delay before the DHT search is issued (anti-profiling). */
+  static final long LOOKUP_DELAY_JITTER_MS = Duration.ofMillis(1500).toMillis();
+
+  private final KademliaId searchedKey;
+  private final ReturnPath returnPath;
+  private boolean answered = false;
+
+  RecordLookupJob(ServerContext serverContext, KademliaId searchedKey, ReturnPath returnPath) {
+    super(serverContext, searchedKey);
+    this.searchedKey = searchedKey;
+    this.returnPath = returnPath;
+  }
+
+  /**
+   * Resolves the rendezvous record for {@code searchedKey}: local KadStore first (no delay), then a
+   * randomized delayed DHT search. Exactly one reverse-garlic answer is sent.
+   */
+  public static void lookup(
+      ServerContext serverContext, KademliaId searchedKey, ReturnPath returnPath) {
+    long now = System.currentTimeMillis();
+    KadContent local = serverContext.getKadStoreManager().get(searchedKey);
+    if (local != null && ChannelDht.extractNewest(List.of(local), searchedKey, now) != null) {
+      respond(serverContext, searchedKey, returnPath, local);
+      return;
+    }
+    new DelayedSearchJob(serverContext, searchedKey, returnPath).start();
+  }
+
+  @Override
+  protected ArrayList<KadContent> success() {
+    ArrayList<KadContent> contents = super.success();
+    KadContent record = ChannelDht.extractNewest(contents, searchedKey, System.currentTimeMillis());
+    fireAnswer(record);
+    return contents;
+  }
+
+  @Override
+  protected void fail() {
+    fireAnswer(null);
+  }
+
+  private synchronized void fireAnswer(KadContent record) {
+    if (!answered) {
+      answered = true;
+      respond(serverContext, searchedKey, returnPath, record);
+    }
+  }
+
+  /** Frames the answer and sends it back through the return path. {@code record} may be null. */
+  static void respond(
+      ServerContext serverContext,
+      KademliaId searchedKey,
+      ReturnPath returnPath,
+      KadContent record) {
+    KadContent valid =
+        record == null
+            ? null
+            : ChannelDht.extractNewest(List.of(record), searchedKey, System.currentTimeMillis());
+    byte[] payload;
+    if (valid == null) {
+      payload = new byte[] {RESPONSE_NOT_FOUND};
+    } else {
+      byte[] store =
+          KademliaStore.newBuilder()
+              .setTimestamp(valid.getTimestamp())
+              .setPublicKey(copyFrom(valid.getPubkey()))
+              .setContent(copyFrom(valid.getContent()))
+              .setSignature(copyFrom(valid.getSignature()))
+              .build()
+              .toByteArray();
+      payload = ByteBuffer.allocate(1 + store.length).put(RESPONSE_FOUND).put(store).array();
+    }
+    ReverseGarlic.sendTaggedPayload(serverContext, returnPath, payload);
+    logger.debug("answered channel record lookup, found={}", valid != null);
+  }
+
+  /** One-shot job adding the randomized anti-profiling delay before the actual DHT search. */
+  static class DelayedSearchJob extends Job {
+
+    private final KademliaId searchedKey;
+    private final ReturnPath returnPath;
+
+    DelayedSearchJob(ServerContext serverContext, KademliaId searchedKey, ReturnPath returnPath) {
+      super(serverContext, rand.nextLong(LOOKUP_DELAY_JITTER_MS + 1), false, true);
+      this.searchedKey = searchedKey;
+      this.returnPath = returnPath;
+    }
+
+    @Override
+    public void init() {
+      // no setup needed
+    }
+
+    @Override
+    public void work() {
+      try {
+        new RecordLookupJob(serverContext, searchedKey, returnPath).start();
+        logger.debug("started delayed channel record lookup search");
+      } finally {
+        done();
+      }
+    }
+  }
+}

--- a/src/main/java/im/redpanda/outbound/ChannelDht.java
+++ b/src/main/java/im/redpanda/outbound/ChannelDht.java
@@ -1,0 +1,199 @@
+package im.redpanda.outbound;
+
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.NodeId;
+import im.redpanda.crypt.Sha256Hash;
+import im.redpanda.kademlia.KadContent;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.util.List;
+
+/**
+ * T43 channel rendezvous DHT primitives (multi-OH / DHT-rendezvous, {@code
+ * plans/PLAN-multi-oh-dht.md}).
+ *
+ * <p>A channel is a keypair; QR v4 shares the 32-byte channel secret, so every participant — and
+ * only they — can compute the same derived rendezvous keypair, hence the same daily-rotating
+ * Kademlia key, sign records and decrypt their content. The rendezvous record maps a channel to its
+ * participants' current OH lists so a channel heals purely over the DHT even when all host nodes
+ * are unreachable.
+ *
+ * <p>Key derivation (mirrors {@link OhDht}, but seeded from the channel <em>secret</em> instead of
+ * a public identifier): {@code recordNodeId = NodeId.fromSeed(SHA256(DOMAIN_TAG ||
+ * channelSecret))}. Seeding from the secret is deliberate — the channel public key is embedded in
+ * every stored record for signature verification, so deriving the signing key from anything public
+ * would let any observer forge records. Only holders of the channel secret can therefore publish or
+ * overwrite a record. The Kademlia key is the standard self-certifying {@code H(dateUTC ||
+ * recordPubkey)}; the domain tag lives in the derived keypair's namespace, keeping it disjoint from
+ * node ids and OH announce records.
+ *
+ * <p>The record content is an <em>opaque ciphertext</em> to nodes: it is encrypted with {@code
+ * k_enc = HKDF(channel_secret)} and carries the participant list, names and per-participant OH
+ * lists (newest-wins per participant entry via an inner timestamp — a client-side merge, see T44).
+ * Nodes never parse it; they only enforce the self-certifying signature, the fixed padded size, the
+ * 48 h TTL and a global store rate limit.
+ *
+ * <p>Anti-profiling: records are padded to a fixed {@link #RECORD_SIZE_BYTES} so stored/answered
+ * sizes never reveal which channel is being published or resolved. Store and lookup travel
+ * garlic-wrapped to a <em>remote</em> node (the light client stays DHT-fremd), so the directly
+ * connected node does not learn the query interest (see {@code GarlicRouter} record commands and
+ * the T43 spec decisions).
+ */
+public final class ChannelDht {
+
+  static {
+    Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+  }
+
+  /**
+   * Domain separation tag: rendezvous record keys live in their own namespace, distinct from node
+   * ids ({@link OhDht} uses {@code redpanda.oh.announce.v1}).
+   */
+  private static final byte[] DOMAIN_TAG =
+      "redpanda.channel.rendezvous.v1".getBytes(StandardCharsets.UTF_8);
+
+  /**
+   * Fixed serialized size of every rendezvous record content. One bucket for all channels so record
+   * size leaks nothing (per the spec's single-padding-bucket decision). The content is opaque:
+   * {@code [4 ciphertextLen][ciphertext][random padding]} up to this size.
+   */
+  public static final int RECORD_SIZE_BYTES = 512;
+
+  /** Length prefix (bytes) in front of the opaque ciphertext inside the padded record. */
+  public static final int CIPHERTEXT_LEN_PREFIX = 4;
+
+  /** Largest ciphertext that still fits the fixed record after the length prefix. */
+  public static final int MAX_CIPHERTEXT_BYTES = RECORD_SIZE_BYTES - CIPHERTEXT_LEN_PREFIX;
+
+  /**
+   * Maximum age of a rendezvous record before it is considered stale. The spec sets a 48 h TTL;
+   * records rotate under the UTC-day key, so a record published late yesterday must stay usable
+   * across today, hence 48 h plus a small rotation slack.
+   */
+  public static final long MAX_RECORD_AGE_MS = 1000L * 60 * 60 * (48 + 2); // 48h TTL + 2h slack
+
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+  private ChannelDht() {}
+
+  /**
+   * Derives the deterministic rendezvous record NodeId for a channel: {@code seed = SHA256(tag ||
+   * channelSecret)} → {@link NodeId#fromSeed}. Same channel secret → same keypair on every device.
+   * Only holders of the channel secret can compute (and therefore sign with) this key.
+   */
+  public static NodeId deriveRecordNodeId(byte[] channelSecret) {
+    ByteBuffer seedInput = ByteBuffer.allocate(DOMAIN_TAG.length + channelSecret.length);
+    seedInput.put(DOMAIN_TAG).put(channelSecret);
+    byte[] seed = Sha256Hash.create(seedInput.array()).getBytes();
+    return NodeId.fromSeed(seed);
+  }
+
+  /**
+   * The Kademlia key the rendezvous record for this channel lives under at {@code timestampMs} (the
+   * key rotates with the UTC date, like all KadContent ids).
+   */
+  public static KademliaId rendezvousKademliaId(byte[] channelSecret, long timestampMs) {
+    return KadContent.createKademliaId(
+        timestampMs, deriveRecordNodeId(channelSecret).exportPublic());
+  }
+
+  /**
+   * Builds the signed, fixed-size rendezvous KadContent for a channel. {@code ciphertext} is the
+   * already k_enc-encrypted channel state; it is framed as {@code [4 len][ciphertext][random
+   * padding]} and signed with the derived record key. Reference for the client-side build (T44).
+   *
+   * @throws IllegalArgumentException if the ciphertext does not fit the fixed record
+   */
+  public static KadContent buildRecordContent(byte[] channelSecret, byte[] ciphertext, long nowMs) {
+    byte[] padded = padToFixedSize(ciphertext);
+    NodeId recordNodeId = deriveRecordNodeId(channelSecret);
+    KadContent kadContent = new KadContent(nowMs, recordNodeId.exportPublic(), padded);
+    kadContent.signWith(recordNodeId);
+    return kadContent;
+  }
+
+  /** Frames and pads the opaque ciphertext to exactly {@link #RECORD_SIZE_BYTES}. */
+  private static byte[] padToFixedSize(byte[] ciphertext) {
+    if (ciphertext.length > MAX_CIPHERTEXT_BYTES) {
+      throw new IllegalArgumentException(
+          "channel record ciphertext too large: "
+              + ciphertext.length
+              + " > "
+              + MAX_CIPHERTEXT_BYTES);
+    }
+    ByteBuffer buffer = ByteBuffer.allocate(RECORD_SIZE_BYTES);
+    buffer.putInt(ciphertext.length);
+    buffer.put(ciphertext);
+    byte[] padding = new byte[buffer.remaining()];
+    SECURE_RANDOM.nextBytes(padding);
+    buffer.put(padding);
+    return buffer.array();
+  }
+
+  /**
+   * Extracts the opaque ciphertext from a padded record content, or {@code null} if the framing is
+   * malformed. Used by clients (T44) after a successful lookup; nodes never need this.
+   */
+  public static byte[] extractCiphertext(byte[] recordContent) {
+    if (recordContent == null || recordContent.length != RECORD_SIZE_BYTES) {
+      return null;
+    }
+    ByteBuffer buffer = ByteBuffer.wrap(recordContent);
+    int len = buffer.getInt();
+    if (len < 0 || len > buffer.remaining()) {
+      return null;
+    }
+    byte[] ciphertext = new byte[len];
+    buffer.get(ciphertext);
+    return ciphertext;
+  }
+
+  /**
+   * Validates a single record as accepted for storage / serving: signed by the embedded pubkey
+   * (self-certifying — the pubkey pins the Kademlia key), exactly the fixed padded size (uniformity
+   * is part of the anti-profiling contract) and not older than {@link #MAX_RECORD_AGE_MS}. The
+   * content stays opaque — the node deliberately cannot tell which channel it belongs to.
+   */
+  public static boolean isValidRecord(KadContent content, long nowMs) {
+    if (content == null || content.getContent() == null) {
+      return false;
+    }
+    if (content.getContent().length != RECORD_SIZE_BYTES) {
+      return false;
+    }
+    if (nowMs - content.getTimestamp() > MAX_RECORD_AGE_MS) {
+      return false;
+    }
+    return content.verify();
+  }
+
+  /**
+   * Picks the newest valid record for {@code searchedKey} from DHT results. Besides {@link
+   * #isValidRecord} the record's self-certifying id must equal the searched key, so a peer cannot
+   * smuggle a foreign (but validly signed) record into the answer. Newest timestamp wins (a channel
+   * republishes daily and on every OH change).
+   *
+   * @return the newest qualifying record, or {@code null} if none qualifies
+   */
+  public static KadContent extractNewest(
+      List<KadContent> contents, KademliaId searchedKey, long nowMs) {
+    if (contents == null || contents.isEmpty()) {
+      return null;
+    }
+    KadContent best = null;
+    for (KadContent content : contents) {
+      if (content == null || !isValidRecord(content, nowMs)) {
+        continue;
+      }
+      if (!content.getId().equals(searchedKey)) {
+        continue;
+      }
+      if (best == null || content.getTimestamp() > best.getTimestamp()) {
+        best = content;
+      }
+    }
+    return best;
+  }
+}

--- a/src/main/java/im/redpanda/outbound/ChannelDht.java
+++ b/src/main/java/im/redpanda/outbound/ChannelDht.java
@@ -6,7 +6,6 @@ import im.redpanda.crypt.Sha256Hash;
 import im.redpanda.kademlia.KadContent;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
 import java.security.Security;
 import java.util.List;
 
@@ -56,16 +55,12 @@ public final class ChannelDht {
 
   /**
    * Fixed serialized size of every rendezvous record content. One bucket for all channels so record
-   * size leaks nothing (per the spec's single-padding-bucket decision). The content is opaque:
-   * {@code [4 ciphertextLen][ciphertext][random padding]} up to this size.
+   * size leaks nothing (per the spec's single-padding-bucket decision). The content is fully opaque
+   * to nodes: the client's {@code [nonce][AEAD ciphertext of a fixed-size plaintext]} blob, sized
+   * to exactly this many bytes. All length/padding metadata lives <em>inside</em> the encrypted
+   * plaintext, so no cleartext field ever reveals the real payload size.
    */
   public static final int RECORD_SIZE_BYTES = 512;
-
-  /** Length prefix (bytes) in front of the opaque ciphertext inside the padded record. */
-  public static final int CIPHERTEXT_LEN_PREFIX = 4;
-
-  /** Largest ciphertext that still fits the fixed record after the length prefix. */
-  public static final int MAX_CIPHERTEXT_BYTES = RECORD_SIZE_BYTES - CIPHERTEXT_LEN_PREFIX;
 
   /**
    * Maximum age of a rendezvous record before it is considered stale. The spec sets a 48 h TTL;
@@ -74,7 +69,12 @@ public final class ChannelDht {
    */
   public static final long MAX_RECORD_AGE_MS = 1000L * 60 * 60 * (48 + 2); // 48h TTL + 2h slack
 
-  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+  /**
+   * Tolerated clock skew for records dated ahead of now. Records further in the future are rejected
+   * so a clock-skewed (or malicious) peer cannot make a future-dated record win the newest-wins
+   * selection. Mirrors {@link im.redpanda.kademlia.KadStoreManager}'s 15-minute future bound.
+   */
+  public static final long MAX_FUTURE_SKEW_MS = 1000L * 60 * 15; // 15 min
 
   private ChannelDht() {}
 
@@ -100,61 +100,35 @@ public final class ChannelDht {
   }
 
   /**
-   * Builds the signed, fixed-size rendezvous KadContent for a channel. {@code ciphertext} is the
-   * already k_enc-encrypted channel state; it is framed as {@code [4 len][ciphertext][random
-   * padding]} and signed with the derived record key. Reference for the client-side build (T44).
+   * Builds the signed rendezvous KadContent for a channel. {@code opaqueContent} is the client's
+   * already-encrypted, fixed-size record blob (nonce + AEAD ciphertext of a fixed-size plaintext);
+   * it must be exactly {@link #RECORD_SIZE_BYTES} bytes and is signed with the derived record key.
+   * Reference for the client-side build (T44). Nodes never parse the content.
    *
-   * @throws IllegalArgumentException if the ciphertext does not fit the fixed record
+   * @throws IllegalArgumentException if {@code opaqueContent} is not exactly the fixed bucket size
    */
-  public static KadContent buildRecordContent(byte[] channelSecret, byte[] ciphertext, long nowMs) {
-    byte[] padded = padToFixedSize(ciphertext);
+  public static KadContent buildRecordContent(
+      byte[] channelSecret, byte[] opaqueContent, long nowMs) {
+    if (opaqueContent.length != RECORD_SIZE_BYTES) {
+      throw new IllegalArgumentException(
+          "channel record content must be exactly "
+              + RECORD_SIZE_BYTES
+              + " bytes, was "
+              + opaqueContent.length);
+    }
     NodeId recordNodeId = deriveRecordNodeId(channelSecret);
-    KadContent kadContent = new KadContent(nowMs, recordNodeId.exportPublic(), padded);
+    KadContent kadContent =
+        new KadContent(nowMs, recordNodeId.exportPublic(), opaqueContent.clone());
     kadContent.signWith(recordNodeId);
     return kadContent;
   }
 
-  /** Frames and pads the opaque ciphertext to exactly {@link #RECORD_SIZE_BYTES}. */
-  private static byte[] padToFixedSize(byte[] ciphertext) {
-    if (ciphertext.length > MAX_CIPHERTEXT_BYTES) {
-      throw new IllegalArgumentException(
-          "channel record ciphertext too large: "
-              + ciphertext.length
-              + " > "
-              + MAX_CIPHERTEXT_BYTES);
-    }
-    ByteBuffer buffer = ByteBuffer.allocate(RECORD_SIZE_BYTES);
-    buffer.putInt(ciphertext.length);
-    buffer.put(ciphertext);
-    byte[] padding = new byte[buffer.remaining()];
-    SECURE_RANDOM.nextBytes(padding);
-    buffer.put(padding);
-    return buffer.array();
-  }
-
-  /**
-   * Extracts the opaque ciphertext from a padded record content, or {@code null} if the framing is
-   * malformed. Used by clients (T44) after a successful lookup; nodes never need this.
-   */
-  public static byte[] extractCiphertext(byte[] recordContent) {
-    if (recordContent == null || recordContent.length != RECORD_SIZE_BYTES) {
-      return null;
-    }
-    ByteBuffer buffer = ByteBuffer.wrap(recordContent);
-    int len = buffer.getInt();
-    if (len < 0 || len > buffer.remaining()) {
-      return null;
-    }
-    byte[] ciphertext = new byte[len];
-    buffer.get(ciphertext);
-    return ciphertext;
-  }
-
   /**
    * Validates a single record as accepted for storage / serving: signed by the embedded pubkey
-   * (self-certifying — the pubkey pins the Kademlia key), exactly the fixed padded size (uniformity
-   * is part of the anti-profiling contract) and not older than {@link #MAX_RECORD_AGE_MS}. The
-   * content stays opaque — the node deliberately cannot tell which channel it belongs to.
+   * (self-certifying — the pubkey pins the Kademlia key), exactly the fixed bucket size (uniformity
+   * is part of the anti-profiling contract), not older than {@link #MAX_RECORD_AGE_MS} and not
+   * further than {@link #MAX_FUTURE_SKEW_MS} in the future. The content stays opaque — the node
+   * deliberately cannot tell which channel it belongs to.
    */
   public static boolean isValidRecord(KadContent content, long nowMs) {
     if (content == null || content.getContent() == null) {
@@ -164,6 +138,9 @@ public final class ChannelDht {
       return false;
     }
     if (nowMs - content.getTimestamp() > MAX_RECORD_AGE_MS) {
+      return false;
+    }
+    if (content.getTimestamp() - nowMs > MAX_FUTURE_SKEW_MS) {
       return false;
     }
     return content.verify();

--- a/src/test/java/im/redpanda/flaschenpost/RecordDhtRouterTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/RecordDhtRouterTest.java
@@ -101,8 +101,8 @@ public class RecordDhtRouterTest {
   public void storeThenLookup_roundTripsRecordBackThroughReturnPath() throws Exception {
     byte[] secret = randomChannelSecret();
     long now = System.currentTimeMillis();
-    byte[] ciphertext = randomBytes(120);
-    KadContent record = ChannelDht.buildRecordContent(secret, ciphertext, now);
+    byte[] content = randomBytes(ChannelDht.RECORD_SIZE_BYTES);
+    KadContent record = ChannelDht.buildRecordContent(secret, content, now);
     KademliaId key = ChannelDht.rendezvousKademliaId(secret, now);
 
     // 1) store
@@ -125,8 +125,9 @@ public class RecordDhtRouterTest {
     assertThat(returned.getContent().toByteArray())
         .as("the exact stored record content is returned")
         .isEqualTo(record.getContent());
-    assertThat(ChannelDht.extractCiphertext(returned.getContent().toByteArray()))
-        .isEqualTo(ciphertext);
+    assertThat(returned.getContent().toByteArray())
+        .as("returned opaque content matches what was stored")
+        .isEqualTo(content);
   }
 
   @Test

--- a/src/test/java/im/redpanda/flaschenpost/RecordDhtRouterTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/RecordDhtRouterTest.java
@@ -1,0 +1,178 @@
+package im.redpanda.flaschenpost;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.ByteString;
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.ServerContext;
+import im.redpanda.jobs.RecordLookupJob;
+import im.redpanda.kademlia.KadContent;
+import im.redpanda.outbound.ChannelDht;
+import im.redpanda.outbound.OutboundHandleStore;
+import im.redpanda.outbound.OutboundMailboxStore;
+import im.redpanda.outbound.OutboundService;
+import im.redpanda.outbound.v1.MailItem;
+import im.redpanda.proto.KademliaStore;
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * T43 acceptance: a garlic-wrapped {@code CMD_RECORD_STORE} stores a channel-rendezvous record in
+ * the node's DHT, and a garlic-wrapped {@code CMD_RECORD_LOOKUP} resolves it and returns it via the
+ * client-chosen return path (reverse garlic into the client's own OH mailbox). Uses a hop_count = 0
+ * return path so the answer is deposited locally and deterministically, mirroring the MS06 R-ACK
+ * router test. Also covers the not-found answer and that an invalid record is not stored.
+ */
+public class RecordDhtRouterTest {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private ServerContext node;
+  private OutboundMailboxStore mailbox;
+  private OutboundHandleStore handles;
+  private byte[] ackOhId;
+  private byte[] ackSessionTag;
+
+  @Before
+  public void setUp() {
+    node = ServerContext.buildDefaultServerContext();
+    handles = new OutboundHandleStore();
+    mailbox = new OutboundMailboxStore();
+    node.setOutboundService(new OutboundService(handles, mailbox));
+
+    ackOhId = randomBytes(KademliaId.ID_LENGTH_BYTES);
+    ackSessionTag = randomBytes(FlaschenpostV2.SESSION_TAG_LEN);
+    long now = System.currentTimeMillis();
+    handles.put(ackOhId, new OutboundHandleStore.HandleRecord(new byte[65], now, now + 60_000));
+  }
+
+  private static byte[] randomBytes(int len) {
+    byte[] bytes = new byte[len];
+    RANDOM.nextBytes(bytes);
+    return bytes;
+  }
+
+  private static byte[] randomChannelSecret() {
+    return randomBytes(32);
+  }
+
+  /** hop_count = 0 return path — the lookup answer is deposited into the local ackOh. */
+  private ReturnPath zeroHopReturnPath() {
+    return new ReturnPath(ackOhId, ackSessionTag, List.of());
+  }
+
+  private byte[] recordStoreLayer(KadContent record) {
+    byte[] store =
+        KademliaStore.newBuilder()
+            .setTimestamp(record.getTimestamp())
+            .setPublicKey(ByteString.copyFrom(record.getPubkey()))
+            .setContent(ByteString.copyFrom(record.getContent()))
+            .setSignature(ByteString.copyFrom(record.getSignature()))
+            .build()
+            .toByteArray();
+    return ByteBuffer.allocate(1 + 4 + store.length)
+        .put(FlaschenpostV2.CMD_RECORD_STORE)
+        .putInt(store.length)
+        .put(store)
+        .array();
+  }
+
+  private byte[] recordLookupLayer(KademliaId key, ReturnPath returnPath) {
+    byte[] rp = returnPath.serialize();
+    return ByteBuffer.allocate(1 + KademliaId.ID_LENGTH_BYTES + rp.length)
+        .put(FlaschenpostV2.CMD_RECORD_LOOKUP)
+        .put(key.getBytes())
+        .put(rp)
+        .array();
+  }
+
+  /** Encrypts a single-layer garlic packet carrying {@code plaintext} for our node. */
+  private byte[] singleLayerPacket(byte[] plaintext) throws Exception {
+    byte[] body =
+        FlaschenpostV2.encryptLayer(
+            node.getNodeId().getEncryptionPubKey(), node.getNonce(), plaintext);
+    return FlaschenpostV2.buildPacket(RANDOM.nextInt(), node.getNonce(), body);
+  }
+
+  @Test
+  public void storeThenLookup_roundTripsRecordBackThroughReturnPath() throws Exception {
+    byte[] secret = randomChannelSecret();
+    long now = System.currentTimeMillis();
+    byte[] ciphertext = randomBytes(120);
+    KadContent record = ChannelDht.buildRecordContent(secret, ciphertext, now);
+    KademliaId key = ChannelDht.rendezvousKademliaId(secret, now);
+
+    // 1) store
+    GarlicRouter.handle(node, singleLayerPacket(recordStoreLayer(record)));
+    KadContent stored = node.getKadStoreManager().get(key);
+    assertThat(stored).as("record must be stored under the rendezvous key").isNotNull();
+    assertThat(stored.getContent()).isEqualTo(record.getContent());
+
+    // 2) lookup with a zero-hop return path → answer deposited into the local ackOh
+    GarlicRouter.handle(node, singleLayerPacket(recordLookupLayer(key, zeroHopReturnPath())));
+
+    List<MailItem> items = mailbox.fetchMessages(ackOhId, 10, 0);
+    assertThat(items).hasSize(1);
+    assertThat(items.get(0).getSessionTag().toByteArray()).isEqualTo(ackSessionTag);
+
+    byte[] answer = items.get(0).getPayload().toByteArray();
+    assertThat(answer[0]).as("lookup found the record").isEqualTo(RecordLookupJob.RESPONSE_FOUND);
+    KademliaStore returned =
+        KademliaStore.parseFrom(java.util.Arrays.copyOfRange(answer, 1, answer.length));
+    assertThat(returned.getContent().toByteArray())
+        .as("the exact stored record content is returned")
+        .isEqualTo(record.getContent());
+    assertThat(ChannelDht.extractCiphertext(returned.getContent().toByteArray()))
+        .isEqualTo(ciphertext);
+  }
+
+  @Test
+  public void lookup_unknownKey_returnsNotFound() throws Exception {
+    KademliaId unknown =
+        ChannelDht.rendezvousKademliaId(randomChannelSecret(), System.currentTimeMillis());
+
+    // No local record and no peers → the node falls back to a (randomly delayed) DHT search that
+    // finds nothing and still answers, so the client never waits out a timeout. Poll for the
+    // asynchronous not-found answer.
+    GarlicRouter.handle(node, singleLayerPacket(recordLookupLayer(unknown, zeroHopReturnPath())));
+
+    List<MailItem> items = awaitMailbox(ackOhId);
+    assertThat(items).hasSize(1);
+    byte[] answer = items.get(0).getPayload().toByteArray();
+    assertThat(answer).containsExactly(RecordLookupJob.RESPONSE_NOT_FOUND);
+  }
+
+  /**
+   * Polls the mailbox until an item arrives (the not-found answer is dispatched asynchronously).
+   */
+  private List<MailItem> awaitMailbox(byte[] ohId) throws InterruptedException {
+    for (int i = 0; i < 120; i++) {
+      List<MailItem> items = mailbox.fetchMessages(ohId, 10, 0);
+      if (!items.isEmpty()) {
+        return items;
+      }
+      Thread.sleep(50);
+    }
+    return mailbox.fetchMessages(ohId, 10, 0);
+  }
+
+  @Test
+  public void store_invalidRecord_isNotStored() throws Exception {
+    // A record whose content is not padded to the fixed bucket size must be rejected by the node.
+    byte[] secret = randomChannelSecret();
+    long now = System.currentTimeMillis();
+    var recordNodeId = ChannelDht.deriveRecordNodeId(secret);
+    KadContent unpadded = new KadContent(now, recordNodeId.exportPublic(), randomBytes(100));
+    unpadded.signWith(recordNodeId);
+    KademliaId key = ChannelDht.rendezvousKademliaId(secret, now);
+
+    GarlicRouter.handle(node, singleLayerPacket(recordStoreLayer(unpadded)));
+
+    assertThat(node.getKadStoreManager().get(key))
+        .as("an invalid (wrong-size) record must not be stored")
+        .isNull();
+  }
+}

--- a/src/test/java/im/redpanda/flaschenpost/RecordStoreRateLimiterTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/RecordStoreRateLimiterTest.java
@@ -1,0 +1,58 @@
+package im.redpanda.flaschenpost;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+/** T43: token-bucket behaviour of the global channel-record store rate limiter. */
+public class RecordStoreRateLimiterTest {
+
+  @Test
+  public void admitsUpToCapacityThenDrops() {
+    long t0 = 1_000_000L;
+    RecordStoreRateLimiter limiter = new RecordStoreRateLimiter(5, 1000L, t0);
+
+    for (int i = 0; i < 5; i++) {
+      assertThat(limiter.tryAcquire(t0)).as("store %d within burst", i).isTrue();
+    }
+    assertThat(limiter.tryAcquire(t0)).as("burst exhausted → drop").isFalse();
+  }
+
+  @Test
+  public void refillsOverTime() {
+    long t0 = 1_000_000L;
+    RecordStoreRateLimiter limiter = new RecordStoreRateLimiter(5, 1000L, t0);
+
+    for (int i = 0; i < 5; i++) {
+      limiter.tryAcquire(t0);
+    }
+    assertThat(limiter.tryAcquire(t0)).isFalse();
+
+    // one refill interval later → exactly one token back
+    assertThat(limiter.tryAcquire(t0 + 1000L)).isTrue();
+    assertThat(limiter.tryAcquire(t0 + 1000L)).isFalse();
+  }
+
+  @Test
+  public void refillIsCappedAtCapacity() {
+    long t0 = 1_000_000L;
+    RecordStoreRateLimiter limiter = new RecordStoreRateLimiter(3, 1000L, t0);
+
+    // idle for a long time → tokens cap at capacity, not unbounded
+    long later = t0 + 1_000_000L;
+    assertThat(limiter.tryAcquire(later)).isTrue();
+    assertThat(limiter.tryAcquire(later)).isTrue();
+    assertThat(limiter.tryAcquire(later)).isTrue();
+    assertThat(limiter.tryAcquire(later)).as("no more than capacity after long idle").isFalse();
+  }
+
+  @Test
+  public void rejectsNonPositiveConfiguration() {
+    long t0 = 1_000_000L;
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> new RecordStoreRateLimiter(0, 1000L, t0))
+        .isInstanceOf(IllegalArgumentException.class);
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> new RecordStoreRateLimiter(5, 0L, t0))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/src/test/java/im/redpanda/outbound/ChannelDhtTest.java
+++ b/src/test/java/im/redpanda/outbound/ChannelDhtTest.java
@@ -1,0 +1,195 @@
+package im.redpanda.outbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.NodeId;
+import im.redpanda.kademlia.KadContent;
+import java.security.SecureRandom;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * T43: tests for the channel-rendezvous DHT primitives — deterministic record-key derivation from
+ * the channel secret, fixed-size padded (opaque) records, TTL / signature / size validation and
+ * newest-wins result selection.
+ */
+public class ChannelDhtTest {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private static byte[] randomChannelSecret() {
+    byte[] secret = new byte[32];
+    RANDOM.nextBytes(secret);
+    return secret;
+  }
+
+  private static byte[] randomCiphertext(int len) {
+    byte[] ciphertext = new byte[len];
+    RANDOM.nextBytes(ciphertext);
+    return ciphertext;
+  }
+
+  // --- Record key derivation ---
+
+  @Test
+  public void deriveRecordNodeId_isDeterministic() {
+    byte[] secret = randomChannelSecret();
+
+    NodeId first = ChannelDht.deriveRecordNodeId(secret);
+    NodeId second = ChannelDht.deriveRecordNodeId(secret.clone());
+
+    assertThat(first.exportPublic()).isEqualTo(second.exportPublic());
+    assertThat(first.getKademliaId()).isEqualTo(second.getKademliaId());
+  }
+
+  @Test
+  public void deriveRecordNodeId_differsPerChannel() {
+    NodeId first = ChannelDht.deriveRecordNodeId(randomChannelSecret());
+    NodeId second = ChannelDht.deriveRecordNodeId(randomChannelSecret());
+
+    assertThat(first.exportPublic()).isNotEqualTo(second.exportPublic());
+  }
+
+  @Test
+  public void rendezvousKademliaId_sameForEveryParticipant() {
+    byte[] secret = randomChannelSecret();
+    long now = System.currentTimeMillis();
+
+    assertThat(ChannelDht.rendezvousKademliaId(secret, now))
+        .isEqualTo(ChannelDht.rendezvousKademliaId(secret.clone(), now));
+  }
+
+  @Test
+  public void rendezvousKademliaId_isDomainSeparatedFromOhAnnounce() {
+    // Feeding the same 32 bytes as an oh_id vs a channel secret must land in different namespaces:
+    // the channel record key is derived through a distinct domain tag.
+    byte[] shared = randomChannelSecret();
+    long now = System.currentTimeMillis();
+
+    assertThat(ChannelDht.rendezvousKademliaId(shared, now))
+        .isNotEqualTo(OhDht.announceKademliaId(shared, now));
+  }
+
+  // --- Record building (padding, signature, self-certifying key) ---
+
+  @Test
+  public void buildRecordContent_recordsHaveConstantSize() {
+    long now = System.currentTimeMillis();
+    for (int i = 0; i < 20; i++) {
+      KadContent content =
+          ChannelDht.buildRecordContent(
+              randomChannelSecret(), randomCiphertext(1 + RANDOM.nextInt(200)), now);
+      assertThat(content.getContent())
+          .as("every rendezvous record must be padded to one bucket size")
+          .hasSize(ChannelDht.RECORD_SIZE_BYTES);
+    }
+  }
+
+  @Test
+  public void buildRecordContent_isSignedAndStoredUnderDerivedKey() {
+    byte[] secret = randomChannelSecret();
+    long now = System.currentTimeMillis();
+
+    KadContent content = ChannelDht.buildRecordContent(secret, randomCiphertext(100), now);
+
+    assertThat(content.verify()).isTrue();
+    assertThat(content.getId()).isEqualTo(ChannelDht.rendezvousKademliaId(secret, now));
+    assertThat(content.getPubkey()).isEqualTo(ChannelDht.deriveRecordNodeId(secret).exportPublic());
+  }
+
+  @Test
+  public void buildAndExtractCiphertext_roundTrips() {
+    byte[] ciphertext = randomCiphertext(137);
+    KadContent content =
+        ChannelDht.buildRecordContent(
+            randomChannelSecret(), ciphertext, System.currentTimeMillis());
+
+    assertThat(ChannelDht.extractCiphertext(content.getContent())).isEqualTo(ciphertext);
+  }
+
+  // --- Validation ---
+
+  @Test
+  public void isValidRecord_acceptsFreshSignedFixedSizeRecord() {
+    long now = System.currentTimeMillis();
+    KadContent content =
+        ChannelDht.buildRecordContent(randomChannelSecret(), randomCiphertext(64), now);
+
+    assertThat(ChannelDht.isValidRecord(content, now)).isTrue();
+  }
+
+  @Test
+  public void isValidRecord_rejectsWrongSize() {
+    // Correctly derived key but content that is not padded to the fixed bucket size.
+    byte[] secret = randomChannelSecret();
+    long now = System.currentTimeMillis();
+    NodeId recordNodeId = ChannelDht.deriveRecordNodeId(secret);
+    KadContent content = new KadContent(now, recordNodeId.exportPublic(), randomCiphertext(100));
+    content.signWith(recordNodeId);
+
+    assertThat(ChannelDht.isValidRecord(content, now)).isFalse();
+  }
+
+  @Test
+  public void isValidRecord_rejectsTamperedContent() {
+    long now = System.currentTimeMillis();
+    KadContent content =
+        ChannelDht.buildRecordContent(randomChannelSecret(), randomCiphertext(64), now);
+    // Flip a byte after signing → signature no longer verifies.
+    content.getContent()[0] ^= 0xFF;
+
+    assertThat(ChannelDht.isValidRecord(content, now)).isFalse();
+  }
+
+  @Test
+  public void isValidRecord_rejectsRecordOlderThanTtl() {
+    long now = System.currentTimeMillis();
+    long published = now - ChannelDht.MAX_RECORD_AGE_MS - 1000;
+    KadContent content =
+        ChannelDht.buildRecordContent(randomChannelSecret(), randomCiphertext(64), published);
+
+    assertThat(ChannelDht.isValidRecord(content, now)).isFalse();
+  }
+
+  // --- Result selection (newest-wins, foreign-record rejection) ---
+
+  @Test
+  public void extractNewest_picksNewestValidRecord() {
+    byte[] secret = randomChannelSecret();
+    long now = System.currentTimeMillis();
+    KademliaId key = ChannelDht.rendezvousKademliaId(secret, now);
+
+    KadContent older = ChannelDht.buildRecordContent(secret, randomCiphertext(64), now - 10_000);
+    KadContent newer = ChannelDht.buildRecordContent(secret, randomCiphertext(64), now);
+    // Both live under today's key.
+    assertThat(older.getId()).isEqualTo(key);
+    assertThat(newer.getId()).isEqualTo(key);
+
+    KadContent best = ChannelDht.extractNewest(List.of(older, newer), key, now);
+
+    assertThat(best).isNotNull();
+    assertThat(best.getTimestamp()).isEqualTo(newer.getTimestamp());
+  }
+
+  @Test
+  public void extractNewest_rejectsRecordUnderDifferentKey() {
+    byte[] secret = randomChannelSecret();
+    long now = System.currentTimeMillis();
+    KademliaId key = ChannelDht.rendezvousKademliaId(secret, now);
+
+    // A validly signed record for ANOTHER channel must not be served for this key.
+    KadContent foreign =
+        ChannelDht.buildRecordContent(randomChannelSecret(), randomCiphertext(64), now);
+
+    assertThat(ChannelDht.extractNewest(List.of(foreign), key, now)).isNull();
+  }
+
+  @Test
+  public void extractNewest_returnsNullForEmptyResults() {
+    long now = System.currentTimeMillis();
+    KademliaId key = ChannelDht.rendezvousKademliaId(randomChannelSecret(), now);
+
+    assertThat(ChannelDht.extractNewest(List.of(), key, now)).isNull();
+  }
+}

--- a/src/test/java/im/redpanda/outbound/ChannelDhtTest.java
+++ b/src/test/java/im/redpanda/outbound/ChannelDhtTest.java
@@ -24,10 +24,15 @@ public class ChannelDhtTest {
     return secret;
   }
 
-  private static byte[] randomCiphertext(int len) {
-    byte[] ciphertext = new byte[len];
-    RANDOM.nextBytes(ciphertext);
-    return ciphertext;
+  private static byte[] randomBytes(int len) {
+    byte[] bytes = new byte[len];
+    RANDOM.nextBytes(bytes);
+    return bytes;
+  }
+
+  /** A fixed-size opaque record blob, as a client would produce (nonce + AEAD ciphertext). */
+  private static byte[] randomRecordContent() {
+    return randomBytes(ChannelDht.RECORD_SIZE_BYTES);
   }
 
   // --- Record key derivation ---
@@ -78,12 +83,20 @@ public class ChannelDhtTest {
     long now = System.currentTimeMillis();
     for (int i = 0; i < 20; i++) {
       KadContent content =
-          ChannelDht.buildRecordContent(
-              randomChannelSecret(), randomCiphertext(1 + RANDOM.nextInt(200)), now);
+          ChannelDht.buildRecordContent(randomChannelSecret(), randomRecordContent(), now);
       assertThat(content.getContent())
-          .as("every rendezvous record must be padded to one bucket size")
+          .as("every rendezvous record is exactly one bucket size")
           .hasSize(ChannelDht.RECORD_SIZE_BYTES);
     }
+  }
+
+  @Test
+  public void buildRecordContent_rejectsWrongSizeContent() {
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () ->
+                ChannelDht.buildRecordContent(
+                    randomChannelSecret(), randomBytes(100), System.currentTimeMillis()))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -91,21 +104,11 @@ public class ChannelDhtTest {
     byte[] secret = randomChannelSecret();
     long now = System.currentTimeMillis();
 
-    KadContent content = ChannelDht.buildRecordContent(secret, randomCiphertext(100), now);
+    KadContent content = ChannelDht.buildRecordContent(secret, randomRecordContent(), now);
 
     assertThat(content.verify()).isTrue();
     assertThat(content.getId()).isEqualTo(ChannelDht.rendezvousKademliaId(secret, now));
     assertThat(content.getPubkey()).isEqualTo(ChannelDht.deriveRecordNodeId(secret).exportPublic());
-  }
-
-  @Test
-  public void buildAndExtractCiphertext_roundTrips() {
-    byte[] ciphertext = randomCiphertext(137);
-    KadContent content =
-        ChannelDht.buildRecordContent(
-            randomChannelSecret(), ciphertext, System.currentTimeMillis());
-
-    assertThat(ChannelDht.extractCiphertext(content.getContent())).isEqualTo(ciphertext);
   }
 
   // --- Validation ---
@@ -114,18 +117,18 @@ public class ChannelDhtTest {
   public void isValidRecord_acceptsFreshSignedFixedSizeRecord() {
     long now = System.currentTimeMillis();
     KadContent content =
-        ChannelDht.buildRecordContent(randomChannelSecret(), randomCiphertext(64), now);
+        ChannelDht.buildRecordContent(randomChannelSecret(), randomRecordContent(), now);
 
     assertThat(ChannelDht.isValidRecord(content, now)).isTrue();
   }
 
   @Test
   public void isValidRecord_rejectsWrongSize() {
-    // Correctly derived key but content that is not padded to the fixed bucket size.
+    // Correctly derived key but content that is not the fixed bucket size.
     byte[] secret = randomChannelSecret();
     long now = System.currentTimeMillis();
     NodeId recordNodeId = ChannelDht.deriveRecordNodeId(secret);
-    KadContent content = new KadContent(now, recordNodeId.exportPublic(), randomCiphertext(100));
+    KadContent content = new KadContent(now, recordNodeId.exportPublic(), randomBytes(100));
     content.signWith(recordNodeId);
 
     assertThat(ChannelDht.isValidRecord(content, now)).isFalse();
@@ -135,7 +138,7 @@ public class ChannelDhtTest {
   public void isValidRecord_rejectsTamperedContent() {
     long now = System.currentTimeMillis();
     KadContent content =
-        ChannelDht.buildRecordContent(randomChannelSecret(), randomCiphertext(64), now);
+        ChannelDht.buildRecordContent(randomChannelSecret(), randomRecordContent(), now);
     // Flip a byte after signing → signature no longer verifies.
     content.getContent()[0] ^= 0xFF;
 
@@ -147,9 +150,21 @@ public class ChannelDhtTest {
     long now = System.currentTimeMillis();
     long published = now - ChannelDht.MAX_RECORD_AGE_MS - 1000;
     KadContent content =
-        ChannelDht.buildRecordContent(randomChannelSecret(), randomCiphertext(64), published);
+        ChannelDht.buildRecordContent(randomChannelSecret(), randomRecordContent(), published);
 
     assertThat(ChannelDht.isValidRecord(content, now)).isFalse();
+  }
+
+  @Test
+  public void isValidRecord_rejectsRecordTooFarInFuture() {
+    long now = System.currentTimeMillis();
+    long published = now + ChannelDht.MAX_FUTURE_SKEW_MS + 60_000;
+    KadContent content =
+        ChannelDht.buildRecordContent(randomChannelSecret(), randomRecordContent(), published);
+
+    assertThat(ChannelDht.isValidRecord(content, now))
+        .as("a future-dated record must not win newest-wins")
+        .isFalse();
   }
 
   // --- Result selection (newest-wins, foreign-record rejection) ---
@@ -157,11 +172,14 @@ public class ChannelDhtTest {
   @Test
   public void extractNewest_picksNewestValidRecord() {
     byte[] secret = randomChannelSecret();
-    long now = System.currentTimeMillis();
+    // Fixed timestamp safely away from midnight UTC (~22:13 UTC): both records share the same UTC
+    // day so they live under the same rotated key, and the explicit nowMs keeps them within TTL —
+    // avoids a day-boundary flake from the real wall clock.
+    long now = 1_700_000_000_000L;
     KademliaId key = ChannelDht.rendezvousKademliaId(secret, now);
 
-    KadContent older = ChannelDht.buildRecordContent(secret, randomCiphertext(64), now - 10_000);
-    KadContent newer = ChannelDht.buildRecordContent(secret, randomCiphertext(64), now);
+    KadContent older = ChannelDht.buildRecordContent(secret, randomRecordContent(), now - 10_000);
+    KadContent newer = ChannelDht.buildRecordContent(secret, randomRecordContent(), now);
     // Both live under today's key.
     assertThat(older.getId()).isEqualTo(key);
     assertThat(newer.getId()).isEqualTo(key);
@@ -180,7 +198,7 @@ public class ChannelDhtTest {
 
     // A validly signed record for ANOTHER channel must not be served for this key.
     KadContent foreign =
-        ChannelDht.buildRecordContent(randomChannelSecret(), randomCiphertext(64), now);
+        ChannelDht.buildRecordContent(randomChannelSecret(), randomRecordContent(), now);
 
     assertThat(ChannelDht.extractNewest(List.of(foreign), key, now)).isNull();
   }


### PR DESCRIPTION
Backend for the Multi-OH / DHT-Rendezvous work (`plans/PLAN-multi-oh-dht.md`, task **T43**). Spec: docs#41 (`channel_rendezvous_dht.md`).

## What
- **`ChannelDht`** — self-certifying channel rendezvous record, analogous to `OhDht`, under its own domain tag `redpanda.channel.rendezvous.v1`. The record signing key is derived from the **channel secret** (`NodeId.fromSeed(SHA256(tag ‖ channel_sk))`) so only participants can publish; the Kademlia key is the standard `H(dateUTC ‖ recordPubkey)`. The value is an **opaque, `k_enc`-encrypted ciphertext** framed and padded to **one 512-byte bucket**. Validation: signature + fixed size + **48 h TTL**; **newest-wins** selection (`extractNewest`).
- **Two new garlic layer commands** (final-hop) so a DHT-fremd light client can have a **remote** node run Kademlia without the directly connected node seeing the query:
  - `CMD_RECORD_STORE` (`0x05`): validate + global rate-limit + `KademliaInsertJob`.
  - `CMD_RECORD_LOOKUP` (`0x06`): local-then-randomly-delayed DHT search, answer via the client-chosen **`ReturnPath`** (MS05/MS06 reverse garlic into the client's own OH mailbox); payload `[1 status][KademliaStore if found]`. No new top-level client command → existing clients never desync.
- **`RecordStoreRateLimiter`** — global token bucket bounding DHT-write amplification (a per-source limit is not available on the stateless garlic path).
- **`ReverseGarlic`** — extracted the shared reverse-garlic onion/deliver logic out of `RoutingAckSender` (MS06 R-ACK now delegates to it) and reused it for the lookup answer.

## Tests
`ChannelDhtTest` (derivation, fixed size, signature/size/TTL, newest-wins, domain separation), `RecordStoreRateLimiterTest` (token bucket), `RecordDhtRouterTest` (garlic store→lookup round-trip, not-found, invalid-record rejected). Full backend suite green locally (371 tests, 0 failures).

Mobile QR v4 + rendezvous integration is T44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHDH2f2Mc2aib3evJP1oda