### PR TITLE
Fix NPE in PeerPerformanceTestGarlicMessageJob.done() on peer disconnect (REDPANDAJ-2EG)

### DIFF
--- a/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
+++ b/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
@@ -216,15 +216,14 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
     flaschenPostInsertPeer =
         serverContext.getPeerList().get(nodes.get(1).getNodeId().getKademliaId());
 
-    if (flaschenPostInsertPeer == null || flaschenPostInsertPeer.getNode() == null) {
+    // REDPANDAJ-2EG: read getNode() exactly once — the peer can disconnect (and clear its node)
+    // at any time, so a re-read after the null-check could still yield null. done() may run much
+    // later (GMAck arrival or timeout); the captured field stays valid regardless.
+    insertNode = flaschenPostInsertPeer == null ? null : flaschenPostInsertPeer.getNode();
+    if (flaschenPostInsertPeer == null || insertNode == null) {
       super.done();
       return true;
     }
-
-    // REDPANDAJ-2EG: capture the node reference while it is still validated under the NodeStore
-    // write lock. done() may run much later (GMAck arrival or timeout), by which time the peer
-    // may have disconnected and cleared its node — the field stays valid regardless.
-    insertNode = flaschenPostInsertPeer.getNode();
     return false;
   }
 

--- a/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
+++ b/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
@@ -44,6 +44,15 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
   ArrayList<Node> nodes;
   boolean success = false;
   private Peer flaschenPostInsertPeer;
+
+  /**
+   * Node of {@link #flaschenPostInsertPeer}, captured in {@code calculatePathOrAbort()} while it is
+   * validated non-null under the NodeStore write lock. {@code Peer.disconnect()} calls {@code
+   * clearNode()} at any time, so {@code done()} must use this stable reference instead of
+   * re-reading {@code flaschenPostInsertPeer.getNode()} (Sentry REDPANDAJ-2EG).
+   */
+  private Node insertNode;
+
   boolean includeReversedPath = false;
 
   public PeerPerformanceTestGarlicMessageJob(ServerContext serverContext) {
@@ -87,10 +96,10 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
     // TOCTOU (REDPANDAJ-2EC): calculatePathOrAbort() validated flaschenPostInsertPeer.getNode()
     // != null, but it did so under the NodeStore write lock which has since been released above.
     // The peer can disconnect in the meantime (Peer.disconnect() -> clearNode()), leaving
-    // getNode() null. Re-read once on the now-unlocked reference and abort gracefully instead of
-    // dereferencing null.
-    Node insertNode = flaschenPostInsertPeer.getNode();
-    if (insertNode == null) {
+    // getNode() null. Re-read once on the now-unlocked reference and abort gracefully (writing
+    // to a disconnected peer's buffer is pointless); done() itself is safe either way since it
+    // only uses the captured insertNode field (REDPANDAJ-2EG).
+    if (flaschenPostInsertPeer.getNode() == null) {
       done();
       return;
     }
@@ -201,6 +210,11 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
       super.done();
       return true;
     }
+
+    // REDPANDAJ-2EG: capture the node reference while it is still validated under the NodeStore
+    // write lock. done() may run much later (GMAck arrival or timeout), by which time the peer
+    // may have disconnected and cleared its node — the field stays valid regardless.
+    insertNode = flaschenPostInsertPeer.getNode();
     return false;
   }
 
@@ -243,10 +257,10 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
   @Override
   public void work() {
     if (getEstimatedRuntime() > JOB_TIMEOUT) {
-
-      if (flaschenPostInsertPeer != null && flaschenPostInsertPeer.getNode() != null) {
-        done();
-      }
+      // REDPANDAJ-2EG: no getNode() guard here — the peer disconnecting must not keep the job
+      // alive forever (it would leak in the running-jobs map). work() only runs after init()
+      // completed, so insertNode is set and done() is safe to call.
+      done();
     }
   }
 
@@ -259,9 +273,11 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
     }
 
     float scoreToAdd = 0;
