### PR TITLE
T55: TD012/TD013/TD014 test debt (redpandaj#271)

### DIFF
--- a/src/test/java/im/redpanda/core/ConnectionHandlerCopyRemainingReadBytesTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerCopyRemainingReadBytesTest.java
@@ -1,0 +1,114 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import org.junit.Test;
+
+/**
+ * Regression tests for TD014 (review-dag-Retest finding on redpandaj#271): {@link
+ * ConnectionHandler#copyRemainingReadBytesToPeerBuffer(ByteBuffer, Peer)} is the locked borrow/put
+ * path that hands handshake bytes which arrived coalesced AFTER the first PING frame
+ * (REDPANDAJ-2DS) over to the peer's regular read buffer. No test in the repo reaches it with
+ * {@code remaining() > 0}: {@code ConnectionHandlerCoalescedHandshakeTest} sends exactly the
+ * coalesced PING frame and nothing more, so {@code tempHandshakeReadBuffer.hasRemaining()} is
+ * always {@code false} there and the method takes its early return on the very first line. A
+ * regression in the locked path itself (lock dropped, wrong branch taken, wrong append offset)
+ * would go unnoticed.
+ *
+ * <p>The method is private; there is no source-level way to call it other than reflection (same
+ * pattern already used by {@code ConnectionHandlerCoalescedHandshakeTest} for {@code
+ * handlePeerInHandshake}), so both branches — {@code peer.readBuffer == null} (allocate + put) and
+ * {@code peer.readBuffer != null} (append) — are driven directly with a hand-built {@code
+ * tempHandshakeReadBuffer} in the same flipped ("read mode") state the real caller ({@code
+ * handleFirstEncryptedCommand}) leaves it in after consuming the command byte.
+ */
+public class ConnectionHandlerCopyRemainingReadBytesTest {
+
+  static {
+    ByteBufferPool.init();
+  }
+
+  private Method copyRemainingReadBytesToPeerBufferMethod() throws NoSuchMethodException {
+    Method method =
+        ConnectionHandler.class.getDeclaredMethod(
+            "copyRemainingReadBytesToPeerBuffer", ByteBuffer.class, Peer.class);
+    method.setAccessible(true);
+    return method;
+  }
+
+  private byte[] contentsOf(ByteBuffer writeMode) {
+    ByteBuffer readable = writeMode.duplicate();
+    readable.flip();
+    byte[] out = new byte[readable.remaining()];
+    readable.get(out);
+    return out;
+  }
+
+  /**
+   * {@code peer.readBuffer == null}: the method must borrow a fresh buffer from the pool sized to
+   * the remaining bytes and put all of them into it.
+   */
+  @Test
+  public void nullReadBufferAllocatesAndFillsFromPool() throws Exception {
+    ConnectionHandler connectionHandler =
+        new ConnectionHandler(ServerContext.buildDefaultServerContext(), false);
+    Peer peer = new Peer("127.0.0.1", 0, new NodeId());
+    assertThat(peer.readBuffer).as("precondition: no buffer claimed yet").isNull();
+
+    byte[] leftoverPlaintext = {10, 20, 30};
+    // Same "flipped, command byte already consumed" state handleFirstEncryptedCommand leaves the
+    // buffer in before calling this method.
+    ByteBuffer tempHandshakeReadBuffer = ByteBuffer.wrap(leftoverPlaintext);
+
+    copyRemainingReadBytesToPeerBufferMethod()
+        .invoke(connectionHandler, tempHandshakeReadBuffer, peer);
+
+    assertThat(peer.readBuffer).as("a buffer must have been borrowed and stored").isNotNull();
+    assertThat(peer.readBuffer.position())
+        .as("all remaining bytes must have been put into the new buffer")
+        .isEqualTo(leftoverPlaintext.length);
+    assertThat(contentsOf(peer.readBuffer)).containsExactly(leftoverPlaintext);
+    assertThat(tempHandshakeReadBuffer.hasRemaining())
+        .as("the source buffer must be fully drained by the relative put")
+        .isFalse();
+
+    peer.disconnect("test cleanup"); // returns peer.readBuffer to the pool via the production path
+    assertThat(peer.readBuffer).isNull();
+  }
+
+  /**
+   * {@code peer.readBuffer != null}: the method must APPEND to the existing buffer (same instance,
+   * prior bytes preserved, new bytes placed right after them) rather than overwrite it or allocate
+   * a second one.
+   */
+  @Test
+  public void nonNullReadBufferAppendsPreservingExistingContent() throws Exception {
+    ConnectionHandler connectionHandler =
+        new ConnectionHandler(ServerContext.buildDefaultServerContext(), false);
+    Peer peer = new Peer("127.0.0.1", 0, new NodeId());
+
+    ByteBuffer existing = ByteBufferPool.borrowObject(16);
+    byte[] alreadyBuffered = {1, 2, 3};
+    existing.put(alreadyBuffered);
+    peer.readBuffer = existing;
+
+    byte[] leftoverPlaintext = {4, 5};
+    ByteBuffer tempHandshakeReadBuffer = ByteBuffer.wrap(leftoverPlaintext);
+
+    copyRemainingReadBytesToPeerBufferMethod()
+        .invoke(connectionHandler, tempHandshakeReadBuffer, peer);
+
+    assertThat(peer.readBuffer)
+        .as("must append into the SAME buffer instance, not allocate a new one")
+        .isSameAs(existing);
+    assertThat(peer.readBuffer.position())
+        .as("position must advance past both the pre-existing and the newly appended bytes")
+        .isEqualTo(alreadyBuffered.length + leftoverPlaintext.length);
+    assertThat(contentsOf(peer.readBuffer)).containsExactly(1, 2, 3, 4, 5);
+
+    peer.disconnect("test cleanup");
+    assertThat(peer.readBuffer).isNull();
+  }
+}

--- a/src/test/java/im/redpanda/core/ReadConnectionHandlerExceptionTest.java
+++ b/src/test/java/im/redpanda/core/ReadConnectionHandlerExceptionTest.java
@@ -1,0 +1,216 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression tests for TD013 (review-dag finding on redpandaj#271): {@link
+ * InboundCommandProcessor#parseCommand} only catches {@code InvalidProtocolBufferException} from a
+ * command handler — any other {@code RuntimeException} a handler throws propagates through {@code
+ * loopCommands}'s {@code finally}-compact, through {@code
+ * ConnectionReaderThread#readConnection(Peer)}'s claim/restore {@code finally} (REDPANDAJ-2EF), all
+ * the way out to {@code run()}'s generic {@code catch (Throwable e)}. The documented contract "no
+ * buffer leak even on a handler exception" was only ever tested on the disconnect-mid-parse half
+ * (see {@code
+ * ReadConnectionOwnershipHandoffTest#disconnectWhileBufferClaimedReturnsBufferExactlyOnce}), never
+ * on the handler-throws half.
+ *
+ * <p>{@code commandHandlers} is a private field of a private nested functional interface, so there
+ * is no source-level way to install a throwing stub from outside {@link InboundCommandProcessor}.
+ * Rather than widen production visibility for a single test (no seam is actually unavoidable here),
+ * a {@link Proxy} implementing the private interface — obtained purely via {@link
+ * Class#getDeclaredClasses()} / {@link InvocationHandler}, which never needs to name the private
+ * type — is swapped into the real handler map through reflection. This changes no production code
+ * at all.
+ */
+public class ReadConnectionHandlerExceptionTest {
+
+  static {
+    ByteBufferPool.init();
+  }
+
+  private ServerSocketChannel serverSocket;
+  private SocketChannel remoteSide;
+  private SocketChannel peerSide;
+
+  @Before
+  public void setUpChannels() throws IOException {
+    serverSocket = ServerSocketChannel.open();
+    serverSocket.bind(new InetSocketAddress("127.0.0.1", 0));
+    remoteSide = SocketChannel.open(serverSocket.getLocalAddress());
+    peerSide = serverSocket.accept();
+  }
+
+  @After
+  public void tearDownChannels() throws IOException {
+    for (SocketChannel channel : new SocketChannel[] {remoteSide, peerSide}) {
+      if (channel != null && channel.isOpen()) {
+        channel.close();
+      }
+    }
+    if (serverSocket != null && serverSocket.isOpen()) {
+      serverSocket.close();
+    }
+  }
+
+  private Peer newConnectedPeer() {
+    Peer peer = new Peer("127.0.0.1", 0, new NodeId());
+    peer.setSocketChannel(peerSide);
+    peer.setConnected(true);
+    peer.writeBuffer = ByteBuffer.allocate(1024 * 100);
+    peer.writeBufferCrypted = ByteBuffer.allocate(1024 * 100);
+    // Same 32-byte key for both directions so the peer's receive stream decrypts frames encrypted
+    // by its own send stream (loopback test trick, see PeerTest /
+    // ReadConnectionOwnershipHandoffTest).
+    byte[] key = new byte[32];
+    peer.setPeerChiperStreams(new GcmFramedStreams(key, key));
+    return peer;
+  }
+
+  private void sendEncrypted(Peer peer, byte[] plaintext) throws IOException {
+    ByteBuffer in = ByteBuffer.allocate(plaintext.length);
+    in.put(plaintext);
+    in.flip();
+    ByteBuffer out = ByteBuffer.allocate(plaintext.length + 1024);
+    peer.getPeerChiperStreams().encrypt(in, out);
+    out.flip();
+    while (out.hasRemaining()) {
+      remoteSide.write(out);
+    }
+  }
+
+  /**
+   * Replaces the {@code Command.PING} handler of a fresh {@link ConnectionReaderThread}'s internal
+   * {@link InboundCommandProcessor} with a stub that unconditionally throws, then returns the
+   * reader thread. Reflection only — no change to production visibility.
+   */
+  private ConnectionReaderThread newReaderThreadWithThrowingPingHandler(RuntimeException toThrow)
+      throws Exception {
+    ConnectionReaderThread readerThread =
+        new ConnectionReaderThread(new ServerContext(), ConnectionReaderThread.STD_TIMEOUT);
+
+    Field inboundProcessorField = ConnectionReaderThread.class.getDeclaredField("inboundProcessor");
+    inboundProcessorField.setAccessible(true);
+    InboundCommandProcessor inboundProcessor =
+        (InboundCommandProcessor) inboundProcessorField.get(readerThread);
+
+    Class<?> commandHandlerInterface = null;
+    for (Class<?> declared : InboundCommandProcessor.class.getDeclaredClasses()) {
+      if (declared.getSimpleName().equals("CommandHandler")) {
+        commandHandlerInterface = declared;
+        break;
+      }
+    }
+    assertThat(commandHandlerInterface)
+        .as("InboundCommandProcessor.CommandHandler nested interface must still exist")
+        .isNotNull();
+
+    InvocationHandler throwing =
+        (proxy, method, args) -> {
+          throw toThrow;
+        };
+    Object throwingHandler =
+        Proxy.newProxyInstance(
+            InboundCommandProcessor.class.getClassLoader(),
+            new Class<?>[] {commandHandlerInterface},
+            throwing);
+
+    Field commandHandlersField = InboundCommandProcessor.class.getDeclaredField("commandHandlers");
+    commandHandlersField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<Byte, Object> commandHandlers =
+        (Map<Byte, Object>) commandHandlersField.get(inboundProcessor);
+    commandHandlers.put(Command.PING, throwingHandler);
+
+    return readerThread;
+  }
+
+  /**
+   * A single PING command exactly fills (and fully drains) the claimed buffer: the handler throws
+   * before returning, so {@code loopCommands}'s {@code finally}-compact runs on a buffer with
+   * nothing left unread. {@code readConnection}'s own claim/restore {@code finally} then sees
+   * {@code position() == 0} ("drained") and must return the claimed buffer to the pool — not leak
+   * it into {@code peer.readBuffer} — even though the exception is still propagating past it.
+   */
+  @Test
+  public void handlerExceptionOnFullyDrainedBufferReturnsBufferToPoolWithoutLeak()
+      throws Exception {
+    Peer peer = newConnectedPeer();
+    ByteBuffer preBorrowed = ByteBufferPool.borrowObject(1024);
+    peer.readBuffer = preBorrowed;
+
+    RuntimeException boom = new IllegalStateException("TD013 handler stub failure");
+    ConnectionReaderThread readerThread = newReaderThreadWithThrowingPingHandler(boom);
+
+    sendEncrypted(peer, new byte[] {Command.PING});
+
+    assertThatThrownBy(() -> readerThread.readConnection(peer))
+        .as("the handler exception must propagate all the way out of readConnection() unmasked")
+        .isSameAs(boom);
+
+    assertThat(peer.readBuffer)
+        .as(
+            "a fully drained buffer must be returned to the pool, not kept in (or leaked out of)"
+                + " the field, even when the handler threw")
+        .isNull();
+    // LIFO pool: the instance we just returned is the first one handed out again, in pristine
+    // state (position 0, limit == capacity) — proves it was returned exactly once, not corrupted.
+    ByteBuffer reBorrowed = ByteBufferPool.borrowObject(1024);
+    assertThat(reBorrowed).isSameAs(preBorrowed);
+    assertThat(reBorrowed.position()).isZero();
+    assertThat(reBorrowed.limit()).isEqualTo(reBorrowed.capacity());
+    ByteBufferPool.returnObject(reBorrowed);
+  }
+
+  /**
+   * Two PING command bytes arrive in one read. The throwing stub is installed before either is
+   * parsed, so it fires on the very first one — but because a second, still-unread command byte
+   * sits behind it in the buffer, the {@code finally}-compact in {@code loopCommands} leaves the
+   * buffer with leftover bytes (position != 0 after compact) instead of fully drained. {@code
+   * readConnection}'s claim/restore {@code finally} must then restore the SAME buffer instance into
+   * {@code peer.readBuffer} (not drop it, not double-return it) so a later read can retry the
+   * still-unparsed second command.
+   */
+  @Test
+  public void handlerExceptionWithLeftoverBytesRestoresBufferIntoField() throws Exception {
+    Peer peer = newConnectedPeer();
+    ByteBuffer preBorrowed = ByteBufferPool.borrowObject(1024);
+    peer.readBuffer = preBorrowed;
+
+    RuntimeException boom = new IllegalStateException("TD013 handler stub failure");
+    ConnectionReaderThread readerThread = newReaderThreadWithThrowingPingHandler(boom);
+
+    sendEncrypted(peer, new byte[] {Command.PING, Command.PING});
+
+    assertThatThrownBy(() -> readerThread.readConnection(peer)).isSameAs(boom);
+
+    assertThat(peer.readBuffer)
+        .as(
+            "leftover (unparsed) bytes after a handler exception must be restored into the field,"
+                + " same instance, not dropped or leaked")
+        .isSameAs(preBorrowed);
+    assertThat(peer.readBuffer.position())
+        .as("the second, unparsed PING command byte must still be buffered (write mode)")
+        .isEqualTo(1);
+    assertThat(peer.isConnected())
+        .as("a handler exception alone must not disconnect the peer")
+        .isTrue();
+
+    // cleanup via the production path
+    peer.disconnect("test cleanup");
+    assertThat(peer.readBuffer).isNull();
+  }
+}

--- a/src/test/java/im/redpanda/core/ReadConnectionStaleChannelGuardTest.java
+++ b/src/test/java/im/redpanda/core/ReadConnectionStaleChannelGuardTest.java
@@ -1,0 +1,277 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketOption;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectableChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.nio.channels.spi.SelectorProvider;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * Regression tests for TD012 (review-dag finding on redpandaj#271): the stale-connection guards in
+ * {@link ConnectionReaderThread#readConnection(Peer)} — {@code peer.getSocketChannel() != channel},
+ * checked in the {@code IOException}/{@code Throwable} catch blocks after a failed {@code
+ * channel.read()} — exist to stop an I/O failure on an OLD, already-replaced channel (a concurrent
+ * re-handshake via {@code Peer.setupConnectionForPeer}, e.g. IncomingHandler thread) from tearing
+ * down the freshly established replacement connection. Every pre-existing test only ever triggers
+ * this branch via {@code peer.setConnected(false)}, never with an actually swapped {@link
+ * Peer#getSocketChannel()} instance — the exact identity comparison the guard performs.
+ *
+ * <p>{@link SocketChannel} and {@link SelectionKey} are abstract with no in-repo test stub, so this
+ * drives the swap deterministically with two minimal purpose-built stubs below: {@link
+ * SwapThenFailSocketChannel#read} performs the swap (mutates {@code peer.socketChannel} to a
+ * different instance, simulating the concurrent re-handshake completing between the channel being
+ * captured and the read failing) and then throws an {@link IOException} — precisely what reading a
+ * killed/reused old fd looks like from the reader thread's side, at the moment the guard is meant
+ * to catch it. {@link CancelTrackingSelectionKey} lets the tests observe that {@code key.cancel()}
+ * (which unconditionally runs before the guard check, see {@code readConnection}) still happens
+ * regardless of the swap.
+ */
+public class ReadConnectionStaleChannelGuardTest {
+
+  static {
+    ByteBufferPool.init();
+  }
+
+  private ConnectionReaderThread newReaderThread() {
+    return new ConnectionReaderThread(new ServerContext(), ConnectionReaderThread.STD_TIMEOUT);
+  }
+
+  private Peer newConnectedPeer() {
+    Peer peer = new Peer("127.0.0.1", 0, new NodeId());
+    peer.setConnected(true);
+    return peer;
+  }
+
+  /**
+   * The channel captured at the top of readConnection() fails with an IOException, but only AFTER a
+   * concurrent re-handshake has already swapped {@code peer.socketChannel} to a different (fresh)
+   * instance — the exact race the guard defends against. The fresh connection must survive: no
+   * {@code disconnect()}, peer stays connected, {@code socketChannel} stays the swapped-in
+   * instance.
+   */
+  @Test
+  public void staleReadFailureAfterConcurrentSwapDoesNotDisconnectFreshConnection()
+      throws Exception {
+    Peer peer = newConnectedPeer();
+    CancelTrackingSelectionKey key = new CancelTrackingSelectionKey();
+    peer.setSelectionKey(key);
+
+    SocketChannel freshConnection = SocketChannel.open();
+    try {
+      SwapThenFailSocketChannel staleChannel = new SwapThenFailSocketChannel(peer, freshConnection);
+      peer.setSocketChannel(staleChannel);
+
+      int read = newReaderThread().readConnection(peer);
+
+      assertThat(read).isEqualTo(0);
+      assertThat(key.cancelled)
+          .as("the stale key is cancelled unconditionally, before the guard is even evaluated")
+          .isTrue();
+      assertThat(peer.isConnected())
+          .as(
+              "the guard must prevent the stale read failure from tearing down the fresh"
+                  + " (swapped-in) connection")
+          .isTrue();
+      assertThat(peer.getSocketChannel())
+          .as("the swapped-in connection must be left completely untouched by the stale failure")
+          .isSameAs(freshConnection);
+    } finally {
+      freshConnection.close();
+    }
+  }
+
+  /**
+   * Same read failure, but WITHOUT a concurrent swap: the channel captured at the top of
+   * readConnection() is still the one and only connection the peer has. The guard must not suppress
+   * a genuine disconnect in this case — this is the negative control proving the first test's green
+   * result comes from the swap, not from the guard being a no-op.
+   */
+  @Test
+  public void staleReadFailureWithoutSwapDisconnectsTheSingleConnection() throws Exception {
+    Peer peer = newConnectedPeer();
+    CancelTrackingSelectionKey key = new CancelTrackingSelectionKey();
+    peer.setSelectionKey(key);
+
+    SwapThenFailSocketChannel channel = new SwapThenFailSocketChannel(peer, null);
+    peer.setSocketChannel(channel);
+
+    int read = newReaderThread().readConnection(peer);
+
+    assertThat(read).isEqualTo(0);
+    assertThat(key.cancelled).isTrue();
+    assertThat(peer.isConnected())
+        .as("without a concurrent swap the guard must not suppress the genuine disconnect")
+        .isFalse();
+  }
+
+  /**
+   * On {@link #read(ByteBuffer)}, optionally swaps {@code peer.socketChannel} to a different
+   * instance (simulating a concurrent re-handshake completing while this read is in flight), then
+   * always fails with an {@link IOException}. Every other {@link SocketChannel} method is unused by
+   * {@code readConnection()}'s failure path and throws {@link UnsupportedOperationException} if
+   * ever called, so an unexpected code path fails loudly instead of silently doing nothing.
+   */
+  private static final class SwapThenFailSocketChannel extends SocketChannel {
+    private final Peer peer;
+    private final SocketChannel swapTo;
+
+    SwapThenFailSocketChannel(Peer peer, SocketChannel swapTo) {
+      super(SelectorProvider.provider());
+      this.peer = peer;
+      this.swapTo = swapTo;
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+      if (swapTo != null) {
+        peer.setSocketChannel(swapTo);
+      }
+      throw new IOException("simulated read failure on a stale connection (TD012)");
+    }
+
+    @Override
+    protected void implCloseSelectableChannel() {
+      // no-op: no real fd/selector registration to release
+    }
+
+    @Override
+    protected void implConfigureBlocking(boolean block) {
+      // no-op: Peer.disconnect() calls configureBlocking(false) unconditionally before close()
+    }
+
+    @Override
+    public SocketChannel bind(SocketAddress local) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> SocketChannel setOption(SocketOption<T> name, T value) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T getOption(SocketOption<T> name) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<SocketOption<?>> supportedOptions() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public SocketChannel shutdownInput() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SocketChannel shutdownOutput() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Socket socket() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isConnected() {
+      return true;
+    }
+
+    @Override
+    public boolean isConnectionPending() {
+      return false;
+    }
+
+    @Override
+    public boolean connect(SocketAddress remote) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean finishConnect() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SocketAddress getRemoteAddress() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long read(ByteBuffer[] dsts, int offset, int length) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int write(ByteBuffer src) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int length) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SocketAddress getLocalAddress() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  /**
+   * Minimal {@link SelectionKey} stub that only tracks whether {@link #cancel()} was called; {@code
+   * readConnection()} calls {@code key.cancel()} unconditionally in the failure path, before the
+   * stale-connection guard is even evaluated, so the tests need a key that survives that call
+   * without an actual {@link Selector} registration.
+   */
+  private static final class CancelTrackingSelectionKey extends SelectionKey {
+    private volatile boolean cancelled = false;
+
+    @Override
+    public SelectableChannel channel() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Selector selector() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isValid() {
+      return !cancelled;
+    }
+
+    @Override
+    public void cancel() {
+      cancelled = true;
+    }
+
+    @Override
+    public int interestOps() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SelectionKey interestOps(int ops) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int readyOps() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Pure test-debt bundle for three review-dag findings on redpandaj#271 (Claim/Restore
ownership of `peer.readBuffer` under `writeBufferLock`, atomic connection swap,
stale-connection guards). **No production code is changed** — three new test classes only.

- **TD012** — `ReadConnectionStaleChannelGuardTest`: the stale-connection guards in
  `ConnectionReaderThread.readConnection` (`peer.getSocketChannel() != channel`) were
  previously only exercised via `peer.setConnected(false)`, never with an actually
  swapped channel instance. Adds a minimal `SocketChannel`/`SelectionKey` stub whose
  `read()` first swaps `peer.socketChannel` to a different instance (simulating a
  concurrent re-handshake completing mid-read) and then throws an `IOException` —
  precisely the race the guard defends against. Two tests: the guard holds (fresh
  connection survives) when there was a swap, and a negative control confirming a
  genuine single-connection failure still disconnects normally.
- **TD013** — `ReadConnectionHandlerExceptionTest`: `InboundCommandProcessor.parseCommand`
  only catches `InvalidProtocolBufferException`; any other `RuntimeException` from a
  handler propagates through `loopCommands`'s finally-compact and `readConnection`'s
  claim/restore finally. The "no buffer leak even on a handler exception" contract was
  only tested on the disconnect-mid-parse half before. Installs a throwing handler stub
  via a `java.lang.reflect.Proxy` for `InboundCommandProcessor`'s *private*
  `CommandHandler` interface (obtained via `getDeclaredClasses()`, no production
  visibility widened) and asserts both the fully-drained (buffer returned to pool) and
  leftover-bytes (buffer restored into field) outcomes, with the exception still
  propagating out of `readConnection()` unmasked.
- **TD014** — `ConnectionHandlerCopyRemainingReadBytesTest`: no test in the repo reached
  `ConnectionHandler.copyRemainingReadBytesToPeerBuffer` with `remaining() > 0` — the
  existing `ConnectionHandlerCoalescedHandshakeTest` always hits the early return. Adds
  direct reflection-based tests (same pattern as that existing test) for both branches:
  `peer.readBuffer == null` (borrow + put) and `peer.readBuffer != null` (append,
  preserving prior content).

All three were manually mutation-tested against the guarded production code (removed the
IOException guard / forced the drained-flag / replaced append with overwrite) to confirm
each new test fails without the corresponding correct behavior, then reverted before
committing — see session log for details.

## Test plan
- [x] `mvn test -Dtest=ReadConnectionStaleChannelGuardTest` — green (2/2)
- [x] `mvn test -Dtest=ReadConnectionHandlerExceptionTest` — green (2/2)
- [x] `mvn test -Dtest=ConnectionHandlerCopyRemainingReadBytesTest` — green (2/2)
- [x] Full local suite (`mvn test`, pipefail-checked exit code): 402 tests, 0 failures, 0 errors, 1 skipped
- [x] Manual mutation check on all three (see commit message) confirms each test is load-bearing
- [x] `git diff --stat main` — only the three new test files, zero production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)