### PR TITLE
Fix REDPANDAJ-2EF: readBuffer ownership handoff vs. re-handshake race

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -688,6 +688,10 @@ public class ConnectionHandler extends Thread {
     // ConnectionReaderThread.readConnection, Peer.disconnect(), Peer.decryptInputData() —
     // REDPANDAJ-2EF). Take the same lock so this post-handshake write neither races a reader
     // restoring leftover bytes nor writes into a buffer a reader has just claimed.
+    // Known pre-existing limitation (unchanged by T50): if the new connection's first socket
+    // bytes get decrypted by a reader before this copy runs, the handshake leftovers end up
+    // AFTER them in the plaintext stream — a misparse then disconnects and resyncs the
+    // connection. The lock prevents structural buffer corruption, not this ordering.
     peer.getWriteBufferLock().lock();
     try {
       if (peer.readBuffer == null) {

--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -681,11 +681,21 @@ public class ConnectionHandler extends Thread {
   }
 
   private void copyRemainingReadBytesToPeerBuffer(ByteBuffer tempHandshakeReadBuffer, Peer peer) {
-    if (tempHandshakeReadBuffer.hasRemaining()) {
+    if (!tempHandshakeReadBuffer.hasRemaining()) {
+      return;
+    }
+    // peer.readBuffer is only ever touched under writeBufferLock (claim/restore in
+    // ConnectionReaderThread.readConnection, Peer.disconnect(), Peer.decryptInputData() —
+    // REDPANDAJ-2EF). Take the same lock so this post-handshake write neither races a reader
+    // restoring leftover bytes nor writes into a buffer a reader has just claimed.
+    peer.getWriteBufferLock().lock();
+    try {
       if (peer.readBuffer == null) {
         peer.readBuffer = ByteBufferPool.borrowObject(tempHandshakeReadBuffer.remaining());
       }
       peer.readBuffer.put(tempHandshakeReadBuffer);
+    } finally {
+      peer.getWriteBufferLock().unlock();
     }
   }
 

--- a/src/main/java/im/redpanda/core/ConnectionReaderThread.java
+++ b/src/main/java/im/redpanda/core/ConnectionReaderThread.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
+import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -282,7 +283,9 @@ public class ConnectionReaderThread implements Runnable {
     return true;
   }
 
-  private int readConnection(Peer peer) throws PeerProtocolException {
+  // package-private (instead of private) so the T50/REDPANDAJ-2EF regression tests can drive the
+  // claim/restore ownership handoff through the real code path.
+  int readConnection(Peer peer) throws PeerProtocolException {
 
     SelectionKey key = peer.selectionKey;
 
@@ -291,15 +294,25 @@ public class ConnectionReaderThread implements Runnable {
     // would parse data from a different peer.");
     // }
 
+    // Capture the channel we read from: a concurrent re-handshake of an already known peer
+    // (Peer.setupConnectionForPeer, IncomingHandler thread) replaces socketChannel, selectionKey
+    // and the cipher streams while this method runs. The captured instance lets us detect below
+    // that the bytes in myReaderBuffer belong to the OLD connection (REDPANDAJ-2EF/2EE).
+    SocketChannel channel = peer.getSocketChannel();
+
     int read = -2;
     String debugStringRead = myReaderBuffer.toString();
     try {
-      read = peer.getSocketChannel().read(myReaderBuffer);
+      read = channel.read(myReaderBuffer);
       Log.put("!!read bytes: " + read, 200);
     } catch (IOException e) {
       // e.printStackTrace();
       key.cancel();
-      peer.disconnect("could not read peer...");
+      // After a concurrent re-handshake the IOException stems from the old, already closed
+      // channel — tearing the peer down then would kill the freshly established connection.
+      if (peer.getSocketChannel() == channel) {
+        peer.disconnect("could not read peer...");
+      }
       return 0;
     } catch (Throwable e) {
       Log.sentry(e);
@@ -307,7 +320,9 @@ public class ConnectionReaderThread implements Runnable {
           "Could not read in ConnectionReaderThread, buffer before read was: " + debugStringRead);
       e.printStackTrace();
       key.cancel();
-      peer.disconnect("could not read...");
+      if (peer.getSocketChannel() == channel) {
+        peer.disconnect("could not read...");
+      }
       return 0;
     }
 
@@ -342,50 +357,79 @@ public class ConnectionReaderThread implements Runnable {
       return 0;
     } else if (read == -1) {
       Log.put("closing connection " + peer.ip + ": not readable! ", 100);
-      peer.disconnect(" read == -1 ");
+      if (peer.getSocketChannel() == channel) {
+        peer.disconnect(" read == -1 ");
+      }
       key.cancel();
     } else {
 
       Log.put("received bytes!", 200);
     }
 
-    if (peer.readBuffer == null) {
-      peer.readBuffer = ByteBufferPool.borrowObject(myReaderBuffer.position());
-    }
-
-    /** Decrypt all bytes from the readBufferCrypted to the readBuffer */
-    peer.decryptInputData(myReaderBuffer);
-
-    // decryptInputData() may have grown the plaintext buffer: it returns the old, now-stale
-    // buffer instance to the ByteBufferPool and stores a larger one in peer.readBuffer. We must
-    // therefore read peer.readBuffer AFTER decrypting — using a reference captured beforehand
-    // would hand a pooled/reused buffer to loopCommands, whose flip()/compact() then corrupts
-    // pool state (observed as an invalid ByteBuffer[pos=0 lim=0] on the next borrowObject).
-    ByteBuffer readBuffer = peer.readBuffer;
-
-    inboundProcessor.loopCommands(peer, readBuffer);
-
-    // System.out.println("buffer after parse: " + readBuffer);
-
-    /**
-     * The readBuffer might be null if the peer is disconnected while parsing a command, the
-     * disconnect method handles the return of the readBuffer...
-     */
-    // Returning peer.readBuffer to the pool must be serialized with the other threads that touch
-    // it — Peer.decryptInputData() and Peer.disconnect() both do so under writeBufferLock. Doing
-    // it lock-free here raced a concurrent disconnect returning the same buffer, producing a
-    // double-return ("Object has already been returned to this pool", REDPANDAJ-2ED) or a buffer
-    // handed to a new owner while still referenced here (borrowObject then saw pos!=0,
-    // REDPANDAJ-2E8). Take the same lock and re-read the field inside it.
+    // Borrow, decrypt and CLAIM the plaintext buffer in one writeBufferLock section
+    // (REDPANDAJ-2EF): the former lock-free gap between decryptInputData() and the return block
+    // let a concurrent Peer.setupConnectionForPeer() -> disconnect() (IncomingHandler thread,
+    // re-handshake of an existing peer) return peer.readBuffer to the ByteBufferPool while
+    // loopCommands below was still flipping/compacting it — the pool then saw the buffer with
+    // pos!=0 ("borrowObject found an invalid ByteBuffer") or, worse, handed it to another
+    // connection while still in use here. Claiming the buffer (field -> local, field = null)
+    // makes this thread the exclusive owner for the whole parse: disconnect() only returns what
+    // is stored in the field, so it can no longer touch the buffer we are working on.
+    ByteBuffer claimedReadBuffer;
     peer.getWriteBufferLock().lock();
     try {
-      if (peer.readBuffer != null && peer.readBuffer.position() == 0) {
-        ByteBuffer toReturn = peer.readBuffer;
-        peer.readBuffer = null;
-        ByteBufferPool.returnObject(toReturn);
+      // If the connection we read from is gone or was replaced by a re-handshake, the bytes in
+      // myReaderBuffer belong to the OLD connection: decrypting them with the new cipher streams
+      // would desync the GCM frame nonce counter (REDPANDAJ-2EE) and their plaintext must not
+      // leak into the new connection. Drop them instead.
+      if (!peer.isConnected() || peer.getSocketChannel() != channel) {
+        myReaderBuffer.clear();
+        return read;
       }
+
+      if (peer.readBuffer == null) {
+        peer.readBuffer = ByteBufferPool.borrowObject(myReaderBuffer.position());
+      }
+
+      // Decrypt all bytes from myReaderBuffer (ciphertext) to peer.readBuffer (plaintext).
+      // decryptInputData() takes the same lock (reentrant) and may grow the buffer: it returns
+      // the old, too-small instance to the ByteBufferPool and stores a larger one in
+      // peer.readBuffer, so the field must only be read AFTER decrypting (REDPANDAJ-2DT/2DV).
+      peer.decryptInputData(myReaderBuffer);
+
+      claimedReadBuffer = peer.readBuffer;
+      peer.readBuffer = null;
     } finally {
       peer.getWriteBufferLock().unlock();
+    }
+
+    try {
+      // Parse commands WITHOUT holding writeBufferLock: loopCommands can run long and its
+      // handlers take the lock themselves (writeBuffer replies) or call disconnect(); holding
+      // the lock across it would risk deadlocks and starve the outbound path. The claimed
+      // buffer is exclusively ours, so no lock is needed for it.
+      inboundProcessor.loopCommands(peer, claimedReadBuffer, true);
+    } finally {
+      // Return or restore the claimed buffer under the lock (pairs with the claim above and
+      // with the other owners of the field: Peer.decryptInputData(), Peer.disconnect() and
+      // ConnectionHandler.copyRemainingReadBytesToPeerBuffer() all serialize on it —
+      // REDPANDAJ-2E8/2ED history). Restore only if the very same connection is still alive
+      // and nobody stored a new buffer in the meantime; leftover bytes of a replaced or dead
+      // connection are garbage and must not leak into a new connection (REDPANDAJ-2EF/2EE).
+      peer.getWriteBufferLock().lock();
+      try {
+        boolean drained = claimedReadBuffer.position() == 0;
+        boolean sameConnectionAlive = peer.isConnected() && peer.getSocketChannel() == channel;
+        if (!drained && sameConnectionAlive && peer.readBuffer == null) {
+          peer.readBuffer = claimedReadBuffer;
+        } else {
+          claimedReadBuffer.position(0);
+          claimedReadBuffer.limit(claimedReadBuffer.capacity());
+          ByteBufferPool.returnObject(claimedReadBuffer);
+        }
+      } finally {
+        peer.getWriteBufferLock().unlock();
+      }
     }
 
     if (myReaderBuffer.position() != 0 && myReaderBuffer.limit() != myReaderBuffer.capacity()) {

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -242,16 +242,30 @@ public class InboundCommandProcessor {
   }
 
   public void loopCommands(Peer peer, ByteBuffer readBuffer) {
+    loopCommands(peer, readBuffer, false);
+  }
+
+  /**
+   * @param callerOwnsBuffer {@code true} when the caller has exclusively claimed the buffer
+   *     beforehand (T50 / REDPANDAJ-2EF ownership handoff in {@code
+   *     ConnectionReaderThread.readConnection}: {@code peer.readBuffer} is {@code null} while this
+   *     runs, so a handler-triggered {@link Peer#disconnect(String)} cannot return the buffer to
+   *     the {@link ByteBufferPool} mid-loop). The buffer is then always compacted, keeping it in
+   *     write mode for the caller's restore/return step — even on a handler exception or
+   *     disconnect. With {@code false} (legacy wiring where the buffer is still referenced by
+   *     {@code peer.readBuffer}) compact only happens while the field still points at this buffer:
+   *     a handler-triggered disconnect already reset and returned the field's buffer
+   *     (REDPANDAJ-2DR), so compacting the stale reference afterwards would corrupt whatever the
+   *     pool's next borrower sees.
+   */
+  public void loopCommands(Peer peer, ByteBuffer readBuffer, boolean callerOwnsBuffer) {
     readBuffer.flip();
 
     int parsedBytesLocally = -1;
 
     // compact() must run even if a handler throws, otherwise the buffer state is left
     // inconsistent (flipped, position/limit not restored) and the connection keeps retrying
-    // the same malformed packet. But if a handler disconnected the peer (or grew the buffer),
-    // Peer.disconnect()/decryptInputData() already returned this exact buffer instance to
-    // ByteBufferPool (and possibly handed it to a different peer/thread) — compacting it here
-    // would then corrupt that other owner's buffer, so only compact if we still own it.
+    // the same malformed packet. See the javadoc above for when compacting is safe.
     try {
       while (readBuffer.hasRemaining() && parsedBytesLocally != 0 && peer.isConnected()) {
         int newPosition = readBuffer.position();
@@ -266,7 +280,7 @@ public class InboundCommandProcessor {
         readBuffer.position(newPosition);
       }
     } finally {
-      if (peer.readBuffer == readBuffer) {
+      if (callerOwnsBuffer || peer.readBuffer == readBuffer) {
         readBuffer.compact();
       }
     }

--- a/src/main/java/im/redpanda/core/Peer.java
+++ b/src/main/java/im/redpanda/core/Peer.java
@@ -478,34 +478,44 @@ public class Peer implements Comparable<Peer> {
     // disconnect old connection if present
     disconnect("new connection for this peer");
 
-    setConnected(true);
-    isConnecting = false;
-    authed = true;
-    retries = 0;
-    lightClient = peerInHandshake.lightClient;
-    protocolVersion = peerInHandshake.protocolVersion;
-    connectedSince = System.currentTimeMillis();
-
-    /** setup the buffers */
+    // The whole connection swap — state flags, buffers, socketChannel, selectionKey AND the
+    // cipher streams — happens in one writeBufferLock section: a concurrently running
+    // ConnectionReaderThread (readConnection/decryptInputData work under the same lock since
+    // REDPANDAJ-2EF) must never observe a half-replaced connection, e.g. the new GCM cipher
+    // streams combined with the old socketChannel, which desyncs the frame nonce counter
+    // (REDPANDAJ-2EE) or leaks bytes between the old and the new connection. The only caller
+    // (ConnectionHandler.setupConnection) already holds this lock; taking the reentrant lock
+    // here as well keeps the invariant local to this class.
     ReentrantLock writeBufferLock = getWriteBufferLock();
     writeBufferLock.lock();
     try {
-      writeBuffer = ByteBuffer.allocate(300 * 1024);
-      writeBufferCrypted = ByteBuffer.allocate(300 * 1024);
-    } catch (Exception e) {
-      Log.putStd("Could not reserve enough memory for this connection. Disconnect peer...");
-      disconnect("Could not reserve enough memory for this connection.");
+      setConnected(true);
+      isConnecting = false;
+      authed = true;
+      retries = 0;
+      lightClient = peerInHandshake.lightClient;
+      protocolVersion = peerInHandshake.protocolVersion;
+      connectedSince = System.currentTimeMillis();
+
+      /** setup the buffers */
+      try {
+        writeBuffer = ByteBuffer.allocate(300 * 1024);
+        writeBufferCrypted = ByteBuffer.allocate(300 * 1024);
+      } catch (Exception e) {
+        Log.putStd("Could not reserve enough memory for this connection. Disconnect peer...");
+        disconnect("Could not reserve enough memory for this connection.");
+      }
+
+      // set up the peer with all data from the peerInHandshake
+      setLastPongReceived(System.currentTimeMillis());
+
+      setSocketChannel(peerInHandshake.getSocketChannel());
+      setSelectionKey(peerInHandshake.getKey());
+
+      setPeerChiperStreams(peerInHandshake.getPeerChiperStreams());
     } finally {
       writeBufferLock.unlock();
     }
-
-    // set up the peer with all data from the peerInHandshake
-    setLastPongReceived(System.currentTimeMillis());
-
-    setSocketChannel(peerInHandshake.getSocketChannel());
-    setSelectionKey(peerInHandshake.getKey());
-
-    setPeerChiperStreams(peerInHandshake.getPeerChiperStreams());
 
     if (!peerInHandshake.lightClient) {
       writeBufferLock.lock();

--- a/src/main/java/im/redpanda/core/Peer.java
+++ b/src/main/java/im/redpanda/core/Peer.java
@@ -32,10 +32,14 @@ public class Peer implements Comparable<Peer> {
   int cnt = 0;
   public long connectedSince = 0;
   private NodeId nodeId;
-  private SocketChannel socketChannel;
+  // volatile: readConnection()'s stale-connection guards compare these lock-free against a
+  // captured reference while setupConnectionForPeer() swaps them under writeBufferLock — without
+  // volatile the JMM permits a stale read, making a guard misfire and tear down the fresh
+  // replacement connection (REDPANDAJ-2EF review finding).
+  private volatile SocketChannel socketChannel;
   public ByteBuffer readBuffer;
   public ByteBuffer writeBuffer;
-  SelectionKey selectionKey;
+  volatile SelectionKey selectionKey;
   private boolean connected = false;
   public boolean isConnecting;
   public long lastPinged = 0;

--- a/src/test/java/im/redpanda/core/ParseCommandTest.java
+++ b/src/test/java/im/redpanda/core/ParseCommandTest.java
@@ -121,6 +121,43 @@ public class ParseCommandTest {
   }
 
   /**
+   * T50 / REDPANDAJ-2EF ownership handoff: when the caller has exclusively claimed the buffer
+   * beforehand ({@code peer.readBuffer} is {@code null}, so a handler-triggered {@link
+   * Peer#disconnect(String)} cannot return it to the pool mid-loop), {@code loopCommands} must
+   * compact the buffer even after a disconnecting handler — the caller still owns it and needs it
+   * back in write mode for its own restore/return step. Counterpart to {@link
+   * #loopCommands_doesNotTouchBufferAfterHandlerDisconnectsPeer()} which pins the legacy
+   * (non-owned) wiring.
+   */
+  @Test
+  public void loopCommands_compactsClaimedBufferEvenAfterHandlerDisconnectsPeer() {
+    ServerContext serverContext = new ServerContext();
+    InboundCommandProcessor processor = new InboundCommandProcessor(serverContext);
+
+    // not pool-managed on purpose: the buffer is "claimed" by the caller in this mode
+    ByteBuffer buffer = ByteBuffer.allocate(1024);
+    buffer.put((byte) 0); // unknown command -> handler disconnects the peer
+    buffer.put(Command.PING); // one extra byte that must survive the compact
+
+    Peer peer = getPeerForDebug();
+    serverContext.getPeerList().add(peer);
+    peer.setConnected(true);
+    peer.readBuffer = null; // claimed: the field is empty while the caller parses
+
+    processor.loopCommands(peer, buffer, true);
+
+    assertThat(peer.isConnected()).isFalse();
+    assertThat(peer.readBuffer)
+        .as("disconnect() must not have grabbed the claimed buffer")
+        .isNull();
+    // compact() ran: the unparsed trailing byte was moved to the front, buffer is in write mode
+    assertThat(buffer.position()).isEqualTo(1);
+    assertThat(buffer.limit()).isEqualTo(buffer.capacity());
+    buffer.flip();
+    assertThat(buffer.get()).isEqualTo(Command.PING);
+  }
+
+  /**
    * REDPANDAJ-2E0: an unknown command byte (observed as command {@code 0} right after another
    * command, i.e. a stream desync) used to throw a {@code RuntimeException} that was only logged
    * while the peer stayed connected and kept re-hitting the same desynced byte on every read.

--- a/src/test/java/im/redpanda/core/ReadConnectionOwnershipHandoffTest.java
+++ b/src/test/java/im/redpanda/core/ReadConnectionOwnershipHandoffTest.java
@@ -1,0 +1,232 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression tests for the T50 / REDPANDAJ-2EF readBuffer ownership handoff in {@link
+ * ConnectionReaderThread#readConnection(Peer)}: the reader claims {@code peer.readBuffer} under
+ * {@code writeBufferLock} (field set to {@code null}) before parsing, so a concurrent {@link
+ * Peer#disconnect(String)} — e.g. triggered by {@link Peer#setupConnectionForPeer} during a
+ * re-handshake of an existing peer on the IncomingHandler thread — can no longer return the buffer
+ * to the {@link ByteBufferPool} while the reader is still flipping/compacting it ("borrowObject
+ * found an invalid ByteBuffer", cross-connection buffer reuse).
+ *
+ * <p>The tests drive the real {@code readConnection} code path over a loopback {@link
+ * SocketChannel} pair with real {@link GcmFramedStreams} (same key for both directions, so the test
+ * can encrypt frames the peer's receive stream will decrypt — same trick as {@link PeerTest}).
+ *
+ * <p>A fully concurrent interleaving test (thread A parked inside loopCommands while thread B runs
+ * setupConnectionForPeer) is intentionally not attempted: {@code ConnectionReaderThread} creates
+ * its {@code InboundCommandProcessor} internally and the command-handler table is private, so there
+ * is no seam to deterministically park the parse loop without adding test hooks to production code.
+ * Instead these tests pin every state transition of the claim/restore protocol (drain, restore,
+ * disconnect-while-claimed, stale-connection drop) deterministically.
+ */
+public class ReadConnectionOwnershipHandoffTest {
+
+  static {
+    ByteBufferPool.init();
+  }
+
+  private ServerSocketChannel serverSocket;
+  private SocketChannel remoteSide;
+  private SocketChannel peerSide;
+
+  @Before
+  public void setUpChannels() throws IOException {
+    serverSocket = ServerSocketChannel.open();
+    serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
+    remoteSide = SocketChannel.open(serverSocket.getLocalAddress());
+    peerSide = serverSocket.accept();
+  }
+
+  @After
+  public void tearDownChannels() throws IOException {
+    for (SocketChannel channel : new SocketChannel[] {remoteSide, peerSide}) {
+      if (channel != null && channel.isOpen()) {
+        channel.close();
+      }
+    }
+    if (serverSocket != null && serverSocket.isOpen()) {
+      serverSocket.close();
+    }
+  }
+
+  private Peer newConnectedPeer() {
+    Peer peer = new Peer("127.0.0.1", 0, new NodeId());
+    peer.setSocketChannel(peerSide);
+    peer.setConnected(true);
+    peer.writeBuffer = ByteBuffer.allocate(1024 * 100);
+    peer.writeBufferCrypted = ByteBuffer.allocate(1024 * 100);
+    // Same 32-byte key for both directions so the peer's receive stream decrypts frames encrypted
+    // by its own send stream (loopback test trick, see PeerTest).
+    byte[] key = new byte[32];
+    peer.setPeerChiperStreams(new GcmFramedStreams(key, key));
+    return peer;
+  }
+
+  private ConnectionReaderThread newReaderThread() {
+    return new ConnectionReaderThread(new ServerContext(), ConnectionReaderThread.STD_TIMEOUT);
+  }
+
+  /** Encrypts the given plaintext with the peer's (loopback) streams and sends it to the peer. */
+  private void sendEncrypted(Peer peer, byte[] plaintext) throws IOException {
+    ByteBuffer in = ByteBuffer.allocate(plaintext.length);
+    in.put(plaintext);
+    in.flip();
+    ByteBuffer out = ByteBuffer.allocate(plaintext.length + 1024);
+    peer.getPeerChiperStreams().encrypt(in, out);
+    out.flip();
+    while (out.hasRemaining()) {
+      remoteSide.write(out);
+    }
+  }
+
+  /**
+   * Fully drained buffer: after parsing, the claimed buffer must be returned to the pool and the
+   * field must stay {@code null}. The LIFO pool handing back the very same instance on the next
+   * borrow proves the return actually happened (and happened exactly once — a double return would
+   * throw an IllegalStateException out of readConnection).
+   */
+  @Test
+  public void drainedBufferIsReturnedToPoolAndFieldStaysNull() throws Exception {
+    Peer peer = newConnectedPeer();
+    ByteBuffer preBorrowed = ByteBufferPool.borrowObject(1024);
+    peer.readBuffer = preBorrowed;
+
+    sendEncrypted(peer, new byte[] {Command.PONG, Command.PONG, Command.PONG});
+
+    int read = newReaderThread().readConnection(peer);
+
+    assertThat(read).isGreaterThan(0);
+    assertThat(peer.lastCommand).isEqualTo(Command.PONG);
+    assertThat(peer.readBuffer)
+        .as("a fully drained buffer must be returned to the pool, not kept in the field")
+        .isNull();
+    // LIFO pool: the instance we just returned is the first one handed out again, in pristine
+    // state. This asserts the buffer really went back to the pool exactly once.
+    ByteBuffer reBorrowed = ByteBufferPool.borrowObject(1024);
+    assertThat(reBorrowed).isSameAs(preBorrowed);
+    assertThat(reBorrowed.position()).isZero();
+    assertThat(reBorrowed.limit()).isEqualTo(reBorrowed.capacity());
+    ByteBufferPool.returnObject(reBorrowed);
+  }
+
+  /**
+   * Unparsed rest bytes of a half-received command: the claimed buffer must be restored into {@code
+   * peer.readBuffer} (same instance, bytes preserved) so the next read can complete the command.
+   */
+  @Test
+  public void bufferWithLeftoverBytesIsRestoredIntoField() throws Exception {
+    Peer peer = newConnectedPeer();
+    ByteBuffer preBorrowed = ByteBufferPool.borrowObject(1024);
+    peer.readBuffer = preBorrowed;
+
+    // SEND_PEERLIST announces a 100-byte payload that never arrives -> parseCommand returns 0,
+    // the command byte + length header (5 bytes) remain unparsed in the buffer.
+    byte[] partialCommand = new byte[5];
+    ByteBuffer header = ByteBuffer.wrap(partialCommand);
+    header.put(Command.SEND_PEERLIST);
+    header.putInt(100);
+    sendEncrypted(peer, partialCommand);
+
+    int read = newReaderThread().readConnection(peer);
+
+    assertThat(read).isGreaterThan(0);
+    assertThat(peer.readBuffer)
+        .as("leftover bytes of a half command must be restored into the field")
+        .isSameAs(preBorrowed);
+    assertThat(peer.readBuffer.position())
+        .as("the 5 header bytes must still be buffered (write mode)")
+        .isEqualTo(5);
+    assertThat(peer.isConnected()).isTrue();
+
+    // cleanup: hand the buffer back via the production path
+    peer.disconnect("test cleanup");
+    assertThat(peer.readBuffer).isNull();
+  }
+
+  /**
+   * Handler disconnects the peer mid-parse (here: unknown command byte, REDPANDAJ-2E0 behavior)
+   * while the buffer is claimed: {@link Peer#disconnect(String)} must not return the claimed buffer
+   * (the field is {@code null}), and afterwards readConnection itself must return it exactly once —
+   * the pre-2EF code raced exactly here. A double return would throw an IllegalStateException from
+   * the pool and fail this test.
+   */
+  @Test
+  public void disconnectWhileBufferClaimedReturnsBufferExactlyOnce() throws Exception {
+    Peer peer = newConnectedPeer();
+    ByteBuffer preBorrowed = ByteBufferPool.borrowObject(1024);
+    peer.readBuffer = preBorrowed;
+
+    sendEncrypted(peer, new byte[] {0}); // unknown command -> handler disconnects the peer
+
+    int read = newReaderThread().readConnection(peer);
+
+    assertThat(read).isGreaterThan(0);
+    assertThat(peer.isConnected()).isFalse();
+    assertThat(peer.readBuffer)
+        .as("after a mid-parse disconnect nothing may be left in the field")
+        .isNull();
+    // the reader (not disconnect) must have returned the claimed buffer to the pool, valid
+    ByteBuffer reBorrowed = ByteBufferPool.borrowObject(1024);
+    assertThat(reBorrowed).isSameAs(preBorrowed);
+    assertThat(reBorrowed.position()).isZero();
+    ByteBufferPool.returnObject(reBorrowed);
+  }
+
+  /**
+   * Connection torn down between the socket read and the decrypt (the re-handshake window): the
+   * stale ciphertext bytes must be dropped — no decrypt (which would desync the GCM frame nonce
+   * counter of a replacement connection, REDPANDAJ-2EE), no borrow, no parse.
+   */
+  @Test
+  public void staleBytesAfterDisconnectAreDroppedWithoutDecrypt() throws Exception {
+    Peer peer = newConnectedPeer();
+
+    sendEncrypted(peer, new byte[] {Command.PONG});
+    // simulate the connection being replaced/torn down after the bytes were read off the socket
+    peer.setConnected(false);
+
+    int read = newReaderThread().readConnection(peer);
+
+    assertThat(read).isGreaterThan(0);
+    assertThat(peer.readBuffer).as("no buffer may be borrowed for dropped stale bytes").isNull();
+    assertThat(peer.lastCommand).as("stale bytes must not be parsed").isEqualTo((byte) 0);
+  }
+
+  /**
+   * Contract of {@link Peer#disconnect(String)} under the handoff: it only returns what is stored
+   * in the field. A buffer claimed by a reader (field {@code null}) is left completely untouched —
+   * no reset, no pool return.
+   */
+  @Test
+  public void disconnectDoesNotTouchClaimedBuffer() {
+    Peer peer = new Peer("127.0.0.1", 0, new NodeId());
+    peer.setConnected(true);
+
+    ByteBuffer claimed = ByteBufferPool.borrowObject(1024);
+    claimed.put((byte) 42); // reader is mid-parse, position 1
+    peer.readBuffer = null; // claimed: field is empty
+
+    peer.disconnect("test");
+
+    assertThat(peer.isConnected()).isFalse();
+    assertThat(peer.readBuffer).isNull();
+    assertThat(claimed.position())
+        .as("disconnect must not reset a buffer it does not own via the field")
+        .isEqualTo(1);
+    // cleanup
+    claimed.clear();
+    ByteBufferPool.returnObject(claimed);
+  }
+}


### PR DESCRIPTION
## RCA (T50)

**REDPANDAJ-2EF** ("borrowObject found an invalid ByteBuffer pos=3"): use-after-return of the peer's `readBuffer`. The ReaderThread held `writeBufferLock` only inside `Peer.decryptInputData()` and in the return block at the end of `readConnection()` — but parsed commands (`loopCommands`) **lock-free** on a local reference in between. The Sentry-recorded returner stack shows the racing path exactly: `Peer.setupConnectionForPeer()` (IncomingHandler thread, re-handshake of an existing peer) → `disconnect()` returns `peer.readBuffer` to the `ByteBufferPool` with forced `position(0)` while the reader is still flipping/compacting it. The pool then sees the buffer with `pos!=0` (self-healing via invalidate → 2EF event) — worst case it hands the buffer to another connection while still in use, i.e. cross-connection data corruption.

## Fix: ownership handoff

- `readConnection()` now **borrows + decrypts + claims** the buffer in one `writeBufferLock` section (claim = field → local, field = `null`), parses lock-free on the exclusively owned buffer (no lock across `loopCommands` — handlers take the lock themselves and can call `disconnect()`), then under the lock either **returns** it (drained, connection dead/replaced, field re-occupied) or **restores** it into the field for the next read.
- `Peer.disconnect()` unchanged: it only returns what is stored in the field — during a claimed parse the field is `null`, so it can no longer touch the reader's buffer.
- `InboundCommandProcessor.loopCommands` gets an explicit `callerOwnsBuffer` parameter: claimed buffers are always compacted (stay in write mode for restore, even after a mid-parse disconnect); legacy wiring keeps the REDPANDAJ-2DR guard.
- `Peer.setupConnectionForPeer()` swaps `socketChannel`/`selectionKey`/cipher streams/connection flags **inside** the `writeBufferLock` section (previously only the buffer allocation was covered; the only caller already held the lock, the invariant is now local to `Peer`).
- `readConnection()` captures the channel it read from and **drops stale bytes** if the connection died or was replaced before decrypting; stale read errors from the old channel no longer tear down the freshly established replacement connection.
- `ConnectionHandler.copyRemainingReadBytesToPeerBuffer()` now writes `peer.readBuffer` under the same lock.

**REDPANDAJ-2EE** ("unexpected GCM frame nonce (expected counter 2)") is very likely the same race family: a reader mid-cycle hitting the new cipher streams with bytes of the old connection (or vice versa). The atomic connection swap + stale-byte drop should cover it — observed alongside, intentionally **not** in the Fixes trailer; keep the Sentry issue open until the testnet confirms.

## Tests

- New `ReadConnectionOwnershipHandoffTest` drives the real `readConnection()` path over a loopback `SocketChannel` pair with real `GcmFramedStreams`: drained buffer returned exactly once (LIFO pool identity check; a double return would throw), leftover bytes of a half command restored (same instance), mid-parse disconnect (unknown command) returns the claimed buffer exactly once, stale bytes after teardown dropped without decrypt, `disconnect()` leaves a claimed buffer untouched.
- `ParseCommandTest`: new counterpart test pinning the `callerOwnsBuffer=true` compact contract next to the existing 2DR guard test.
- A fully concurrent interleaving test (parking `loopCommands` while `setupConnectionForPeer` runs) was deliberately not added: the handler table is private, there is no seam to park the parse loop deterministically without adding production test hooks — the state transitions of the claim/restore protocol are pinned deterministically instead.
- `mvn verify` locally green: 385 tests, 0 failures (1 pre-existing skip). Note: in a linked git worktree the git-commit-id plugin needs `-Dmaven.gitcommitid.skip=true`; CI checkouts are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErN7gXeXPL2wrpTprXFww4