### PR TITLE
fix(T34-rest): guard remaining nodeGraph concurrency races

### DIFF
--- a/src/main/java/im/redpanda/flaschenpost/GMParser.java
+++ b/src/main/java/im/redpanda/flaschenpost/GMParser.java
@@ -107,8 +107,9 @@ public class GMParser {
         GraphPath<Node, NodeEdge> path = null;
         try {
           path = DijkstraShortestPath.findPathBetween(graph, peerNode, targetNode);
-        } catch (IllegalArgumentException ignored) {
-          // peerNode or targetNode not in graph
+        } catch (IllegalArgumentException | NullPointerException ignored) {
+          // peerNode/targetNode not in graph, or an edge was concurrently removed
+          // mid-traversal (Sentry REDPANDAJ-2DW/2E5 pattern) — treat as no route.
         }
         if (path == null) {
           continue;
@@ -338,14 +339,24 @@ public class GMParser {
         return;
       }
 
-      Node targetNode = serverContext.getNodeStore().get(garlicMessage.destination);
-      RouteSelection selection =
-          selectBestRoutePeer(
-              serverContext.getNodeStore().getNodeGraph(),
-              serverContext.getNode(),
-              peers,
-              targetNode,
-              MAX_ROUTE_WEIGHT);
+      // maintainNodes() mutates the graph under the NodeStore write lock (Sentry
+      // REDPANDAJ-2DW/2E5 fix); take the read lock here so Dijkstra never traverses
+      // a graph that is concurrently being restructured.
+      Lock nodeStoreLock = serverContext.getNodeStore().getReadWriteLock().readLock();
+      RouteSelection selection;
+      nodeStoreLock.lock();
+      try {
+        Node targetNode = serverContext.getNodeStore().get(garlicMessage.destination);
+        selection =
+            selectBestRoutePeer(
+                serverContext.getNodeStore().getNodeGraph(),
+                serverContext.getNode(),
+                peers,
+                targetNode,
+                MAX_ROUTE_WEIGHT);
+      } finally {
+        nodeStoreLock.unlock();
+      }
       double shortestPathWeight = selection.weight();
       Peer peerWithShortestPath = selection.peer();
 

--- a/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
+++ b/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
@@ -208,6 +208,12 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
 
   private boolean dismissCheckByTimeoutIfEdgeQualityBad(
       DefaultDirectedWeightedGraph<Node, NodeEdge> nodeGraph, NodeEdge edge) {
+    // the edge may have been removed from the graph concurrently since the caller
+    // copied the edge list; check membership before resolving its weight
+    // (Sentry REDPANDAJ-2DW, REDPANDAJ-2E5 pattern)
+    if (!nodeGraph.containsEdge(edge)) {
+      return true;
+    }
     if (edge.isLastCheckFailed()) {
       double edgeWeight = nodeGraph.getEdgeWeight(edge);
       if (edgeWeight >= MAX_WEIGHT) {

--- a/src/test/java/im/redpanda/flaschenpost/GMParserAdditionalTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/GMParserAdditionalTest.java
@@ -677,6 +677,53 @@ public class GMParserAdditionalTest {
   }
 
   /**
+   * Regression for REDPANDAJ-2DW/2E5-class races: if an edge on the candidate's remaining path is
+   * concurrently ripped out of the graph (maintainNodes on another thread) while Dijkstra is
+   * traversing it, jgrapht's intrusive edge specifics throw a {@link NullPointerException} rather
+   * than {@link IllegalArgumentException}. Before the fix, {@code selectBestRoutePeer} only caught
+   * {@code IllegalArgumentException} around {@code findPathBetween}, so that NPE escaped past the
+   * job and crashed the caller instead of the candidate simply being skipped.
+   */
+  @Test
+  public void selectBestRoutePeer_survivesEdgeVanishingMidDijkstraTraversal() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+
+    Node selfNode = new Node(serverContext, serverContext.getNodeId());
+    Node targetNode = new Node(serverContext, NodeId.generateWithSimpleKey());
+    TestPeer peer = authedPeerWithNode(serverContext, "10.5.0.1", 1);
+    Node peerNode = peer.getNode();
+
+    DefaultDirectedWeightedGraph<Node, NodeEdge> realGraph =
+        new DefaultDirectedWeightedGraph<>(NodeEdge.class);
+    realGraph.addVertex(selfNode);
+    realGraph.addVertex(targetNode);
+    realGraph.addVertex(peerNode);
+    realGraph.setEdgeWeight(realGraph.addEdge(selfNode, peerNode), 1.0);
+    realGraph.setEdgeWeight(realGraph.addEdge(peerNode, targetNode), 1.0);
+
+    // Wrap the graph so that, exactly like a concurrent removeEdge/removeVertex would,
+    // getEdgeWeight throws NullPointerException the moment Dijkstra tries to weigh the
+    // peer -> target edge mid-traversal.
+    org.jgrapht.graph.GraphDelegator<Node, NodeEdge> flakyGraph =
+        new org.jgrapht.graph.GraphDelegator<>(realGraph) {
+          @Override
+          public double getEdgeWeight(NodeEdge e) {
+            if (realGraph.getEdgeSource(e).equals(peerNode)) {
+              throw new NullPointerException("edge vanished mid-traversal");
+            }
+            return super.getEdgeWeight(e);
+          }
+        };
+
+    GMParser.RouteSelection selection =
+        GMParser.selectBestRoutePeer(
+            flakyGraph, selfNode, java.util.List.of(peer), targetNode, GMParser.MAX_ROUTE_WEIGHT);
+
+    // The NPE must be swallowed (candidate skipped), not escape the call.
+    assertNull(selection.peer());
+  }
+
+  /**
    * Builds an authed + connected peer with a Node attached, so {@link Peer#getNode()} returns the
    * node (it returns null for un-authed / disconnected peers).
    */

--- a/src/test/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJobTest.java
+++ b/src/test/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJobTest.java
@@ -1,10 +1,16 @@
 package im.redpanda.jobs;
 
+import static org.junit.Assert.assertTrue;
+
 import im.redpanda.core.Node;
+import im.redpanda.core.NodeId;
 import im.redpanda.core.ServerContext;
 import im.redpanda.flaschenpost.GMParser;
+import im.redpanda.store.NodeEdge;
+import java.lang.reflect.Method;
 import java.security.Security;
 import java.util.ArrayList;
+import org.jgrapht.graph.DefaultDirectedWeightedGraph;
 import org.junit.Test;
 
 public class PeerPerformanceTestGarlicMessageJobTest {
@@ -33,5 +39,44 @@ public class PeerPerformanceTestGarlicMessageJobTest {
 
     GMParser.parse(serverContext, bytes);
     // todo assert?
+  }
+
+  /**
+   * Regression for REDPANDAJ-2DW/2E5-class races: {@code dismissCheckByTimeoutIfEdgeQualityBad}
+   * used to call {@code getEdgeWeight(edge)} without first checking that the edge is still in the
+   * graph. If another thread (e.g. {@code NodeStore.maintainNodes}) removed the edge between the
+   * caller copying the edge list and this check running, the intrusive edge specifics lookup throws
+   * instead of the edge simply being skipped. Verifies the edge is dismissed cleanly instead of
+   * throwing once it's no longer in the graph.
+   */
+  @Test
+  public void dismissCheckByTimeoutIfEdgeQualityBad_edgeRemovedFromGraphIsDismissedNotThrown()
+      throws Exception {
+    Node nodeA = new Node(serverContext, serverContext.getNodeId());
+    Node nodeB = new Node(serverContext, NodeId.generateWithSimpleKey());
+
+    DefaultDirectedWeightedGraph<Node, NodeEdge> graph =
+        new DefaultDirectedWeightedGraph<>(NodeEdge.class);
+    graph.addVertex(nodeA);
+    graph.addVertex(nodeB);
+    NodeEdge edge = graph.addEdge(nodeA, nodeB);
+    graph.setEdgeWeight(edge, 100.0);
+    edge.setLastCheckFailed(true);
+
+    // Simulate a concurrent maintainNodes() removing the edge after the caller snapshotted it.
+    graph.removeEdge(edge);
+
+    PeerPerformanceTestGarlicMessageJob job =
+        new PeerPerformanceTestGarlicMessageJob(serverContext);
+    Method method =
+        PeerPerformanceTestGarlicMessageJob.class.getDeclaredMethod(
+            "dismissCheckByTimeoutIfEdgeQualityBad",
+            DefaultDirectedWeightedGraph.class,
+            NodeEdge.class);
+    method.setAccessible(true);
+
+    boolean dismissed = (boolean) method.invoke(job, graph, edge);
+
+    assertTrue(dismissed);
   }
 }


### PR DESCRIPTION
## Summary
Closes out the two remaining sub-findings from T34 (Sentry REDPANDAJ-2DW/2E5-class nodeGraph concurrency races), the main race having already been fixed in #260.

- `PeerPerformanceTestGarlicMessageJob.dismissCheckByTimeoutIfEdgeQualityBad` called `getEdgeWeight()` before checking edge membership — a concurrently removed edge threw instead of being dismissed. Added the same `containsEdge` guard already used by the caller loop.
- `GMParser.selectBestRoutePeer` ran without the `NodeStore` read lock while `maintainNodes()` mutates the graph under the write lock, and its `catch` only handled `IllegalArgumentException` — the `NullPointerException` jgrapht's intrusive edge specifics throw on a vanished edge could escape. Added the read lock at the call site and widened the catch as defense in depth.

## Test plan
- [x] New regression test: edge removed from graph before the timeout-dismiss check is dismissed, not thrown (`PeerPerformanceTestGarlicMessageJobTest`)
- [x] New regression test: `getEdgeWeight` throwing `NullPointerException` mid-Dijkstra-traversal is swallowed, candidate skipped (`GMParserAdditionalTest`)
- [x] `mvn test` for `im.redpanda.jobs.**`, `im.redpanda.flaschenpost.**`, `im.redpanda.store.**` — 104 tests, all green

Backlog: T34-Rest