### PR TITLE
T46: rate-limit CMD_RECORD_LOOKUP, harden store-limiter ordering

### DIFF
--- a/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
+++ b/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
@@ -53,7 +53,31 @@ public final class GarlicRouter {
           RecordStoreRateLimiter.DEFAULT_REFILL_INTERVAL_MS,
           System.currentTimeMillis());
 
+  /**
+   * Own bucket for inbound channel-rendezvous record lookups (T46). A lookup triggers a Kademlia
+   * search plus a reverse-garlic answer, so an unbounded flood of lookups is its own DHT-query
+   * amplification vector, independent of the store path above — hence a separate bucket rather than
+   * sharing tokens with {@link #RECORD_STORE_RATE_LIMITER}.
+   */
+  private static RecordStoreRateLimiter recordLookupRateLimiter =
+      new RecordStoreRateLimiter(
+          RecordStoreRateLimiter.DEFAULT_CAPACITY,
+          RecordStoreRateLimiter.DEFAULT_REFILL_INTERVAL_MS,
+          System.currentTimeMillis());
+
   private GarlicRouter() {}
+
+  /**
+   * Test-only hook (T46): swaps the record-lookup rate limiter for a small, deterministic bucket so
+   * tests can exercise exhaustion without depending on wall-clock timing or draining the
+   * production-sized bucket shared with other tests. Returns the previous instance so the caller
+   * can restore it.
+   */
+  static RecordStoreRateLimiter swapRecordLookupRateLimiterForTest(RecordStoreRateLimiter limiter) {
+    RecordStoreRateLimiter previous = recordLookupRateLimiter;
+    recordLookupRateLimiter = limiter;
+    return previous;
+  }
 
   /** Entry point for a received FLASCHENPOST_V2 payload (the raw 2048-byte packet). */
   public static void handle(ServerContext serverContext, byte[] packet) {
@@ -231,6 +255,10 @@ public final class GarlicRouter {
    * opaque to us; we only enforce the self-certifying signature, the fixed padded size and the 48 h
    * TTL ({@link ChannelDht}) plus a global store rate limit. Best-effort, no response — the client
    * verifies by a later lookup. Malformed layers are dropped silently.
+   *
+   * <p>The rate limit is consumed before the Ed25519 signature is verified (T46): a flood of
+   * structurally well-formed but forged records would otherwise force a full signature check per
+   * packet with nothing bounding that cost.
    */
   private static void handleRecordStore(ServerContext serverContext, byte[] plaintext) {
     if (plaintext.length < 1 + 4) {
@@ -247,6 +275,12 @@ public final class GarlicRouter {
     byte[] storeBytes = new byte[len];
     buffer.get(storeBytes);
 
+    long now = System.currentTimeMillis();
+    if (!RECORD_STORE_RATE_LIMITER.tryAcquire(now)) {
+      log.debug("channel record store rate limit hit, dropping");
+      return;
+    }
+
     KademliaStore storeMsg;
     try {
       storeMsg = KademliaStore.parseFrom(storeBytes);
@@ -254,7 +288,6 @@ public final class GarlicRouter {
       log.debug("flaschenpost v2 record store payload not parseable, dropping");
       return;
     }
-    long now = System.currentTimeMillis();
     KadContent record =
         new KadContent(
             storeMsg.getTimestamp(),
@@ -265,14 +298,9 @@ public final class GarlicRouter {
       log.debug("flaschenpost v2 record store record invalid (sig/size/ttl), dropping");
       return;
     }
-    if (!RECORD_STORE_RATE_LIMITER.tryAcquire(now)) {
-      log.debug("channel record store rate limit hit, dropping");
-      return;
-    }
     // Store locally first so the record is immediately resolvable on this node. Only replicate if
     // the local put was accepted — KadStoreManager can still reject on its own timestamp bounds,
-    // and
-    // replicating a record we ourselves won't keep would be pointless.
+    // and replicating a record we ourselves won't keep would be pointless.
     if (serverContext.getKadStoreManager().put(record)) {
       new KademliaInsertJob(serverContext, record).start();
     }
@@ -283,10 +311,18 @@ public final class GarlicRouter {
    * the channel-rendezvous record up in the DHT on behalf of a DHT-fremd client and returns it via
    * the return path (reverse garlic into the client's own OH mailbox, see {@link RecordLookupJob}).
    * The return path is only structurally validated; malformed layers are dropped silently.
+   *
+   * <p>Rate-limited (T46): each lookup triggers a Kademlia search and a reverse-garlic answer, the
+   * same DHT-query amplification the store path guards against, so it is gated on its own bucket
+   * ({@link #recordLookupRateLimiter}) before a search is started.
    */
   private static void handleRecordLookup(ServerContext serverContext, byte[] plaintext) {
     if (plaintext.length < 1 + KademliaId.ID_LENGTH_BYTES + ReturnPath.FIXED_LEN) {
       log.debug("flaschenpost v2 record lookup layer too short, dropping");
+      return;
+    }
+    if (!recordLookupRateLimiter.tryAcquire(System.currentTimeMillis())) {
+      log.debug("channel record lookup rate limit hit, dropping");
       return;
     }
     ByteBuffer buffer = ByteBuffer.wrap(plaintext);

--- a/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
+++ b/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
@@ -15,6 +15,7 @@ import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.util.Arrays;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -59,7 +60,7 @@ public final class GarlicRouter {
    * amplification vector, independent of the store path above — hence a separate bucket rather than
    * sharing tokens with {@link #RECORD_STORE_RATE_LIMITER}.
    */
-  private static RecordStoreRateLimiter recordLookupRateLimiter =
+  private static volatile RecordStoreRateLimiter recordLookupRateLimiter =
       new RecordStoreRateLimiter(
           RecordStoreRateLimiter.DEFAULT_CAPACITY,
           RecordStoreRateLimiter.DEFAULT_REFILL_INTERVAL_MS,
@@ -71,11 +72,12 @@ public final class GarlicRouter {
    * Test-only hook (T46): swaps the record-lookup rate limiter for a small, deterministic bucket so
    * tests can exercise exhaustion without depending on wall-clock timing or draining the
    * production-sized bucket shared with other tests. Returns the previous instance so the caller
-   * can restore it.
+   * can restore it. {@code volatile} on the field guarantees the swap is visible to connection
+   * threads without extra synchronization.
    */
   static RecordStoreRateLimiter swapRecordLookupRateLimiterForTest(RecordStoreRateLimiter limiter) {
     RecordStoreRateLimiter previous = recordLookupRateLimiter;
-    recordLookupRateLimiter = limiter;
+    recordLookupRateLimiter = Objects.requireNonNull(limiter);
     return previous;
   }
 
@@ -256,8 +258,9 @@ public final class GarlicRouter {
    * TTL ({@link ChannelDht}) plus a global store rate limit. Best-effort, no response — the client
    * verifies by a later lookup. Malformed layers are dropped silently.
    *
-   * <p>The rate limit is consumed before the Ed25519 signature is verified (T46): a flood of
-   * structurally well-formed but forged records would otherwise force a full signature check per
+   * <p>The rate limit is consumed after the (cheap) protobuf parse but before the Ed25519 signature
+   * is verified (T46): a flood of unparseable garbage would otherwise drain the bucket for nothing,
+   * while a flood of parseable-but-forged records would otherwise force a full signature check per
    * packet with nothing bounding that cost.
    */
   private static void handleRecordStore(ServerContext serverContext, byte[] plaintext) {
@@ -275,12 +278,6 @@ public final class GarlicRouter {
     byte[] storeBytes = new byte[len];
     buffer.get(storeBytes);
 
-    long now = System.currentTimeMillis();
-    if (!RECORD_STORE_RATE_LIMITER.tryAcquire(now)) {
-      log.debug("channel record store rate limit hit, dropping");
-      return;
-    }
-
     KademliaStore storeMsg;
     try {
       storeMsg = KademliaStore.parseFrom(storeBytes);
@@ -288,6 +285,13 @@ public final class GarlicRouter {
       log.debug("flaschenpost v2 record store payload not parseable, dropping");
       return;
     }
+
+    long now = System.currentTimeMillis();
+    if (!RECORD_STORE_RATE_LIMITER.tryAcquire(now)) {
+      log.debug("channel record store rate limit hit, dropping");
+      return;
+    }
+
     KadContent record =
         new KadContent(
             storeMsg.getTimestamp(),
@@ -314,15 +318,12 @@ public final class GarlicRouter {
    *
    * <p>Rate-limited (T46): each lookup triggers a Kademlia search and a reverse-garlic answer, the
    * same DHT-query amplification the store path guards against, so it is gated on its own bucket
-   * ({@link #recordLookupRateLimiter}) before a search is started.
+   * ({@link #recordLookupRateLimiter}) — consumed only after the structural checks below pass, so
+   * malformed lookups that never start a search can't drain the bucket for valid clients.
    */
   private static void handleRecordLookup(ServerContext serverContext, byte[] plaintext) {
     if (plaintext.length < 1 + KademliaId.ID_LENGTH_BYTES + ReturnPath.FIXED_LEN) {
       log.debug("flaschenpost v2 record lookup layer too short, dropping");
-      return;
-    }
-    if (!recordLookupRateLimiter.tryAcquire(System.currentTimeMillis())) {
-      log.debug("channel record lookup rate limit hit, dropping");
       return;
     }
     ByteBuffer buffer = ByteBuffer.wrap(plaintext);
@@ -331,6 +332,10 @@ public final class GarlicRouter {
     ReturnPath returnPath = ReturnPath.parse(buffer);
     if (returnPath == null) {
       log.debug("flaschenpost v2 record lookup return path invalid, dropping");
+      return;
+    }
+    if (!recordLookupRateLimiter.tryAcquire(System.currentTimeMillis())) {
+      log.debug("channel record lookup rate limit hit, dropping");
       return;
     }
     RecordLookupJob.lookup(serverContext, searchedKey, returnPath);

--- a/src/test/java/im/redpanda/flaschenpost/RecordDhtRouterTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/RecordDhtRouterTest.java
@@ -161,6 +161,33 @@ public class RecordDhtRouterTest {
   }
 
   @Test
+  public void lookup_rateLimitExhausted_dropsWithoutSearching() throws Exception {
+    // Swap in a 1-token bucket with a refill interval far longer than the lookup job's own
+    // anti-profiling jitter (up to 1.5 s, see RecordLookupJob.LOOKUP_DELAY_JITTER_MS) so the second
+    // call is deterministically over budget regardless of how long the first answer takes.
+    RecordStoreRateLimiter previous =
+        GarlicRouter.swapRecordLookupRateLimiterForTest(
+            new RecordStoreRateLimiter(1, 60_000L, System.currentTimeMillis()));
+    try {
+      KademliaId key =
+          ChannelDht.rendezvousKademliaId(randomChannelSecret(), System.currentTimeMillis());
+      byte[] layer = recordLookupLayer(key, zeroHopReturnPath());
+
+      // 1st lookup consumes the single token and is admitted (answers not-found asynchronously).
+      // 2nd lookup arrives immediately after → bucket empty → dropped before a search ever starts.
+      GarlicRouter.handle(node, singleLayerPacket(layer));
+      GarlicRouter.handle(node, singleLayerPacket(layer));
+
+      List<MailItem> items = awaitMailbox(ackOhId);
+      assertThat(items)
+          .as("only the 1st (admitted) lookup may produce an answer, the 2nd must be dropped")
+          .hasSize(1);
+    } finally {
+      GarlicRouter.swapRecordLookupRateLimiterForTest(previous);
+    }
+  }
+
+  @Test
   public void store_invalidRecord_isNotStored() throws Exception {
     // A record whose content is not padded to the fixed bucket size must be rejected by the node.
     byte[] secret = randomChannelSecret();

--- a/src/test/java/im/redpanda/flaschenpost/RecordDhtRouterTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/RecordDhtRouterTest.java
@@ -179,6 +179,12 @@ public class RecordDhtRouterTest {
       GarlicRouter.handle(node, singleLayerPacket(layer));
 
       List<MailItem> items = awaitMailbox(ackOhId);
+      // Both lookups share the same up-to-1.5 s jitter window (RecordLookupJob), so the 1st
+      // answer landing first proves nothing about the 2nd being dropped — settle past the max
+      // jitter before asserting the final count, so a regression that wrongly admits the 2nd
+      // lookup can't slip through as a late-arriving 2nd item.
+      Thread.sleep(1_700L); // > RecordLookupJob.LOOKUP_DELAY_JITTER_MS (1.5 s), package-private
+      items = mailbox.fetchMessages(ackOhId, 10, 0);
       assertThat(items)
           .as("only the 1st (admitted) lookup may produce an answer, the 2nd must be dropped")
           .hasSize(1);

--- a/src/test/java/im/redpanda/flaschenpost/RecordDhtRouterTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/RecordDhtRouterTest.java
@@ -91,10 +91,15 @@ public class RecordDhtRouterTest {
 
   /** Encrypts a single-layer garlic packet carrying {@code plaintext} for our node. */
   private byte[] singleLayerPacket(byte[] plaintext) throws Exception {
+    return singleLayerPacket(plaintext, RANDOM.nextInt());
+  }
+
+  /** Same as {@link #singleLayerPacket(byte[])} but with an explicit {@code packet_id}. */
+  private byte[] singleLayerPacket(byte[] plaintext, int packetId) throws Exception {
     byte[] body =
         FlaschenpostV2.encryptLayer(
             node.getNodeId().getEncryptionPubKey(), node.getNonce(), plaintext);
-    return FlaschenpostV2.buildPacket(RANDOM.nextInt(), node.getNonce(), body);
+    return FlaschenpostV2.buildPacket(packetId, node.getNonce(), body);
   }
 
   @Test
@@ -175,8 +180,10 @@ public class RecordDhtRouterTest {
 
       // 1st lookup consumes the single token and is admitted (answers not-found asynchronously).
       // 2nd lookup arrives immediately after → bucket empty → dropped before a search ever starts.
-      GarlicRouter.handle(node, singleLayerPacket(layer));
-      GarlicRouter.handle(node, singleLayerPacket(layer));
+      // Fixed, distinct packet IDs (rather than the default random ones) so this can never be
+      // confused with a GMStoreManager packet_id-dedup drop.
+      GarlicRouter.handle(node, singleLayerPacket(layer, 1));
+      GarlicRouter.handle(node, singleLayerPacket(layer, 2));
 
       List<MailItem> items = awaitMailbox(ackOhId);
       // Both lookups share the same up-to-1.5 s jitter window (RecordLookupJob), so the 1st


### PR DESCRIPTION
## Summary
- `record_lookup` had no rate limit, unlike `record_store` — a DHT-query-amplification gap (each lookup triggers an async Kademlia search + reverse-garlic answer). Adds its own token bucket.
- `record_store`'s existing limiter is now consumed *before* the Ed25519 signature check, so a flood of forged records can't force unbounded signature verification.
- New regression test `RecordDhtRouterTest#lookup_rateLimitExhausted_dropsWithoutSearching`.

Reviewed by Fable 5 (independent subagent pass, incl. 8x flake-loop of the new test): no production bugs found; one test-robustness note addressed (settle past max jitter before final assertion instead of asserting on the first mailbox item).

Backlog: T46 in `plans/agent-backlog.md`.

## Test plan
- [x] `mvn -q -Dtest=RecordDhtRouterTest,RecordStoreRateLimiterTest,GarlicRouterTest test` green
- [x] Full `mvn test` green (one unrelated pre-existing flaky failure in `InboundCommandProcessorUpdateHardeningTest`, reproduced as flaky standalone too, untouched by this diff)
- [x] New test looped 8x by reviewer agent, all green

https://claude.ai/code/session_01PTpaNCjnuCCnVs8HxsTHNj