### PR TITLE
T52: Quick-win fixes TD007 (GM double-scoring) + TD008 (sendPing NPE) + TD010 (setupConnectionForPeer OOM path)

### DIFF
--- a/src/main/java/im/redpanda/core/Peer.java
+++ b/src/main/java/im/redpanda/core/Peer.java
@@ -263,7 +263,7 @@ public class Peer implements Comparable<Peer> {
       return;
     }
 
-    if (getSelectionKey() == null || writeBuffer == null) {
+    if (getSelectionKey() == null) {
       setConnected(false);
       return;
     }
@@ -276,13 +276,23 @@ public class Peer implements Comparable<Peer> {
     lastPinged = System.currentTimeMillis();
 
     if (writeBufferLock.tryLock()) {
-      if (writeBuffer.capacity() > 0) {
-        writeBuffer.put(Command.PING);
-        Log.put("pinged...", 100);
-      } else {
-        Log.put("didnt ping, buffer has content...", 100);
+      try {
+        // Re-read (and check) writeBuffer under the lock: disconnect() nulls it under this same
+        // lock, so checking it before acquiring the lock leaves a window in which the field turns
+        // null between the check and the tryLock() succeeding, NPE-ing on writeBuffer.capacity()
+        // below (REDPANDAJ-TD008).
+        ByteBuffer buffer = writeBuffer;
+        if (buffer == null) {
+          setConnected(false);
+        } else if (buffer.capacity() > 0) {
+          buffer.put(Command.PING);
+          Log.put("pinged...", 100);
+        } else {
+          Log.put("didnt ping, buffer has content...", 100);
+        }
+      } finally {
+        writeBufferLock.unlock();
       }
-      writeBufferLock.unlock();
     } else {
       Log.put("Could not lock for ping!", 50);
     }
@@ -508,6 +518,11 @@ public class Peer implements Comparable<Peer> {
       } catch (Exception e) {
         Log.putStd("Could not reserve enough memory for this connection. Disconnect peer...");
         disconnect("Could not reserve enough memory for this connection.");
+        // Early return (REDPANDAJ-TD010): without it the code below kept running on the peer
+        // disconnect() just tore down, re-populating socketChannel/selectionKey/cipherStreams
+        // (and, past the lock, writing into a writeBuffer that allocation never actually produced)
+        // on a peer that is now disconnected and whose buffers are null again.
+        return;
       }
 
       // set up the peer with all data from the peerInHandshake

--- a/src/main/java/im/redpanda/core/Peer.java
+++ b/src/main/java/im/redpanda/core/Peer.java
@@ -279,12 +279,17 @@ public class Peer implements Comparable<Peer> {
       try {
         // Re-read (and check) writeBuffer under the lock: disconnect() nulls it under this same
         // lock, so checking it before acquiring the lock leaves a window in which the field turns
-        // null between the check and the tryLock() succeeding, NPE-ing on writeBuffer.capacity()
+        // null between the check and the tryLock() succeeding, NPE-ing on writeBuffer.remaining()
         // below (REDPANDAJ-TD008).
         ByteBuffer buffer = writeBuffer;
         if (buffer == null) {
           setConnected(false);
-        } else if (buffer.capacity() > 0) {
+        } else if (buffer.remaining() > 0) {
+          // remaining(), not capacity(): capacity is the fixed 300 KiB allocation size and is
+          // never 0, so the old capacity() check never actually skipped a full buffer — a put()
+          // on a genuinely full buffer would have thrown BufferOverflowException instead (Copilot
+          // review finding on this PR). remaining() is the free-space check the "buffer has
+          // content" log message below always intended.
           buffer.put(Command.PING);
           Log.put("pinged...", 100);
         } else {
@@ -515,7 +520,11 @@ public class Peer implements Comparable<Peer> {
       try {
         writeBuffer = ByteBuffer.allocate(300 * 1024);
         writeBufferCrypted = ByteBuffer.allocate(300 * 1024);
-      } catch (Exception e) {
+      } catch (Exception | OutOfMemoryError e) {
+        // ByteBuffer.allocate throws OutOfMemoryError (an Error, not an Exception) on genuine
+        // allocation failure -- the case this handler's log message and disconnect() call are
+        // actually for. A plain `catch (Exception e)` never caught it, making this defensive
+        // path dead code for its real purpose (Copilot review finding on this PR).
         Log.putStd("Could not reserve enough memory for this connection. Disconnect peer...");
         disconnect("Could not reserve enough memory for this connection.");
         // Early return (REDPANDAJ-TD010): without it the code below kept running on the peer

--- a/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
+++ b/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
@@ -296,12 +296,15 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
     }
 
     float scoreToAdd = 0;
-    // REDPANDAJ-2EG: use the insertNode captured in init() — flaschenPostInsertPeer.getNode()
-    // may have been nulled by a concurrent Peer.disconnect() (clearNode()) by now.
+    // TD007: insertNode is always nodes.get(1) — calculatePathOrAbort() picks
+    // flaschenPostInsertPeer (and captures insertNode from it) as the peer for that exact graph
+    // node, and NodeStore.maintainNodes() adds graph edges using peer.getNode() as the vertex, so
+    // both refer to the same Node instance. It is therefore already covered by the nodes loop
+    // below; a historical explicit increment here (predating the path-based selection, back when
+    // flaschenPostInsertPeer could be a node outside `nodes`) double-scored it on every run. The
+    // insertNode != null check above still gates the loop: it is how done() detects that init()
+    // never got as far as building a real path (see REDPANDAJ-2EG below).
     if (success) {
-      insertNode.increaseGmTestsSuccessful();
-      insertNode.seen();
-
       for (Node node : nodes) {
         node.increaseGmTestsSuccessful();
         node.seen();
@@ -309,7 +312,6 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
 
       scoreToAdd = DELTA_SUCCESS;
     } else {
-      insertNode.increaseGmTestsFailed();
       for (Node node : nodes) {
         node.increaseGmTestsFailed();
       }

--- a/src/test/java/im/redpanda/core/PeerTest.java
+++ b/src/test/java/im/redpanda/core/PeerTest.java
@@ -237,12 +237,8 @@ public class PeerTest {
       serverSocketChannel.bind(new InetSocketAddress("127.0.0.1", 0));
       int port = serverSocketChannel.socket().getLocalPort();
 
-      try (SocketChannel client = SocketChannel.open(new InetSocketAddress("127.0.0.1", port))) {
-        SocketChannel accepted;
-        do {
-          accepted = serverSocketChannel.accept();
-        } while (accepted == null);
-        accepted.configureBlocking(false);
+      try (SocketChannel client = SocketChannel.open(new InetSocketAddress("127.0.0.1", port));
+          SocketChannel accepted = acceptBlocking(serverSocketChannel)) {
         SelectionKey key = accepted.register(selector, SelectionKey.OP_READ);
 
         Peer peer = new Peer("127.0.0.1", port, new NodeId());
@@ -271,12 +267,8 @@ public class PeerTest {
       serverSocketChannel.bind(new InetSocketAddress("127.0.0.1", 0));
       int port = serverSocketChannel.socket().getLocalPort();
 
-      try (SocketChannel client = SocketChannel.open(new InetSocketAddress("127.0.0.1", port))) {
-        SocketChannel accepted;
-        do {
-          accepted = serverSocketChannel.accept();
-        } while (accepted == null);
-        accepted.configureBlocking(false);
+      try (SocketChannel client = SocketChannel.open(new InetSocketAddress("127.0.0.1", port));
+          SocketChannel accepted = acceptBlocking(serverSocketChannel)) {
         SelectionKey key = accepted.register(selector, SelectionKey.OP_READ);
 
         Peer peer = new Peer("127.0.0.1", port, new NodeId());
@@ -314,12 +306,8 @@ public class PeerTest {
       serverSocketChannel.bind(new InetSocketAddress("127.0.0.1", 0));
       int port = serverSocketChannel.socket().getLocalPort();
 
-      try (SocketChannel client = SocketChannel.open(new InetSocketAddress("127.0.0.1", port))) {
-        SocketChannel accepted;
-        do {
-          accepted = serverSocketChannel.accept();
-        } while (accepted == null);
-        accepted.configureBlocking(false);
+      try (SocketChannel client = SocketChannel.open(new InetSocketAddress("127.0.0.1", port));
+          SocketChannel accepted = acceptBlocking(serverSocketChannel)) {
         SelectionKey key = accepted.register(selector, SelectionKey.OP_READ);
 
         PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", accepted);
@@ -343,6 +331,21 @@ public class PeerTest {
         assertEquals(2, peer.writeBuffer.position());
       }
     }
+  }
+
+  /**
+   * Accepts the next pending connection on {@code serverSocketChannel}, non-blocking-polling until
+   * it arrives, and configures it non-blocking. Returned channel is the caller's to close (use in
+   * try-with-resources) so loopback tests don't leak file descriptors across the suite.
+   */
+  private static SocketChannel acceptBlocking(ServerSocketChannel serverSocketChannel)
+      throws java.io.IOException {
+    SocketChannel accepted;
+    do {
+      accepted = serverSocketChannel.accept();
+    } while (accepted == null);
+    accepted.configureBlocking(false);
+    return accepted;
   }
 
   private void setUpTestCipherStreams(Peer peer) {

--- a/src/test/java/im/redpanda/core/PeerTest.java
+++ b/src/test/java/im/redpanda/core/PeerTest.java
@@ -1,13 +1,20 @@
 package im.redpanda.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import im.redpanda.core.exceptions.PeerProtocolException;
 import im.redpanda.crypt.Utils;
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
 import java.util.Random;
 import org.junit.Test;
 
@@ -211,6 +218,131 @@ public class PeerTest {
     assertThat(staleReferenceBeforeDecrypt.position()).isEqualTo(0);
     assertThat(staleReferenceBeforeDecrypt.limit())
         .isEqualTo(staleReferenceBeforeDecrypt.capacity());
+  }
+
+  /**
+   * Regression for TD008: {@code disconnect()} nulls {@code writeBuffer} under {@code
+   * writeBufferLock}, while {@code sendPing()} used to check/use it before acquiring that lock — a
+   * full disconnect() (lock, null the field, unlock) could complete in the window between the
+   * pre-lock check and {@code tryLock()} succeeding, so the field was null again by the time the
+   * locked section dereferenced it. This test pins the end state of that race directly: {@code
+   * writeBuffer} is already null when {@code sendPing()} is entered (selectionKey still valid,
+   * exactly as a caller mid-{@code tryLock()} would observe it). Must not throw NPE.
+   */
+  @Test
+  public void sendPingWithNullWriteBufferDoesNotThrowNpe() throws Exception {
+    try (ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+        Selector selector = Selector.open()) {
+      serverSocketChannel.configureBlocking(false);
+      serverSocketChannel.bind(new InetSocketAddress("127.0.0.1", 0));
+      int port = serverSocketChannel.socket().getLocalPort();
+
+      try (SocketChannel client = SocketChannel.open(new InetSocketAddress("127.0.0.1", port))) {
+        SocketChannel accepted;
+        do {
+          accepted = serverSocketChannel.accept();
+        } while (accepted == null);
+        accepted.configureBlocking(false);
+        SelectionKey key = accepted.register(selector, SelectionKey.OP_READ);
+
+        Peer peer = new Peer("127.0.0.1", port, new NodeId());
+        peer.setConnected(true);
+        peer.setSocketChannel(accepted);
+        peer.setSelectionKey(key);
+        peer.writeBuffer = null;
+
+        peer.sendPing();
+
+        assertFalse(
+            "sendPing must mark the peer disconnected on a null writeBuffer", peer.isConnected());
+      }
+    }
+  }
+
+  /**
+   * Companion to {@link #sendPingWithNullWriteBufferDoesNotThrowNpe()}: the normal, non-null
+   * writeBuffer path must still queue a PING byte (guards against an overzealous TD008 fix).
+   */
+  @Test
+  public void sendPingWithNonNullWriteBufferPutsPingByte() throws Exception {
+    try (ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+        Selector selector = Selector.open()) {
+      serverSocketChannel.configureBlocking(false);
+      serverSocketChannel.bind(new InetSocketAddress("127.0.0.1", 0));
+      int port = serverSocketChannel.socket().getLocalPort();
+
+      try (SocketChannel client = SocketChannel.open(new InetSocketAddress("127.0.0.1", port))) {
+        SocketChannel accepted;
+        do {
+          accepted = serverSocketChannel.accept();
+        } while (accepted == null);
+        accepted.configureBlocking(false);
+        SelectionKey key = accepted.register(selector, SelectionKey.OP_READ);
+
+        Peer peer = new Peer("127.0.0.1", port, new NodeId());
+        peer.setConnected(true);
+        peer.setSocketChannel(accepted);
+        peer.setSelectionKey(key);
+        peer.writeBuffer = ByteBuffer.allocate(1024);
+
+        peer.sendPing();
+
+        assertEquals(1, peer.writeBuffer.position());
+        assertEquals(Command.PING, peer.writeBuffer.get(0));
+      }
+    }
+  }
+
+  /**
+   * Regression for TD010: on the (extremely rare) buffer-allocation failure branch of {@code
+   * setupConnectionForPeer}, the method used to keep running after calling {@code disconnect()},
+   * re-populating socketChannel/selectionKey/cipherStreams on the peer it had just torn down (and,
+   * for a non-light-client peer, going on to NPE on the still-null {@code writeBuffer} a few lines
+   * later). A genuine allocation failure is not deterministically/safely injectable without either
+   * exhausting the shared test-fork heap (risking every other test in the fork) or adding a
+   * production-only test seam, so this suite does not attempt to reproduce the OOM branch itself;
+   * see the inline comment at the {@code return} in {@code setupConnectionForPeer} for the
+   * reasoning. This test instead pins the unaffected happy path (allocation succeeds) so a future
+   * refactor of the added early return cannot silently break normal connection setup.
+   */
+  @Test
+  public void setupConnectionForPeer_happyPath_populatesConnectionStateAndBuffers()
+      throws Exception {
+    try (ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+        Selector selector = Selector.open()) {
+      serverSocketChannel.configureBlocking(false);
+      serverSocketChannel.bind(new InetSocketAddress("127.0.0.1", 0));
+      int port = serverSocketChannel.socket().getLocalPort();
+
+      try (SocketChannel client = SocketChannel.open(new InetSocketAddress("127.0.0.1", port))) {
+        SocketChannel accepted;
+        do {
+          accepted = serverSocketChannel.accept();
+        } while (accepted == null);
+        accepted.configureBlocking(false);
+        SelectionKey key = accepted.register(selector, SelectionKey.OP_READ);
+
+        PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", accepted);
+        peerInHandshake.setKey(key);
+        peerInHandshake.setLightClient(false);
+        peerInHandshake.setProtocolVersion(23);
+
+        Peer peer = new Peer("127.0.0.1", port, new NodeId());
+
+        peer.setupConnectionForPeer(peerInHandshake);
+
+        assertTrue(peer.isConnected());
+        assertTrue(peer.isAuthed());
+        assertNotNull(peer.writeBuffer);
+        assertEquals(300 * 1024, peer.writeBuffer.capacity());
+        assertNotNull(peer.writeBufferCrypted);
+        assertEquals(300 * 1024, peer.writeBufferCrypted.capacity());
+        assertSame(accepted, peer.getSocketChannel());
+        assertSame(key, peer.getSelectionKey());
+        // non-lightClient path queues UPDATE_REQUEST_TIMESTAMP + ANDROID_UPDATE_REQUEST_TIMESTAMP
+        assertEquals(2, peer.writeBuffer.position());
+      }
+    }
   }
 
   private void setUpTestCipherStreams(Peer peer) {

--- a/src/test/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJobTest.java
+++ b/src/test/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJobTest.java
@@ -160,9 +160,43 @@ public class PeerPerformanceTestGarlicMessageJobTest {
     job.done();
     job.done();
 
-    // One scoring pass counts the insert node twice (explicitly plus via the nodes loop, as it
-    // is part of the path) — a second done() must not add to that.
-    assertEquals(2, insertNode.getGmTestsFailed());
+    // One scoring pass counts the insert node exactly once (it is nodes.get(1), scored via the
+    // nodes loop; TD007 removed the historical duplicate explicit increment) — a second done()
+    // must not add to that.
+    assertEquals(1, insertNode.getGmTestsFailed());
+  }
+
+  /**
+   * Regression for TD007: {@code done()} used to score the insert peer's node twice on the success
+   * path too — once via an explicit {@code insertNode.increaseGmTestsSuccessful()} call and again
+   * via the {@code nodes} loop, because {@code insertNode} is always {@code nodes.get(1)} (the
+   * direct next hop {@code calculatePathOrAbort()} picked {@code flaschenPostInsertPeer} from). A
+   * non-insert node on the same path (e.g. {@code nodes.get(2)}) must be scored exactly once, and
+   * so must the insert node itself.
+   */
+  @Test
+  public void done_success_scoresInsertNodeOnlyOnceNotTwice() throws Exception {
+    Node ownNode = new Node(serverContext, serverContext.getNodeId());
+    Node insertNode = new Node(serverContext, NodeId.generateWithSimpleKey());
+    Node hopNode = new Node(serverContext, NodeId.generateWithSimpleKey());
+
+    PeerPerformanceTestGarlicMessageJob job =
+        new PeerPerformanceTestGarlicMessageJob(serverContext);
+    job.nodes = new ArrayList<>();
+    job.nodes.add(ownNode);
+    job.nodes.add(insertNode);
+    job.nodes.add(hopNode);
+    job.nodes.add(ownNode);
+
+    Peer insertPeer = new Peer("127.0.0.1", 1234, insertNode.getNodeId());
+    insertPeer.setNode(insertNode);
+    setPrivateField(job, "flaschenPostInsertPeer", insertPeer);
+    setPrivateField(job, "insertNode", insertNode);
+
+    job.success();
+
+    assertEquals(1, insertNode.getGmTestsSuccessful());
+    assertEquals(1, hopNode.getGmTestsSuccessful());
   }
 
   /**
@@ -203,9 +237,9 @@ public class PeerPerformanceTestGarlicMessageJobTest {
 
     job.work();
 
-    // done() ran and scored the timed-out test as failed in exactly one scoring pass (the insert
-    // node is counted twice per pass: explicitly plus via the nodes loop).
-    assertEquals(2, insertNode.getGmTestsFailed());
+    // done() ran and scored the timed-out test as failed in exactly one scoring pass, counting
+    // the insert node once (nodes.get(1), via the nodes loop; see TD007).
+    assertEquals(1, insertNode.getGmTestsFailed());
   }
 
   private static void setPrivateField(Object target, String name, Object value) throws Exception {


### PR DESCRIPTION
## Summary

Three small, independent pre-existing findings from the T49/T50 reviews (redpandaj#270, redpandaj#271), bundled into one mini-PR per task T52.

### TD008 — `Peer.sendPing()` NPE race window
`sendPing()` checked/used `writeBuffer` *before* acquiring `writeBufferLock`, while `disconnect()` nulls that same field *under* the lock. A full `disconnect()` (lock → null → unlock) could complete in the window between the pre-lock check and `tryLock()` succeeding, so `writeBuffer.capacity()` inside the "locked" branch could still NPE on a field that turned null in the meantime.

Fix: move the check next to the use, both under the lock — consistent with the REDPANDAJ-2EF/2EE pattern already used elsewhere in `Peer`.

`src/main/java/im/redpanda/core/Peer.java:260-296`

### TD010 — `Peer.setupConnectionForPeer()` kept running after the OOM `disconnect()`
On a buffer-allocation failure the catch block called `disconnect()` but the method then kept executing, re-populating `socketChannel`/`selectionKey`/cipher streams on the peer `disconnect()` just tore down — and, for a non-light-client peer, going on to NPE a few lines later on the `writeBuffer` that allocation never actually produced.

Fix: early `return` right after the `disconnect()` call.

`src/main/java/im/redpanda/core/Peer.java:514-527`

**Regression test note (TD010):** no test forces the actual allocation failure. `ByteBuffer.allocate(300*1024)` essentially never throws under normal heap, and forcing a real `OutOfMemoryError` inside a shared Surefire fork would risk destabilizing every other test in that fork; there's also no test seam to inject the failure without a production-only change. Logged as TD016 in the tech-debt backlog. Added a happy-path test instead (`setupConnectionForPeer_happyPath_populatesConnectionStateAndBuffers`) so the new early return can't silently break normal connection setup.

### TD007 — `PeerPerformanceTestGarlicMessageJob.done()` double-scored the insert peer's node
`done()` incremented the insert peer's GM-test counters twice per scoring pass: once via an explicit `insertNode.increaseGmTestsSuccessful()/Failed()` call, and again via the `nodes` loop — because `insertNode` is always `nodes.get(1)`. `calculatePathOrAbort()` derives `flaschenPostInsertPeer` from that exact graph node (`nodes.get(1).getNodeId()`), and `NodeStore.maintainNodes()` builds graph edges directly from `peer.getNode()`, so `insertNode` and `nodes.get(1)` are literally the same `Node` instance — not just equal.

**Decision: bug, not intentional double-weighting.** Git archaeology (`b440ab0`, "Add big improvement for gm probes", 2021-12-24) shows the explicit increment predates the path-based peer selection: back then `flaschenPostInsertPeer` was chosen independently via `getClosestGoodPeer()` and was frequently *not* part of `nodes` at all, so the explicit increment was the *only* way the insert peer got scored. When the selection logic was later switched to picking `nodes.get(1)` directly, the now-redundant explicit increment was never removed — bitrot from the refactor, no commit message or comment anywhere frames it as deliberate extra weighting for the direct peer.

Fix: removed the redundant explicit increment; the `nodes` loop is now the single source of truth. (`insertNode.seen()` was likewise redundant with the loop's `node.seen()` call and removed for the same reason — harmless either way since `seen()` just stamps a timestamp, but no longer duplicated.)

`src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java:296-318`

Existing REDPANDAJ-2EG tests that asserted the *old* double count (`done_calledTwice_scoresInsertNodeOnlyOnce`, `work_timeoutWithDisconnectedInsertPeer_terminatesJob`) updated to assert `1` instead of `2`. New test added for the success path: `done_success_scoresInsertNodeOnlyOnceNotTwice`.

## Tech-debt follow-ups logged (not fixed here, out of scope)
- **TD016**: missing regression test for the TD010 OOM path (no test seam without a production change).
- **TD017**: the job's own node also appears twice in `nodes` (start *and* end of the path) — same double-count class as TD007, but for `serverContext.getNode()` itself. Effect on anything downstream is unverified (self is presumably never selected as a target peer, so likely inert) — logged for later triage rather than fixed here to keep this PR minimal.

## Test plan
- [x] `mvn test -Dtest=PeerTest,PeerPerformanceTestGarlicMessageJobTest,ReadConnectionOwnershipHandoffTest,ConnectionHandlerCoalescedHandshakeTest` — green (27 tests)
- [x] Full `mvn test` — green (394 tests, 0 failures/errors, 1 skipped; includes the known-flaky `InboundCommandProcessorUpdateHardeningTest`, which passed this run)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)