+    // REDPANDAJ-2EG: use the insertNode captured in init() — flaschenPostInsertPeer.getNode()
+    // may have been nulled by a concurrent Peer.disconnect() (clearNode()) by now.
     if (success) {
-      flaschenPostInsertPeer.getNode().increaseGmTestsSuccessful();
-      flaschenPostInsertPeer.getNode().seen();
+      insertNode.increaseGmTestsSuccessful();
+      insertNode.seen();
 
       for (Node node : nodes) {
         node.increaseGmTestsSuccessful();
@@ -270,7 +286,7 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
 
       scoreToAdd = DELTA_SUCCESS;
     } else {
-      flaschenPostInsertPeer.getNode().increaseGmTestsFailed();
+      insertNode.increaseGmTestsFailed();
       for (Node node : nodes) {
         node.increaseGmTestsFailed();
       }
@@ -311,7 +327,7 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
             + " hops: "
             + (nodes.size() - 1)
             + " inserted to peer: "
-            + flaschenPostInsertPeer.getNode()
+            + insertNode
             + ANSI_RESET
             + (includeReversedPath ? " REVERSED" : ""));
     // }

--- a/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
+++ b/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
@@ -13,6 +13,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jgrapht.graph.DefaultDirectedWeightedGraph;
 
@@ -49,9 +50,18 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
    * Node of {@link #flaschenPostInsertPeer}, captured in {@code calculatePathOrAbort()} while it is
    * validated non-null under the NodeStore write lock. {@code Peer.disconnect()} calls {@code
    * clearNode()} at any time, so {@code done()} must use this stable reference instead of
-   * re-reading {@code flaschenPostInsertPeer.getNode()} (Sentry REDPANDAJ-2EG).
+   * re-reading {@code flaschenPostInsertPeer.getNode()} (Sentry REDPANDAJ-2EG). Volatile: written
+   * on the job-scheduler thread in init(), read in done() possibly from the thread parsing the
+   * GMAck.
    */
-  private Node insertNode;
+  private volatile Node insertNode;
+
+  /**
+   * done() can be entered concurrently (GMAck arrival via GMParser vs. timeout via the job
+   * scheduler). {@code Job.done()} is idempotent for the cleanup, but the scoring in our override
+   * must also run at most once (REDPANDAJ-2EG review follow-up).
+   */
+  private final AtomicBoolean scored = new AtomicBoolean(false);
 
   boolean includeReversedPath = false;
 
@@ -268,8 +278,22 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
   public void done() {
     super.done();
 
+    // Only the first caller may score: done() can race with itself (GMAck thread vs. timeout on
+    // the job-scheduler thread), which used to double-score nodes and edges (REDPANDAJ-2EG
+    // review follow-up; super.done() only dedups the cleanup, not this override).
+    if (!scored.compareAndSet(false, true)) {
+      return;
+    }
+
     if (nodes.size() < 2) {
       throw new RuntimeException("job started with too less nodes, this should not happen");
+    }
+
+    // REDPANDAJ-2EG: done() can be reached before init() captured insertNode, e.g. when the
+    // Job.run() catch-all calls done() after an exception inside calculatePathOrAbort(). No
+    // garlic message was sent in that case, so there is nothing to score.
+    if (insertNode == null) {
+      return;
     }
 
     float scoreToAdd = 0;

--- a/src/test/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJobTest.java
+++ b/src/test/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJobTest.java
@@ -1,5 +1,6 @@
 package im.redpanda.jobs;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -146,9 +147,87 @@ public class PeerPerformanceTestGarlicMessageJobTest {
     return job;
   }
 
+  /**
+   * Review follow-up for REDPANDAJ-2EG: done() can race with itself (GMAck arrival vs. timeout on
+   * the job-scheduler thread). {@code Job.done()} dedups only the cleanup — the scoring in the
+   * override must also run at most once, otherwise nodes are double-scored.
+   */
+  @Test
+  public void done_calledTwice_scoresInsertNodeOnlyOnce() throws Exception {
+    PeerPerformanceTestGarlicMessageJob job = buildJobWithDisconnectedInsertPeer();
+    Node insertNode = (Node) getPrivateField(job, "insertNode");
+
+    job.done();
+    job.done();
+
+    // One scoring pass counts the insert node twice (explicitly plus via the nodes loop, as it
+    // is part of the path) — a second done() must not add to that.
+    assertEquals(2, insertNode.getGmTestsFailed());
+  }
+
+  /**
+   * Review follow-up for REDPANDAJ-2EG: if init() throws inside calculatePathOrAbort() after the
+   * nodes path was populated but before insertNode was captured, the Job.run() catch-all calls
+   * done() with insertNode still null. Nothing was sent, so done() must terminate cleanly without
+   * scoring instead of throwing an NPE.
+   */
+  @Test
+  public void done_beforeInsertNodeCaptured_terminatesCleanlyWithoutScoring() throws Exception {
+    Node ownNode = new Node(serverContext, serverContext.getNodeId());
+    Node otherNode = new Node(serverContext, NodeId.generateWithSimpleKey());
+
+    PeerPerformanceTestGarlicMessageJob job =
+        new PeerPerformanceTestGarlicMessageJob(serverContext);
+    job.nodes = new ArrayList<>();
+    job.nodes.add(ownNode);
+    job.nodes.add(otherNode);
+    // insertNode and flaschenPostInsertPeer intentionally left unset (init() aborted mid-way).
+
+    job.done();
+
+    assertEquals(0, otherNode.getGmTestsFailed());
+  }
+
+  /**
+   * Review follow-up for REDPANDAJ-2EG: the timeout path must terminate the job even when the
+   * insert peer has disconnected — the old {@code getNode() != null} guard in work() left such jobs
+   * alive (and leaked in the running-jobs map) forever.
+   */
+  @Test
+  public void work_timeoutWithDisconnectedInsertPeer_terminatesJob() throws Exception {
+    PeerPerformanceTestGarlicMessageJob job = buildJobWithDisconnectedInsertPeer();
+    Node insertNode = (Node) getPrivateField(job, "insertNode");
+    // reRunDelay is 2500 ms; three runs exceed JOB_TIMEOUT (5000 ms).
+    setPrivateField(job, "runCounter", 3);
+    assertTrue(job.getEstimatedRuntime() > PeerPerformanceTestGarlicMessageJob.JOB_TIMEOUT);
+
+    job.work();
+
+    // done() ran and scored the timed-out test as failed in exactly one scoring pass (the insert
+    // node is counted twice per pass: explicitly plus via the nodes loop).
+    assertEquals(2, insertNode.getGmTestsFailed());
+  }
+
   private static void setPrivateField(Object target, String name, Object value) throws Exception {
-    Field field = target.getClass().getDeclaredField(name);
+    Field field = findField(target.getClass(), name);
     field.setAccessible(true);
     field.set(target, value);
+  }
+
+  private static Object getPrivateField(Object target, String name) throws Exception {
+    Field field = findField(target.getClass(), name);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
+  private static Field findField(Class<?> type, String name) throws NoSuchFieldException {
+    for (Class<?> current = type; current != null; current = current.getSuperclass()) {
+      try {
+        return current.getDeclaredField(name);
+      } catch (NoSuchFieldException e) {
+        // continue with superclass
+      }
+    }
+    throw new NoSuchFieldException(name);
   }
 }

--- a/src/test/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJobTest.java
+++ b/src/test/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJobTest.java
@@ -1,12 +1,15 @@
 package im.redpanda.jobs;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import im.redpanda.core.Node;
 import im.redpanda.core.NodeId;
+import im.redpanda.core.Peer;
 import im.redpanda.core.ServerContext;
 import im.redpanda.flaschenpost.GMParser;
 import im.redpanda.store.NodeEdge;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.security.Security;
 import java.util.ArrayList;
@@ -78,5 +81,74 @@ public class PeerPerformanceTestGarlicMessageJobTest {
     boolean dismissed = (boolean) method.invoke(job, graph, edge);
 
     assertTrue(dismissed);
+  }
+
+  /**
+   * Regression for REDPANDAJ-2EG: {@code done()} used to dereference {@code
+   * flaschenPostInsertPeer.getNode()}. init() validates the node under the NodeStore write lock,
+   * but the GMAck answering the test message arrives much later ({@code GMParser} -> {@code
+   * success()} -> {@code done()}); if the insert peer disconnected in the meantime, {@code
+   * Peer.disconnect()} has already called {@code clearNode()} and {@code getNode()} returns null,
+   * so the success path threw an NPE. done() must instead use the node reference captured during
+   * init() and complete without exception.
+   */
+  @Test
+  public void done_insertPeerDisconnectedBetweenInitAndAck_successPathDoesNotThrow()
+      throws Exception {
+    PeerPerformanceTestGarlicMessageJob job = buildJobWithDisconnectedInsertPeer();
+
+    // GMAck arrives after the peer disconnected: must terminate cleanly, not NPE.
+    job.success();
+  }
+
+  /**
+   * Same race as above but for the failure path (timeout via {@code work()} or the init()
+   * disconnect guard calling {@code done()} directly): line "increaseGmTestsFailed" used to NPE the
+   * same way, which also defeated the init() guard that relies on done() for a clean abort.
+   */
+  @Test
+  public void done_insertPeerDisconnectedBetweenInitAndTimeout_failPathDoesNotThrow()
+      throws Exception {
+    PeerPerformanceTestGarlicMessageJob job = buildJobWithDisconnectedInsertPeer();
+
+    job.done();
+  }
+
+  /**
+   * Builds a job in the state left behind by a successful init() — nodes path computed, insert peer
+   * and its node captured — after which the insert peer disconnects ({@code clearNode()}), as seen
+   * in REDPANDAJ-2EG.
+   */
+  private PeerPerformanceTestGarlicMessageJob buildJobWithDisconnectedInsertPeer()
+      throws Exception {
+    Node ownNode = new Node(serverContext, serverContext.getNodeId());
+    Node insertNode = new Node(serverContext, NodeId.generateWithSimpleKey());
+
+    PeerPerformanceTestGarlicMessageJob job =
+        new PeerPerformanceTestGarlicMessageJob(serverContext);
+    job.nodes = new ArrayList<>();
+    job.nodes.add(ownNode);
+    job.nodes.add(insertNode);
+    job.nodes.add(ownNode);
+
+    Peer insertPeer = new Peer("127.0.0.1", 1234, insertNode.getNodeId());
+    insertPeer.setNode(insertNode);
+
+    setPrivateField(job, "flaschenPostInsertPeer", insertPeer);
+    // init() captures the validated node reference exactly once, under the NodeStore write lock.
+    setPrivateField(job, "insertNode", insertNode);
+
+    // Peer disconnects before the GMAck/timeout triggers done(): Peer.disconnect() clears the
+    // node as its very first step, after which getNode() returns null.
+    insertPeer.clearNode();
+    assertNull(insertPeer.getNode());
+
+    return job;
+  }
+
+  private static void setPrivateField(Object target, String name, Object value) throws Exception {
+    Field field = target.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
   }
 }


### PR DESCRIPTION
## Summary

Fixes the Sentry NPE **REDPANDAJ-2EG** in `PeerPerformanceTestGarlicMessageJob.done()`.

### Root cause (TOCTOU)

`init()` selects `flaschenPostInsertPeer` and validates `getNode() != null` under the NodeStore write lock. The GMAck answering the garlic test message arrives much later (`GMParser` -> `success()` -> `done()`). If the insert peer disconnected in the meantime, `Peer.disconnect()` has already called `clearNode()` (and `getNode()` also returns null once the peer is no longer authed/connected), so `done()` NPE'd at `flaschenPostInsertPeer.getNode().increaseGmTestsSuccessful()`.

Two follow-on defects of the same root cause:

1. The REDPANDAJ-2EC guard in `init()` calls `done()` on disconnect — but `done()`'s failure path dereferenced `getNode()` again, so the guard itself NPE'd instead of aborting cleanly.
2. `work()` only called `done()` on timeout when `getNode() != null` — a disconnected peer therefore kept the job alive in the running-jobs map forever (leak).

### Fix

- Capture the insert peer's `Node` in a new field `insertNode` inside `calculatePathOrAbort()`, while it is still validated non-null under the NodeStore write lock. The `nodes` list/graph holds stable `Node` references; only the `Peer -> Node` link is cleared on disconnect.
- `done()` now exclusively uses `insertNode` (success path, failure path, and the path println) and never touches `flaschenPostInsertPeer.getNode()` again.
- `work()` calls `done()` unconditionally on timeout — `work()` only runs after `init()` completed (the `Job.run()` loop checks the done flag), so `insertNode` is always set there. The timeout path now always terminates the job.

Scoring, path logic and output are otherwise unchanged.

### Tests

- New regression tests in `PeerPerformanceTestGarlicMessageJobTest`: job in post-`init()` state, insert peer disconnects (`clearNode()`), then `success()` (GMAck path) and `done()` (timeout/guard path) — both must complete without exception. Both NPE'd before the fix (verified) and pass after.
- Full `mvn verify` run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErN7gXeXPL2wrpTprXFww4
