### PR TITLE
T58/TD020: disconnect losing peer on parallel same-identity handshakes

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -728,20 +728,44 @@ public class ConnectionHandler extends Thread {
        * lets add it by KademliaId
        */
       Peer oldPeer = peerList.add(peerOrigin);
+      if (oldPeer != null && oldPeer != peerOrigin) {
+        // TD020: two inbound connections from the same node raced. Both handshakes saw
+        // peerList.get(identity) == null in ConnectionReaderThread.parseHandshake and each built
+        // its own, fully connected Peer object; only the first to reach peerList.add() got
+        // registered. peerOrigin is the loser here — oldPeer (the winner) already holds this
+        // identity, so peerList.add() returned it without registering peerOrigin. peerOrigin is
+        // connected and being read by the selector (setupConnectionForPeer already adopted its
+        // socket/streams and its key is attached above) but is unreachable for outbound, because
+        // peerList.get(identity) returns oldPeer — i.e. a silent, un-healing orphan that keeps a
+        // socket and reader busy forever. Disconnect it so no unregistered, still-reading peer
+        // object survives; the winner keeps its own connection.
+        //
+        // The sequential half-open reconnect (T54) does NOT reach this branch: there parseHandshake
+        // found the already-registered peer and set it as peerOrigin, so peerList.add() returns
+        // that very object (oldPeer == peerOrigin) and the connection swap has already happened
+        // inside Peer.setupConnectionForPeer (PR #271) — that case is handled by the else-if
+        // diagnostic branch below, not here.
+        logger.info(
+            "duplicate parallel connection from the same identity (KadId: {}); disconnecting the "
+                + "unregistered duplicate",
+            peerInHandshake.getIdentity());
+        peerOrigin.disconnect("duplicate parallel inbound connection; identity already registered");
+        return;
+      }
       if (oldPeer != null && oldPeer.isConnected()) {
-        // TD019: diagnostics only. The actual connection/registry decision has already been made
-        // above — by peerList.add() (returns the pre-existing peer on an identity match, otherwise
-        // registers this one) and by the atomic channel/stream swap in
-        // Peer.setupConnectionForPeer(); nothing here changes that outcome. The former "same node
-        // with same id" branch was removed as dead code (T54 analysis): peerList.add() only ever
-        // returns a non-null oldPeer whose NodeId equals peerOrigin's — either via the KademliaId
-        // hashmap hit, or via the ip+port branch that returns oldPeer only in its equal-NodeId
-        // else — so a "different id" case can never reach this point. Switched from
-        // System.out.println to the logger so real duplicate-connection incidents are traceable.
-        // The message names the guaranteed invariant (same node identity / KademliaId), not
-        // "same ip+port": peerList.add() also returns the pre-existing peer on a KademliaId
-        // hashmap hit whose ip+port may differ, so an ip+port claim would mislead operators
-        // (Copilot review, PR #275).
+        // TD019: diagnostics only. Reaching here means oldPeer == peerOrigin (see the TD020 branch
+        // above, which handles a distinct pre-existing winner): peerList.add() returned the very
+        // peer we just re-registered, i.e. a reconnect/half-open swap whose atomic channel/stream
+        // replacement already happened in Peer.setupConnectionForPeer(); nothing here changes that
+        // outcome. The former "same node with same id" branch was removed as dead code (T54
+        // analysis): peerList.add() only ever returns a non-null oldPeer whose NodeId equals
+        // peerOrigin's — either via the KademliaId hashmap hit, or via the ip+port branch that
+        // returns oldPeer only in its equal-NodeId else — so a "different id" case can never reach
+        // this point. Switched from System.out.println to the logger so real duplicate-connection
+        // incidents are traceable. The message names the guaranteed invariant (same node identity /
+        // KademliaId), not "same ip+port": peerList.add() also returns the pre-existing peer on a
+        // KademliaId hashmap hit whose ip+port may differ, so an ip+port claim would mislead
+        // operators (Copilot review, PR #275).
         logger.info(
             "already connected to a node with the same identity (KadId: {})",
             peerInHandshake.getIdentity());

--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -716,13 +716,6 @@ public class ConnectionHandler extends Thread {
       // update the selection key to the actual peer
       peerInHandshake.getKey().attach(peerOrigin);
 
-      // Log a clear success message for e2e and operators
-      logger.info(
-          "Connected successfully to {}:{} (KadId: {})",
-          peerOrigin.getIp(),
-          peerOrigin.getPort(),
-          peerInHandshake.getIdentity());
-
       /**
        * If this is a new connection not initialzed by us this peer might not be in our PeerList,
        * lets add it by KademliaId
@@ -752,6 +745,16 @@ public class ConnectionHandler extends Thread {
         peerOrigin.disconnect("duplicate parallel inbound connection; identity already registered");
         return;
       }
+
+      // Log a clear success message for e2e and operators. Placed after the TD020 duplicate check
+      // so it only fires for a connection we actually keep — not for a losing parallel duplicate
+      // that was just disconnected above (Copilot review, PR #276).
+      logger.info(
+          "Connected successfully to {}:{} (KadId: {})",
+          peerOrigin.getIp(),
+          peerOrigin.getPort(),
+          peerInHandshake.getIdentity());
+
       if (oldPeer != null && oldPeer.isConnected()) {
         // TD019: diagnostics only. Reaching here means oldPeer == peerOrigin (see the TD020 branch
         // above, which handles a distinct pre-existing winner): peerList.add() returned the very

--- a/src/test/java/im/redpanda/core/ConnectionHandlerDuplicateConnectionTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerDuplicateConnectionTest.java
@@ -9,15 +9,21 @@ import java.nio.channels.SocketChannel;
 import org.junit.Test;
 
 /**
- * TD019 regression: {@link ConnectionHandler#setupConnection} contains a diagnostic-only branch
- * that fires when {@code peerList.add(peerOrigin)} returns an already-connected {@code oldPeer}
- * (i.e. a peer with the same identity is already registered and connected). The T54 analysis
- * established that {@code PeerList.add()} only ever returns a non-null {@code oldPeer} whose {@code
- * NodeId} equals {@code peerOrigin}'s, which is why the former "same node with same id" sub-branch
- * was removed as dead code. This test drives a light-client {@code setupConnection} against a pre-
- * registered connected duplicate so that diagnostic branch is actually exercised and cannot
- * silently rot; it also pins the observable outcome: the pre-existing (old) peer stays the
- * registered peer for that identity — {@code setupConnection} does not double-register the new one.
+ * Regression tests for the two {@code oldPeer != null} outcomes of {@code peerList.add(peerOrigin)}
+ * inside {@link ConnectionHandler#setupConnection}:
+ *
+ * <ul>
+ *   <li><b>TD020 (parallel-handshake orphan):</b> when {@code oldPeer != peerOrigin}, two inbound
+ *       connections from the same identity raced — both saw {@code peerList.get(identity) == null}
+ *       during {@code parseHandshake} and built separate, fully connected {@code Peer} objects, and
+ *       only the first got registered. The loser ({@code peerOrigin}) must be <em>disconnected</em>
+ *       so no unregistered, still-reading peer object survives; the pre-registered winner stays.
+ *   <li><b>TD019 (reconnect diagnostic):</b> when {@code oldPeer == peerOrigin} — the sequential
+ *       half-open reconnect (T54), where {@code parseHandshake} found the already-registered peer
+ *       and the channel/stream swap already happened in {@link Peer#setupConnectionForPeer} (PR
+ *       #271) — {@code setupConnection} only logs a diagnostic and leaves that peer registered and
+ *       connected.
+ * </ul>
  */
 public class ConnectionHandlerDuplicateConnectionTest {
 
@@ -25,8 +31,70 @@ public class ConnectionHandlerDuplicateConnectionTest {
     java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
   }
 
+  /**
+   * TD020: two inbound connections from the same node complete their handshakes in parallel. Both
+   * built distinct, connected {@link Peer} objects because neither saw the other in the PeerList
+   * yet; the first (winner) is already registered. Driving the second (loser) through {@code
+   * setupConnection} must disconnect it — it is otherwise a silent orphan: connected and read by
+   * the selector, but unreachable for outbound because {@code peerList.get(identity)} returns the
+   * winner.
+   */
   @Test
-  public void setupConnectionWithAlreadyConnectedDuplicateHitsDiagnosticBranchAndKeepsOldPeer()
+  public void parallelHandshakeLoserIsDisconnectedAndNotRegistered() throws Exception {
+    ByteBufferPool.init();
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    ConnectionHandler connectionHandler = new ConnectionHandler(serverContext, false);
+
+    NodeId identity = NodeId.generateWithSimpleKey();
+
+    // The winner: a distinct, fully connected peer for this identity is already registered.
+    Peer winner = new Peer("127.0.0.1", 0, identity);
+    winner.setConnected(true);
+    serverContext.getPeerList().add(winner);
+
+    // The loser: a second physical connection from the same identity finishes its handshake.
+    Peer loser = new Peer("127.0.0.1", 0, identity);
+    try (SocketChannel channel = SocketChannel.open()) {
+      PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", channel);
+      peerInHandshake.setPeer(loser);
+      peerInHandshake.setLightClient(true); // skip the Node/DB lookups in setupConnection
+      peerInHandshake.setIdentity(identity.getKademliaId());
+      peerInHandshake.setNodeId(identity);
+      peerInHandshake.setKey(new NoopSelectionKey());
+      connectionHandler.addPeerInHandshake(peerInHandshake);
+
+      connectionHandler.setupConnection(loser, peerInHandshake);
+
+      // The winner stays the registered peer; the loser is NOT registered in its place.
+      Peer registered = serverContext.getPeerList().get(identity.getKademliaId());
+      assertThat(registered)
+          .as("the pre-registered winner must remain the registered peer for this identity")
+          .isSameAs(winner);
+      assertThat(registered)
+          .as("setupConnection must not register the racing duplicate")
+          .isNotSameAs(loser);
+
+      // The core of TD020: the loser must be torn down, not left as a connected, still-reading
+      // orphan.
+      assertThat(loser.isConnected())
+          .as("the losing parallel duplicate must be disconnected, not orphaned")
+          .isFalse();
+      assertThat(channel.isOpen()).as("the losing duplicate's socket must be closed").isFalse();
+      assertThat(winner.isConnected())
+          .as("disconnecting the loser must not touch the winner's connection")
+          .isTrue();
+    }
+  }
+
+  /**
+   * TD019 diagnostic branch: a sequential reconnect where {@code parseHandshake} found the
+   * already-registered peer, so {@code peerOrigin} <em>is</em> that same registered object. {@code
+   * peerList.add()} returns it ({@code oldPeer == peerOrigin}); {@code setupConnection} must leave
+   * it registered and connected (the channel swap already happened in {@code
+   * setupConnectionForPeer}) and must NOT take the TD020 disconnect path.
+   */
+  @Test
+  public void reconnectOfSameRegisteredPeerHitsDiagnosticBranchAndStaysConnected()
       throws Exception {
     ByteBufferPool.init();
     ServerContext serverContext = ServerContext.buildDefaultServerContext();
@@ -34,38 +102,34 @@ public class ConnectionHandlerDuplicateConnectionTest {
 
     NodeId identity = NodeId.generateWithSimpleKey();
 
-    // A peer with this identity is already registered and connected.
-    Peer alreadyConnected = new Peer("127.0.0.1", 0, identity);
-    alreadyConnected.setConnected(true);
-    serverContext.getPeerList().add(alreadyConnected);
+    // This very peer is already registered; a fresh connection for it now completes (reconnect).
+    Peer peer = new Peer("127.0.0.1", 0, identity);
+    serverContext.getPeerList().add(peer);
 
-    // A second physical connection from the same identity now completes its handshake.
-    Peer incoming = new Peer("127.0.0.1", 0, identity);
     try (SocketChannel channel = SocketChannel.open()) {
       PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", channel);
-      peerInHandshake.setPeer(incoming);
+      peerInHandshake.setPeer(peer); // parseHandshake found and reused the registered peer
       peerInHandshake.setLightClient(true); // skip the Node/DB lookups in setupConnection
       peerInHandshake.setIdentity(identity.getKademliaId());
       peerInHandshake.setNodeId(identity);
       peerInHandshake.setKey(new NoopSelectionKey());
       connectionHandler.addPeerInHandshake(peerInHandshake);
 
-      connectionHandler.setupConnection(incoming, peerInHandshake);
+      connectionHandler.setupConnection(peer, peerInHandshake);
 
-      // peerList.add() returned the already-connected peer (the oldPeer diagnostic branch, TD019);
-      // the incoming duplicate was NOT registered in its place.
       Peer registered = serverContext.getPeerList().get(identity.getKademliaId());
       assertThat(registered)
-          .as("the already-connected peer must remain the registered peer for this identity")
-          .isSameAs(alreadyConnected);
-      assertThat(registered)
-          .as("setupConnection must not double-register the incoming duplicate")
-          .isNotSameAs(incoming);
+          .as("the reconnecting peer stays the registered peer for this identity")
+          .isSameAs(peer);
+      assertThat(peer.isConnected())
+          .as("a reconnect must leave the peer connected, not take the TD020 disconnect path")
+          .isTrue();
     }
   }
 
   /**
-   * Minimal {@link SelectionKey} stub: {@code setupConnection} only calls the final {@code attach}.
+   * Minimal {@link SelectionKey} stub: {@code setupConnection} calls the final {@code attach}, and
+   * (on the TD020 disconnect path) {@code Peer.disconnect} calls {@code cancel}.
    */
   private static final class NoopSelectionKey extends SelectionKey {
     @Override


### PR DESCRIPTION
## Problem (TD020)

Two simultaneous inbound connections from the *same* node race through the handshake. Both see `peerList.get(identity) == null` in `ConnectionReaderThread.parseHandshake` (neither is registered yet) and each builds its own, fully-connected `Peer` object. Only the first to reach `peerList.add()` gets registered; the second receives an early-return `oldPeer` **without being registered itself**.

The loser stays `connected` and is read by the selector (its socket/streams were already adopted in `setupConnectionForPeer`, its key attached), but is **unreachable for outbound** because `peerList.get(identity)` returns the winner. Result: a silent, un-healing orphan holding a socket + reader forever, with no log.

## Fix

In `ConnectionHandler.setupConnection`, after `peerList.add(peerOrigin)`: when the returned `oldPeer` is non-null **and a different object** than `peerOrigin`, `peerOrigin` is the race loser (it was not registered) — `disconnect()` it and return. No unregistered, still-reading peer object can survive.

### Why this does not regress the sequential half-open reconnect (T54)

In the sequential reconnect, `parseHandshake` found the already-registered peer and set it as `peerOrigin`, so `peerList.add()` returns that **same object** (`oldPeer == peerOrigin`). The connection swap already happened inside `Peer.setupConnectionForPeer` (PR #271). That case falls to the existing `else-if` diagnostic branch, unchanged. `oldPeer != peerOrigin` (distinct objects, same identity) can *only* arise from the parallel race, so the disconnect is targeted precisely at the orphan case.

### Fix choice: disconnect vs. adopt/swap

Disconnect the loser, not adopt-into-winner. Both racing connections are equally fresh (both just handshook), so keeping the already-registered one is correct and KISS. Adopting the loser's socket into the winner would make two `Peer` objects reference the same `SocketChannel`; the loser's own teardown would then close the socket the winner just adopted. Disconnect avoids that shared-socket hazard entirely.

## Tests

`ConnectionHandlerDuplicateConnectionTest` covers both `oldPeer != null` outcomes:
- **TD020 disconnect path** (distinct objects): loser is disconnected, its socket closed, it is not registered, and the winner's connection is untouched.
- **Reconnect diagnostic path** (same object): peer stays registered and connected, does not take the disconnect path.

Local `mvn verify` green: 405 tests, 0 failures.