### PR TITLE
TD009: tighten ConnectionReaderThread myReaderBuffer endcheck (T53)

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionReaderThread.java
+++ b/src/main/java/im/redpanda/core/ConnectionReaderThread.java
@@ -53,7 +53,10 @@ public class ConnectionReaderThread implements Runnable {
    */
   public static final AtomicLong REJECTED_LEGACY_V22_ATTEMPTS = new AtomicLong();
 
-  private final ByteBuffer myReaderBuffer = ByteBuffer.allocate(1024 * 50);
+  // package-private (instead of private) so the T53/TD009 regression tests can prepare/observe
+  // this thread-local buffer's state directly, without having to engineer a live decrypt failure
+  // through a real socket for every scenario (mirrors the readConnection() precedent below).
+  final ByteBuffer myReaderBuffer = ByteBuffer.allocate(1024 * 50);
   private final ServerContext serverContext;
   private final InboundCommandProcessor inboundProcessor;
 
@@ -289,10 +292,9 @@ public class ConnectionReaderThread implements Runnable {
 
     SelectionKey key = peer.selectionKey;
 
-    // if (myReaderBuffer.position() != 0) {
-    // throw new RuntimeException("buffer has to be at position 0, otherwise we
-    // would parse data from a different peer.");
-    // }
+    // Entry invariant (myReaderBuffer must be position 0, ready to fill) is enforced at the
+    // *end* of every call via assertReaderBufferReadyForNextRead() below, so it always holds
+    // here too (TD009 / T53).
 
     // Capture the channel we read from: a concurrent re-handshake of an already known peer
     // (Peer.setupConnectionForPeer, IncomingHandler thread) replaces socketChannel, selectionKey
@@ -395,7 +397,24 @@ public class ConnectionReaderThread implements Runnable {
       // decryptInputData() takes the same lock (reentrant) and may grow the buffer: it returns
       // the old, too-small instance to the ByteBufferPool and stores a larger one in
       // peer.readBuffer, so the field must only be read AFTER decrypting (REDPANDAJ-2DT/2DV).
-      peer.decryptInputData(myReaderBuffer);
+      try {
+        peer.decryptInputData(myReaderBuffer);
+      } catch (PeerProtocolException e) {
+        // decryptInputData() only compact()s myReaderBuffer (position -> 0) on success. A thrown
+        // PeerProtocolException (bad GCM frame length/nonce/tag, see GcmFramedStreams#decrypt)
+        // still leaves it dirty: the framed cipher drains myReaderBuffer completely into its own
+        // internal frame-reassembly buffer (appendToInbound) *before* it can ever throw, so what
+        // is left behind is position == limit (remaining() == 0, but position != 0), not a clean
+        // "ready for the next read" state. myReaderBuffer is a thread-local field this
+        // ConnectionReaderThread reuses across every future Peer it services (see run()'s poll
+        // loop), so left uncleared it would starve every subsequent read on this thread
+        // (remaining() == 0 forever, channel.read() always returns 0) and, combined with the
+        // tightened invariant guard below, could disconnect a later, unrelated peer for THIS
+        // peer's corruption. Clear it here, at the actual source of the dirty state, instead of
+        // relying on the invariant guard further down to notice (TD009 / T53 review follow-up).
+        myReaderBuffer.clear();
+        throw e;
+      }
 
       claimedReadBuffer = peer.readBuffer;
       peer.readBuffer = null;
@@ -432,12 +451,49 @@ public class ConnectionReaderThread implements Runnable {
       }
     }
 
-    if (myReaderBuffer.position() != 0 && myReaderBuffer.limit() != myReaderBuffer.capacity()) {
-      throw new RuntimeException(
-          "myReaderBuffer was not ready for the next read: " + myReaderBuffer);
-    }
+    assertReaderBufferReadyForNextRead(peer);
 
     return read;
+  }
+
+  /**
+   * Invariant guard (TD009, T50 review finding, tightened in T53): {@code myReaderBuffer} must be
+   * fully drained (position 0) before this thread-local buffer is reused to read the next {@code
+   * Peer} this thread services (see the shared poll loop in {@link #run()}). Previously this only
+   * threw when {@code limit != capacity} too, tolerating a dirty buffer whenever a read happened to
+   * fill it to exactly capacity — any leftover ciphertext bytes there would be prefixed onto the
+   * next peer's bytes and decrypted under that peer's session keys: a cross-peer ciphertext-mixing
+   * window (theoretical — GCM authentication would almost certainly fail loudly on the mismatched
+   * key rather than silently yield valid-looking plaintext — but a real gap in the invariant
+   * nonetheless).
+   *
+   * <p>Analysis as of T53 (2026-07, after redpandaj#271/#272): every exception-free path through
+   * {@link Peer#decryptInputData} ends in {@code ByteBuffer.compact()}, which always resets
+   * position to 0 ({@link GcmFramedStreams#decrypt} drains {@code myReaderBuffer} into its own
+   * {@code inbound} reassembly buffer unconditionally, before it can ever throw — see {@code
+   * appendToInbound}). The one path that used to leave it dirty (a thrown {@link
+   * PeerProtocolException} from a bad frame/tag) is now cleared at the throw site in {@link
+   * #readConnection}. No live path is known to reach this branch any more; it is kept as a
+   * defensive invariant guard against future decrypt paths, not because one currently exists.
+   *
+   * <p>Unlike a bare throw, this clears the buffer and disconnects {@code peer} itself: {@code
+   * run()}'s generic {@code catch (Throwable e)} only logs to Sentry, it does not touch {@code
+   * myReaderBuffer} or the peer — relying on the caller to "handle" the exception would leave the
+   * dirty bytes in place for whichever peer this thread services next, exactly the leak this guard
+   * exists to prevent. Package-private so {@code ConnectionReaderThreadBufferIsolationTest} can
+   * drive it directly with a manually-prepared buffer, without depending on a live decrypt failure
+   * to reach it.
+   */
+  void assertReaderBufferReadyForNextRead(Peer peer) throws PeerProtocolException {
+    if (myReaderBuffer.position() == 0) {
+      return;
+    }
+    String staleState = myReaderBuffer.toString();
+    myReaderBuffer.clear();
+    peer.disconnect("myReaderBuffer left dirty after read (TD009 invariant guard)");
+    throw new PeerProtocolException(
+        "myReaderBuffer was not ready for the next read, cleared buffer and disconnected peer: "
+            + staleState);
   }
 
   public static void sendHandshake(ServerContext serverContext, PeerInHandshake peerInHandshake) {

--- a/src/main/java/im/redpanda/core/ConnectionReaderThread.java
+++ b/src/main/java/im/redpanda/core/ConnectionReaderThread.java
@@ -54,8 +54,11 @@ public class ConnectionReaderThread implements Runnable {
   public static final AtomicLong REJECTED_LEGACY_V22_ATTEMPTS = new AtomicLong();
 
   // package-private (instead of private) so the T53/TD009 regression tests can prepare/observe
-  // this thread-local buffer's state directly, without having to engineer a live decrypt failure
-  // through a real socket for every scenario (mirrors the readConnection() precedent below).
+  // this per-reader-thread scratch buffer's state directly, without having to engineer a live
+  // decrypt failure through a real socket for every scenario (mirrors the readConnection()
+  // precedent below). Confined to a single thread because each ConnectionReaderThread instance
+  // is started on and only ever run by its own dedicated virtual thread (see the constructor) —
+  // not a java.lang.ThreadLocal.
   final ByteBuffer myReaderBuffer = ByteBuffer.allocate(1024 * 50);
   private final ServerContext serverContext;
   private final InboundCommandProcessor inboundProcessor;
@@ -292,9 +295,11 @@ public class ConnectionReaderThread implements Runnable {
 
     SelectionKey key = peer.selectionKey;
 
-    // Entry invariant (myReaderBuffer must be position 0, ready to fill) is enforced at the
-    // *end* of every call via assertReaderBufferReadyForNextRead() below, so it always holds
-    // here too (TD009 / T53).
+    // Entry invariant (myReaderBuffer must be position 0, ready to fill): every return path below
+    // leaves it at position 0 — either untouched from before this call (no bytes were appended to
+    // it on this path) or explicitly cleared (the stale-connection drop), or checked via
+    // assertReaderBufferReadyForNextRead() at the end of the normal read/decrypt/parse path — so
+    // it always holds here too (TD009 / T53). Not enforced by that one method call alone.
 
     // Capture the channel we read from: a concurrent re-handshake of an already known peer
     // (Peer.setupConnectionForPeer, IncomingHandler thread) replaces socketChannel, selectionKey
@@ -405,8 +410,8 @@ public class ConnectionReaderThread implements Runnable {
         // still leaves it dirty: the framed cipher drains myReaderBuffer completely into its own
         // internal frame-reassembly buffer (appendToInbound) *before* it can ever throw, so what
         // is left behind is position == limit (remaining() == 0, but position != 0), not a clean
-        // "ready for the next read" state. myReaderBuffer is a thread-local field this
-        // ConnectionReaderThread reuses across every future Peer it services (see run()'s poll
+        // "ready for the next read" state. myReaderBuffer is a per-reader-thread scratch field
+        // this ConnectionReaderThread reuses across every future Peer it services (see run()'s poll
         // loop), so left uncleared it would starve every subsequent read on this thread
         // (remaining() == 0 forever, channel.read() always returns 0) and, combined with the
         // tightened invariant guard below, could disconnect a later, unrelated peer for THIS
@@ -458,14 +463,14 @@ public class ConnectionReaderThread implements Runnable {
 
   /**
    * Invariant guard (TD009, T50 review finding, tightened in T53): {@code myReaderBuffer} must be
-   * fully drained (position 0) before this thread-local buffer is reused to read the next {@code
-   * Peer} this thread services (see the shared poll loop in {@link #run()}). Previously this only
-   * threw when {@code limit != capacity} too, tolerating a dirty buffer whenever a read happened to
-   * fill it to exactly capacity — any leftover ciphertext bytes there would be prefixed onto the
-   * next peer's bytes and decrypted under that peer's session keys: a cross-peer ciphertext-mixing
-   * window (theoretical — GCM authentication would almost certainly fail loudly on the mismatched
-   * key rather than silently yield valid-looking plaintext — but a real gap in the invariant
-   * nonetheless).
+   * fully drained (position 0) before this per-reader-thread scratch buffer is reused to read the
+   * next {@code Peer} this thread services (see the shared poll loop in {@link #run()}). Previously
+   * this only threw when {@code limit != capacity} too, tolerating a dirty buffer whenever a read
+   * happened to fill it to exactly capacity — any leftover ciphertext bytes there would be prefixed
+   * onto the next peer's bytes and decrypted under that peer's session keys: a cross-peer
+   * ciphertext-mixing window (theoretical — GCM authentication would almost certainly fail loudly
+   * on the mismatched key rather than silently yield valid-looking plaintext — but a real gap in
+   * the invariant nonetheless).
    *
    * <p>Analysis as of T53 (2026-07, after redpandaj#271/#272): every exception-free path through
    * {@link Peer#decryptInputData} ends in {@code ByteBuffer.compact()}, which always resets

--- a/src/test/java/im/redpanda/core/ConnectionReaderThreadBufferIsolationTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionReaderThreadBufferIsolationTest.java
@@ -16,8 +16,8 @@ import org.junit.Test;
 
 /**
  * Regression tests for TD009 (T50 review finding, fixed in T53): {@code myReaderBuffer} in {@link
- * ConnectionReaderThread} is a thread-local scratch buffer reused across every {@link Peer} this
- * reader thread services over its lifetime (see the shared poll loop in {@link
+ * ConnectionReaderThread} is a per-reader-thread scratch buffer reused across every {@link Peer}
+ * this reader thread services over its lifetime (see the shared poll loop in {@link
  * ConnectionReaderThread#run()}). If it is ever left with leftover ciphertext bytes after a read
  * (position != 0), those bytes would be prefixed onto whatever peer this thread reads next and
  * decrypted under THAT peer's session keys — a cross-peer ciphertext-mixing window.

--- a/src/test/java/im/redpanda/core/ConnectionReaderThreadBufferIsolationTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionReaderThreadBufferIsolationTest.java
@@ -1,0 +1,206 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import im.redpanda.core.exceptions.PeerProtocolException;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Regression tests for TD009 (T50 review finding, fixed in T53): {@code myReaderBuffer} in {@link
+ * ConnectionReaderThread} is a thread-local scratch buffer reused across every {@link Peer} this
+ * reader thread services over its lifetime (see the shared poll loop in {@link
+ * ConnectionReaderThread#run()}). If it is ever left with leftover ciphertext bytes after a read
+ * (position != 0), those bytes would be prefixed onto whatever peer this thread reads next and
+ * decrypted under THAT peer's session keys — a cross-peer ciphertext-mixing window.
+ *
+ * <p>Two scenarios are covered:
+ *
+ * <ul>
+ *   <li>{@link #corruptedFrameDoesNotLeakIntoNextPeersRead()} drives the one live path that used to
+ *       leave {@code myReaderBuffer} dirty (a thrown {@link PeerProtocolException} from a bad GCM
+ *       frame) through the real socket/decrypt code, and proves the SAME reader thread reading a
+ *       second, unrelated peer afterwards is unaffected.
+ *   <li>{@link #invariantGuardClearsBufferAndDisconnectsPeerOnDirectViolation()} drives {@link
+ *       ConnectionReaderThread#assertReaderBufferReadyForNextRead} directly with a manually
+ *       prepared dirty buffer (package-private field), since no live path is known to reach that
+ *       guard any more after the fix above — see its javadoc for the analysis. This is the "prepare
+ *       a buffer with leftover bytes" scenario asked for in T53.
+ * </ul>
+ */
+public class ConnectionReaderThreadBufferIsolationTest {
+
+  static {
+    ByteBufferPool.init();
+  }
+
+  private final List<ServerSocketChannel> serverSockets = new ArrayList<>();
+  private final List<SocketChannel> openChannels = new ArrayList<>();
+
+  @After
+  public void tearDownChannels() throws IOException {
+    for (SocketChannel channel : openChannels) {
+      if (channel.isOpen()) {
+        channel.close();
+      }
+    }
+    for (ServerSocketChannel serverSocket : serverSockets) {
+      if (serverSocket.isOpen()) {
+        serverSocket.close();
+      }
+    }
+  }
+
+  /** One loopback connection with its own, independent GCM session key. */
+  private static final class PeerFixture {
+    final Peer peer;
+    final SocketChannel remoteSide;
+
+    PeerFixture(Peer peer, SocketChannel remoteSide) {
+      this.peer = peer;
+      this.remoteSide = remoteSide;
+    }
+  }
+
+  private PeerFixture newConnectedPeerFixture() throws IOException {
+    ServerSocketChannel serverSocket = ServerSocketChannel.open();
+    serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
+    serverSockets.add(serverSocket);
+    SocketChannel remoteSide = SocketChannel.open(serverSocket.getLocalAddress());
+    SocketChannel peerSide = serverSocket.accept();
+    openChannels.add(remoteSide);
+    openChannels.add(peerSide);
+
+    Peer peer = new Peer("127.0.0.1", 0, new NodeId());
+    peer.setSocketChannel(peerSide);
+    peer.setConnected(true);
+    peer.writeBuffer = ByteBuffer.allocate(1024 * 100);
+    peer.writeBufferCrypted = ByteBuffer.allocate(1024 * 100);
+    // Each fixture gets its OWN random key, unlike the shared-key loopback trick elsewhere: the
+    // whole point here is that two DIFFERENT peers must never decrypt under each other's keys.
+    byte[] key = new byte[32];
+    new java.security.SecureRandom().nextBytes(key);
+    peer.setPeerChiperStreams(new GcmFramedStreams(key, key));
+
+    return new PeerFixture(peer, remoteSide);
+  }
+
+  private ConnectionReaderThread newReaderThread() {
+    return new ConnectionReaderThread(new ServerContext(), ConnectionReaderThread.STD_TIMEOUT);
+  }
+
+  private void sendEncrypted(PeerFixture fixture, byte[] plaintext) throws IOException {
+    ByteBuffer in = ByteBuffer.allocate(plaintext.length);
+    in.put(plaintext);
+    in.flip();
+    ByteBuffer out = ByteBuffer.allocate(plaintext.length + 1024);
+    fixture.peer.getPeerChiperStreams().encrypt(in, out);
+    out.flip();
+    while (out.hasRemaining()) {
+      fixture.remoteSide.write(out);
+    }
+  }
+
+  /** Same frame as {@link #sendEncrypted}, but with the trailing GCM tag byte flipped. */
+  private void sendCorruptedFrame(PeerFixture fixture, byte[] plaintext) throws IOException {
+    ByteBuffer in = ByteBuffer.allocate(plaintext.length);
+    in.put(plaintext);
+    in.flip();
+    ByteBuffer out = ByteBuffer.allocate(plaintext.length + 1024);
+    fixture.peer.getPeerChiperStreams().encrypt(in, out);
+    out.flip();
+    byte[] frame = new byte[out.remaining()];
+    out.get(frame);
+    frame[frame.length - 1] ^= (byte) 0xFF; // corrupt the last GCM tag byte -> auth failure
+    ByteBuffer corrupted = ByteBuffer.wrap(frame);
+    while (corrupted.hasRemaining()) {
+      fixture.remoteSide.write(corrupted);
+    }
+  }
+
+  /**
+   * The live path (before this fix): a bad GCM frame makes {@code decryptInputData} throw {@link
+   * PeerProtocolException} after already draining {@code myReaderBuffer} into the framed cipher's
+   * internal reassembly buffer, leaving it at position == limit != 0 instead of a clean state. The
+   * SAME {@link ConnectionReaderThread} instance is then handed a second, unrelated peer with its
+   * own independent key — it must read that peer's PONG cleanly, with no trace of the corrupted
+   * first peer's bytes.
+   */
+  @Test
+  public void corruptedFrameDoesNotLeakIntoNextPeersRead() throws Exception {
+    ConnectionReaderThread readerThread = newReaderThread();
+
+    PeerFixture peer1 = newConnectedPeerFixture();
+    sendCorruptedFrame(peer1, new byte[] {Command.PONG});
+
+    assertThatThrownBy(() -> readerThread.readConnection(peer1.peer))
+        .isInstanceOf(PeerProtocolException.class);
+
+    assertThat(readerThread.myReaderBuffer.position())
+        .as("myReaderBuffer must be cleared right at the decrypt-failure throw site")
+        .isZero();
+    assertThat(readerThread.myReaderBuffer.limit())
+        .isEqualTo(readerThread.myReaderBuffer.capacity());
+
+    PeerFixture peer2 = newConnectedPeerFixture();
+    sendEncrypted(peer2, new byte[] {Command.PONG});
+
+    int read = readerThread.readConnection(peer2.peer);
+
+    assertThat(read).isGreaterThan(0);
+    assertThat(peer2.peer.lastCommand)
+        .as("peer2 must parse its own PONG cleanly, unaffected by peer1's corrupted bytes")
+        .isEqualTo(Command.PONG);
+  }
+
+  /**
+   * Direct simulation of an endcheck violation ("buffer prepared with leftover bytes"): no live
+   * path reaches {@link ConnectionReaderThread#assertReaderBufferReadyForNextRead} any more (see
+   * its javadoc), so this drives the guard directly via the package-private {@code myReaderBuffer}
+   * field, with position != 0 and limit == capacity — precisely the corner case the old, weaker
+   * check (`pos != 0 && limit != capacity`) used to let through silently.
+   */
+  @Test
+  public void invariantGuardClearsBufferAndDisconnectsPeerOnDirectViolation() throws Exception {
+    ConnectionReaderThread readerThread = newReaderThread();
+    PeerFixture peer1 = newConnectedPeerFixture();
+
+    // Simulate leftover ciphertext from a hypothetical prior peer's read.
+    readerThread.myReaderBuffer.put(new byte[] {1, 2, 3, 4, 5});
+    assertThat(readerThread.myReaderBuffer.position()).isEqualTo(5);
+    assertThat(readerThread.myReaderBuffer.limit())
+        .as("the corner case the old check tolerated: limit == capacity despite pos != 0")
+        .isEqualTo(readerThread.myReaderBuffer.capacity());
+
+    assertThatThrownBy(() -> readerThread.assertReaderBufferReadyForNextRead(peer1.peer))
+        .as("(a) the error path must fire")
+        .isInstanceOf(PeerProtocolException.class)
+        .hasMessageContaining("cleared buffer and disconnected peer");
+
+    assertThat(peer1.peer.isConnected())
+        .as("the peer whose bytes were stuck in the buffer must be disconnected")
+        .isFalse();
+    assertThat(readerThread.myReaderBuffer.position()).isZero();
+    assertThat(readerThread.myReaderBuffer.limit())
+        .isEqualTo(readerThread.myReaderBuffer.capacity());
+
+    // (b) the next peer serviced by this same reader thread must never see the {1,2,3,4,5} bytes.
+    PeerFixture peer2 = newConnectedPeerFixture();
+    sendEncrypted(peer2, new byte[] {Command.PONG});
+
+    int read = readerThread.readConnection(peer2.peer);
+
+    assertThat(read).isGreaterThan(0);
+    assertThat(peer2.peer.lastCommand)
+        .as("peer2 must parse its own PONG cleanly, with no trace of the prepared leftover bytes")
+        .isEqualTo(Command.PONG);
+  }
+}


### PR DESCRIPTION
## T53 / TD009 — ConnectionReaderThread myReaderBuffer endcheck

TD009 (T50 review finding, redpandaj#271): the endcheck on the thread-local
`myReaderBuffer` after each `readConnection()` tolerated `pos != 0` as long
as `limit == capacity`. `myReaderBuffer` is reused across every `Peer` a
`ConnectionReaderThread` services over its lifetime (poll loop in `run()`),
so any leftover ciphertext bytes left in it would be prefixed onto the next
peer's bytes and decrypted under *that* peer's session keys — a theoretical
cross-peer ciphertext-mixing window.

### Fehlerpfad: clear + disconnect (nicht nur clear)

Chosen over a bare clear-and-continue: leftover bytes mean the ciphertext
stream state for the affected peer's connection is already corrupted (some
frame bytes consumed into the framed-cipher's internal reassembly buffer,
some possibly not) — there is no safe way to "resync" and keep reading that
connection. Clearing `myReaderBuffer` makes the buffer safe for the *next*
peer; disconnecting the *current* peer is what actually terminates the
corrupted stream instead of silently limping on with an inconsistent GCM
frame-nonce counter. Both steps happen before the guard throws, so the
buffer is never left dirty for another peer, and a bare `RuntimeException`
that just gets logged by `run()`'s generic `catch (Throwable e)` is no longer
load-bearing for correctness.

### Analyse: existiert nach #271/#272 noch ein Pfad, der pos != 0 hinterlässt?

Two changes were needed, not just the endcheck:

1. **Success path (existing behavior, unchanged):** `Peer.decryptInputData()`
   always ends in `byteBufferToDecrypt.compact()`, which resets
   `myReaderBuffer` to `position == 0`. `GcmFramedStreams#decrypt` always
   fully drains its `input` argument into an internal `inbound`
   reassembly buffer via `appendToInbound()` (which grows `inbound` as
   needed before ever putting), so `input.hasRemaining()` is always false
   after that call — `compact()` therefore always yields `position == 0`
   on any *successful* return.

2. **The one path that was actually still dirty (fixed in this PR):** when
   `decrypt()` itself throws `PeerProtocolException` (bad GCM frame
   length/nonce/tag), it does so *after* `appendToInbound()` has already
   drained `myReaderBuffer` — so the exception propagates straight out of
   `decryptInputData()` *without* reaching `compact()`, leaving
   `myReaderBuffer` at `position == limit != 0` (`remaining() == 0`, but not
   position 0). Because this exception propagates straight out of
   `readConnection()` too (declared `throws PeerProtocolException`, no catch
   in between), **the endcheck itself was never even reached on this path**
   — tightening the check alone would not have fixed anything real. This PR
   clears `myReaderBuffer` right at the throw site instead
   (`ConnectionReaderThread.java`, the `catch (PeerProtocolException e)`
   around `peer.decryptInputData(myReaderBuffer)`).

   Left unfixed, the practical impact of this path was not actually a
   cross-peer *mix* (since `remaining() == 0` means the next `channel.read()`
   into the buffer would just no-op with 0 bytes, not append past a live
   peer's fresh ciphertext) but a **reader-thread livelock**: every future
   peer serviced by that same `ConnectionReaderThread` instance would see
   `read == 0` forever. Still a bug worth fixing, and the fix directly
   addresses the "restbytes must never reach the next peer" requirement.

3. **Conclusion:** with both fixes in place, no live path is known to leave
   `myReaderBuffer` at `pos != 0` any more. The tightened endcheck
   (`assertReaderBufferReadyForNextRead`) is kept as a **defensive invariant
   guard** against future decrypt paths, not because a reachable one exists
   today — consistent with the ask in T53 to add it regardless.

### Changes

- `assertReaderBufferReadyForNextRead(Peer)`: tightened from
  `pos != 0 && limit != capacity` to `pos != 0`; on violation clears the
  buffer, disconnects `peer`, then throws `PeerProtocolException`.
  Package-private (extracted from the old inline check) so tests can drive
  it directly.
- `readConnection()`: wraps `peer.decryptInputData(myReaderBuffer)` to clear
  `myReaderBuffer` at the actual throw site before rethrowing.
- `myReaderBuffer` field made package-private (was `private`), same rationale
  as the existing `readConnection()` package-private precedent, so tests can
  prepare/observe its state directly.
- Removed the stale, long-commented-out original entry check at the top of
  `readConnection()` (superseded by the endcheck now enforcing the same
  invariant at the end of every call).

### Tests

New `ConnectionReaderThreadBufferIsolationTest`:

- `corruptedFrameDoesNotLeakIntoNextPeersRead`: drives the one live path that
  used to leave the buffer dirty (a corrupted GCM tag) through the real
  socket/decrypt code with one `ConnectionReaderThread` instance, then reads
  a second, unrelated peer (independent key) on the *same* instance and
  asserts it parses cleanly.
- `invariantGuardClearsBufferAndDisconnectsPeerOnDirectViolation`: the
  "prepare a buffer with leftover bytes" regression test asked for in T53 —
  directly writes `{1,2,3,4,5}` into `myReaderBuffer` (the exact
  `pos != 0 && limit == capacity` corner case the old check used to
  tolerate), calls the guard directly, and asserts (a) it throws and
  disconnects the peer, (b) the same reader thread's next peer read is
  completely unaffected.

### Test status

- Targeted (`ConnectionReaderThreadBufferIsolationTest`,
  `ConnectionReaderThreadTest`, `ReadConnectionOwnershipHandoffTest`,
  `PeerTest`): 22/22 green.
- Full local suite (`mvn test`, pipefail-checked exit code): 396 run, 0
  failures, 0 errors, 1 skipped, BUILD SUCCESS — including the known-flaky
  `InboundCommandProcessorUpdateHardeningTest` (15/15 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
