### PR TITLE
fix(T36): guard KademliaSearchJob.work() against null peers

### DIFF
--- a/src/main/java/im/redpanda/jobs/KademliaSearchJob.java
+++ b/src/main/java/im/redpanda/jobs/KademliaSearchJob.java
@@ -116,6 +116,14 @@ public class KademliaSearchJob extends Job {
 
   @Override
   public void work() {
+    // init() returns early (blacklisted id: fail() + done(), see above) before peers is
+    // set. done() cancels the recurring future, but a concurrently already-dispatched
+    // run() can still reach work() in that same window (Sentry REDPANDAJ-2E3) — bail out
+    // instead of NPEing on peers.keySet().
+    if (peers == null) {
+      return;
+    }
+
     /** check for timeout, maybe we already got an answer but not SEND_TO_NODES */
     if (getEstimatedRuntime() > 1000 * 5) {
       System.out.println("5 second timeout reached for KadSearch... ");

--- a/src/test/java/im/redpanda/jobs/KademliaSearchJobTest.java
+++ b/src/test/java/im/redpanda/jobs/KademliaSearchJobTest.java
@@ -1,0 +1,33 @@
+package im.redpanda.jobs;
+
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.ServerContext;
+import org.junit.Test;
+
+public class KademliaSearchJobTest {
+
+  private static final ServerContext serverContext = ServerContext.buildDefaultServerContext();
+
+  /**
+   * Regression for REDPANDAJ-2E3: a second search for the same id started within the blacklist
+   * window ({@code init()} calls {@code fail(); done(); return;} before {@code peers} is ever
+   * assigned) must not NPE if {@code work()} still runs for that job (e.g. a concurrently
+   * already-dispatched run() reaching work() in the same window the first job's init() is
+   * blacklisting the id).
+   */
+  @Test
+  public void work_afterBlacklistedInitDoesNotThrow() {
+    KademliaId id = new KademliaId();
+
+    KademliaSearchJob first = new KademliaSearchJob(serverContext, id);
+    first.init();
+
+    // Second search for the same id, still inside the blacklist window: takes the
+    // early-return branch (fail(); done(); return;) without ever assigning `peers`.
+    KademliaSearchJob blacklisted = new KademliaSearchJob(serverContext, id);
+    blacklisted.init();
+
+    // Must not throw NullPointerException on peers.keySet().
+    blacklisted.work();
+  }
+}


### PR DESCRIPTION
## Summary
Fixes Sentry REDPANDAJ-2E3: `KademliaSearchJob.init()` returns early (`fail(); done(); return;`) when the searched id is still blacklisted from a recent search, before `peers` is assigned. `done()` cancels the recurring future, but a `run()` invocation that was already concurrently dispatched can still reach `work()` in that window and NPE on `peers.keySet()`.

KISS fix: null-guard at the top of `work()`.

## Test plan
- [x] New regression test: second search for the same id inside the blacklist window takes the early-return branch, `work()` on it does not throw
- [x] `mvn test -Dtest=im.redpanda.jobs.**` — all green

Backlog: T36