### PR TITLE
T57: Quick-win bundle TD017 (own-node double-score) + TD018 (lazy debug string) + TD019 (dead branch)

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -729,11 +729,18 @@ public class ConnectionHandler extends Thread {
        */
       Peer oldPeer = peerList.add(peerOrigin);
       if (oldPeer != null && oldPeer.isConnected()) {
-        if (!peerOrigin.getNodeId().equals(oldPeer.getNodeId())) {
-          System.out.println("already connected to same node with same id");
-        } else {
-          System.out.println("already connected to same node with same ip+port");
-        }
+        // TD019: diagnostics only. The actual connection/registry decision has already been made
+        // above — by peerList.add() (returns the pre-existing peer on an identity match, otherwise
+        // registers this one) and by the atomic channel/stream swap in
+        // Peer.setupConnectionForPeer(); nothing here changes that outcome. The former "same node
+        // with same id" branch was removed as dead code (T54 analysis): peerList.add() only ever
+        // returns a non-null oldPeer whose NodeId equals peerOrigin's — either via the KademliaId
+        // hashmap hit, or via the ip+port branch that returns oldPeer only in its equal-NodeId
+        // else — so a "different id" case can never reach this point. Switched from
+        // System.out.println to the logger so real duplicate-connection incidents are traceable.
+        logger.info(
+            "already connected to same node with same ip+port (KadId: {})",
+            peerInHandshake.getIdentity());
       }
 
       /** Lets search for the Node object for that peer and load it. */

--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -738,8 +738,12 @@ public class ConnectionHandler extends Thread {
         // hashmap hit, or via the ip+port branch that returns oldPeer only in its equal-NodeId
         // else — so a "different id" case can never reach this point. Switched from
         // System.out.println to the logger so real duplicate-connection incidents are traceable.
+        // The message names the guaranteed invariant (same node identity / KademliaId), not
+        // "same ip+port": peerList.add() also returns the pre-existing peer on a KademliaId
+        // hashmap hit whose ip+port may differ, so an ip+port claim would mislead operators
+        // (Copilot review, PR #275).
         logger.info(
-            "already connected to same node with same ip+port (KadId: {})",
+            "already connected to a node with the same identity (KadId: {})",
             peerInHandshake.getIdentity());
       }
 

--- a/src/main/java/im/redpanda/core/ConnectionReaderThread.java
+++ b/src/main/java/im/redpanda/core/ConnectionReaderThread.java
@@ -308,7 +308,6 @@ public class ConnectionReaderThread implements Runnable {
     SocketChannel channel = peer.getSocketChannel();
 
     int read = -2;
-    String debugStringRead = myReaderBuffer.toString();
     try {
       read = channel.read(myReaderBuffer);
       Log.put("!!read bytes: " + read, 200);
@@ -322,6 +321,12 @@ public class ConnectionReaderThread implements Runnable {
       }
       return 0;
     } catch (Throwable e) {
+      // TD018: build the buffer debug string lazily here, only on the exceptional path. It used to
+      // be constructed (ByteBuffer.toString() + string concat) on EVERY readConnection() call — a
+      // per-peer-read hot path — although it is consumed solely in this catch block. The buffer
+      // object is the same instance as before the read attempt; channel.read() throwing means it
+      // did not transfer bytes, so this still reflects the pre-read state (pos/lim/cap).
+      String debugStringRead = myReaderBuffer.toString();
       Log.sentry(e);
       Log.sentry(
           "Could not read in ConnectionReaderThread, buffer before read was: " + debugStringRead);

--- a/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
+++ b/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
@@ -304,6 +304,21 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
     // flaschenPostInsertPeer could be a node outside `nodes`) double-scored it on every run. The
     // insertNode != null check above still gates the loop: it is how done() detects that init()
     // never got as far as building a real path (see REDPANDAJ-2EG below).
+    //
+    // TD017: the own node (serverContext.getNode()) is deliberately left in `nodes` twice — once
+    // as nodes.get(0) (path start in calculatePathOrAbort()) and once as the appended last element
+    // (the GMAck target = ourselves). Both positions are structurally required to build the nested
+    // garlic layers and the edge-scoring path below, so they are NOT deduplicated. The scoring loop
+    // therefore increments the own node's GM-test counters twice per run — but this is inert, not a
+    // bug: nothing acts on the own node's inflated stats. The only score-based decision that could
+    // touch it, NodeStore.removeBadScoredNode(), explicitly skips the own node
+    // (`node.equals(serverContext.getNode())`); NodeStore.addRandomNodeToGraph() sorts onHeap by
+    // score only to ADD new vertices, and the own node is already a graph vertex; and
+    // Peer.getPriority() reads Node.getGmTests* only for connected remote peers, which the own node
+    // never is. Unlike the TD007 insert-peer double-count (which was a real bug fixed in
+    // redpandaj#272), the own-node double-count changes no observable behavior, so it is documented
+    // here rather than removed (KISS — deduping would mean special-casing the own node inside the
+    // structurally-shared `nodes` list).
     if (success) {
       for (Node node : nodes) {
         node.increaseGmTestsSuccessful();

--- a/src/test/java/im/redpanda/core/ConnectionHandlerDuplicateConnectionTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerDuplicateConnectionTest.java
@@ -1,0 +1,106 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.channels.SelectableChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import org.junit.Test;
+
+/**
+ * TD019 regression: {@link ConnectionHandler#setupConnection} contains a diagnostic-only branch
+ * that fires when {@code peerList.add(peerOrigin)} returns an already-connected {@code oldPeer}
+ * (i.e. a peer with the same identity is already registered and connected). The T54 analysis
+ * established that {@code PeerList.add()} only ever returns a non-null {@code oldPeer} whose {@code
+ * NodeId} equals {@code peerOrigin}'s, which is why the former "same node with same id" sub-branch
+ * was removed as dead code. This test drives a light-client {@code setupConnection} against a pre-
+ * registered connected duplicate so that diagnostic branch is actually exercised and cannot
+ * silently rot; it also pins the observable outcome: the pre-existing (old) peer stays the
+ * registered peer for that identity — {@code setupConnection} does not double-register the new one.
+ */
+public class ConnectionHandlerDuplicateConnectionTest {
+
+  static {
+    java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+  }
+
+  @Test
+  public void setupConnectionWithAlreadyConnectedDuplicateHitsDiagnosticBranchAndKeepsOldPeer()
+      throws Exception {
+    ByteBufferPool.init();
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    ConnectionHandler connectionHandler = new ConnectionHandler(serverContext, false);
+
+    NodeId identity = NodeId.generateWithSimpleKey();
+
+    // A peer with this identity is already registered and connected.
+    Peer alreadyConnected = new Peer("127.0.0.1", 0, identity);
+    alreadyConnected.setConnected(true);
+    serverContext.getPeerList().add(alreadyConnected);
+
+    // A second physical connection from the same identity now completes its handshake.
+    Peer incoming = new Peer("127.0.0.1", 0, identity);
+    try (SocketChannel channel = SocketChannel.open()) {
+      PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", channel);
+      peerInHandshake.setPeer(incoming);
+      peerInHandshake.setLightClient(true); // skip the Node/DB lookups in setupConnection
+      peerInHandshake.setIdentity(identity.getKademliaId());
+      peerInHandshake.setNodeId(identity);
+      peerInHandshake.setKey(new NoopSelectionKey());
+      connectionHandler.addPeerInHandshake(peerInHandshake);
+
+      connectionHandler.setupConnection(incoming, peerInHandshake);
+
+      // peerList.add() returned the already-connected peer (the oldPeer diagnostic branch, TD019);
+      // the incoming duplicate was NOT registered in its place.
+      Peer registered = serverContext.getPeerList().get(identity.getKademliaId());
+      assertThat(registered)
+          .as("the already-connected peer must remain the registered peer for this identity")
+          .isSameAs(alreadyConnected);
+      assertThat(registered)
+          .as("setupConnection must not double-register the incoming duplicate")
+          .isNotSameAs(incoming);
+    }
+  }
+
+  /**
+   * Minimal {@link SelectionKey} stub: {@code setupConnection} only calls the final {@code attach}.
+   */
+  private static final class NoopSelectionKey extends SelectionKey {
+    @Override
+    public SelectableChannel channel() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Selector selector() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isValid() {
+      return true;
+    }
+
+    @Override
+    public void cancel() {
+      // no-op
+    }
+
+    @Override
+    public int interestOps() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SelectionKey interestOps(int ops) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int readyOps() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/src/test/java/im/redpanda/core/ReadConnectionStaleChannelGuardTest.java
+++ b/src/test/java/im/redpanda/core/ReadConnectionStaleChannelGuardTest.java
@@ -115,6 +115,34 @@ public class ReadConnectionStaleChannelGuardTest {
   }
 
   /**
+   * TD018 regression: when {@code channel.read()} fails with a non-{@link IOException} {@link
+   * Throwable} (e.g. a {@link RuntimeException}), {@code readConnection()} routes into its {@code
+   * catch (Throwable)} branch, which is where the {@code debugStringRead} buffer diagnostic is now
+   * built lazily (moved off the per-read hot path). This exercises that branch — building the debug
+   * string, cancelling the key, and disconnecting the single (un-swapped) connection — so the lazy
+   * construction cannot silently rot. Without a swap the guard must not suppress the disconnect.
+   */
+  @Test
+  public void nonIoThrowableFailureBuildsDebugStringAndDisconnectsSingleConnection()
+      throws Exception {
+    Peer peer = newConnectedPeer();
+    CancelTrackingSelectionKey key = new CancelTrackingSelectionKey();
+    peer.setSelectionKey(key);
+
+    SwapThenFailSocketChannel channel = new SwapThenFailSocketChannel(peer, null, true);
+    peer.setSocketChannel(channel);
+
+    int read = newReaderThread().readConnection(peer);
+
+    assertThat(read).isEqualTo(0);
+    assertThat(key.cancelled).isTrue();
+    assertThat(peer.isConnected())
+        .as(
+            "a non-IOException read failure on the single connection must still disconnect the peer")
+        .isFalse();
+  }
+
+  /**
    * On {@link #read(ByteBuffer)}, optionally swaps {@code peer.socketChannel} to a different
    * instance (simulating a concurrent re-handshake completing while this read is in flight), then
    * always fails with an {@link IOException}. Every other {@link SocketChannel} method is unused by
@@ -124,17 +152,27 @@ public class ReadConnectionStaleChannelGuardTest {
   private static final class SwapThenFailSocketChannel extends SocketChannel {
     private final Peer peer;
     private final SocketChannel swapTo;
+    private final boolean throwRuntime;
 
     SwapThenFailSocketChannel(Peer peer, SocketChannel swapTo) {
+      this(peer, swapTo, false);
+    }
+
+    SwapThenFailSocketChannel(Peer peer, SocketChannel swapTo, boolean throwRuntime) {
       super(SelectorProvider.provider());
       this.peer = peer;
       this.swapTo = swapTo;
+      this.throwRuntime = throwRuntime;
     }
 
     @Override
     public int read(ByteBuffer dst) throws IOException {
       if (swapTo != null) {
         peer.setSocketChannel(swapTo);
+      }
+      if (throwRuntime) {
+        // Non-IOException failure routes into readConnection()'s catch(Throwable) branch (TD018).
+        throw new RuntimeException("simulated non-IO read failure (TD018)");
       }
       throw new IOException("simulated read failure on a stale connection (TD012)");
     }


### PR DESCRIPTION
## Summary

Three small, independent pre-existing findings bundled into one mini-PR per task **T57** (quick-win bundle TD017 + TD018 + TD019). Pure internal cleanup, no wire-format change.

### TD017 — `PeerPerformanceTestGarlicMessageJob.done()`: own node double-scored (justification, not a fix)
The own node (`serverContext.getNode()`) appears in `nodes` twice — as `nodes.get(0)` (path start in `calculatePathOrAbort()`) and as the appended last element (the GMAck target = ourselves). The scoring loop therefore increments the own node's GM-test counters twice per run — same class as the TD007 insert-peer bug, but for the own node.

**Verdict: inconsequential, not a bug.** Nothing acts on the own node's inflated stats:
- `NodeStore.removeBadScoredNode()` — the only score-based pruning decision — explicitly skips the own node (`node.equals(serverContext.getNode())`).
- `NodeStore.addRandomNodeToGraph()` sorts `onHeap` by score only to *add* new vertices; the own node is already a graph vertex (skipped by `containsVertex`).
- `Peer.getPriority()` reads `Node.getGmTests*` only for connected **remote** peers; the own node is never a remote peer.

Unlike TD007 (a real bug, fixed in redpandaj#272), this changes no observable behavior. Documented with a justification comment rather than deduped — both list positions are structurally required to build the nested garlic layers and the edge-scoring path, so removing the duplicate would mean special-casing the own node inside a structurally-shared list (KISS).

`src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java`

### TD018 — `ConnectionReaderThread.readConnection()`: eager debug-string allocation on the hot path
`debugStringRead = myReaderBuffer.toString()` was built (ByteBuffer `toString()` + later string concat) on **every** `readConnection()` call — a per-peer-read hot path — although it is consumed only in the `catch (Throwable)` branch of the subsequent `channel.read()`. The predominant success case paid for the allocation for nothing.

Fix: build the string lazily inside the catch block. The buffer is the same instance as before the read; a throwing `channel.read()` did not transfer bytes, so it still reflects the pre-read state.

`src/main/java/im/redpanda/core/ConnectionReaderThread.java`

### TD019 — `ConnectionHandler.setupConnection()`: dead branch + println
The `already connected to same node with same id` branch was mathematically unreachable (T54 analysis): `PeerList.add()` returns a non-null `oldPeer` only when its `NodeId` equals `peerOrigin`'s — KademliaId hashmap hit, or the ip+port branch's equal-NodeId `else`. So the `!getNodeId().equals(...)` case never fires.

Fix: removed the dead branch, switched the remaining diagnostic from `System.out.println` to `logger.info` (so real duplicate-connection incidents are traceable), and added a comment that only diagnostics happen here — the actual connection decision was already made by `peerList.add()` / the atomic swap in `Peer.setupConnectionForPeer()`.

`src/main/java/im/redpanda/core/ConnectionHandler.java`

### DoD per item
- TD017: justification comment (inconsequential, evidence above).
- TD018: justification comment — a "no allocation in success path" test has no observable behavior to assert; the Sentry-log behavior on the exceptional path is unchanged. Test not practical.
- TD019: dead-code removal + logging change; documented via comment (logging change not meaningfully unit-testable).

## Test plan
- [x] `mvn verify` — green (402 tests, 0 failures, 0 errors, 1 skipped)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)