### PR TITLE
fix(H5): start KademliaSearchJobHousekeeper so the search blacklist is bounded

### DIFF
--- a/src/main/java/im/redpanda/App.java
+++ b/src/main/java/im/redpanda/App.java
@@ -11,6 +11,7 @@ import im.redpanda.core.Server;
 import im.redpanda.core.ServerContext;
 import im.redpanda.jobs.GMManagerCleanJobs;
 import im.redpanda.jobs.KadRefreshJob;
+import im.redpanda.jobs.KademliaSearchJobHousekeeper;
 import im.redpanda.jobs.NodeConnectionPointsSeenJob;
 import im.redpanda.jobs.NodeInfoSetRefreshJob;
 import im.redpanda.jobs.OhAnnounceJob;
@@ -162,6 +163,9 @@ public class App {
     new SaveJobs(serverContext).start();
     new GMManagerCleanJobs(serverContext).start();
     new KadRefreshJob(serverContext).start();
+    // evicts expired entries from KademliaSearchJob's static search blacklist, which is fed
+    // from inbound (peer-controlled) search requests and would otherwise grow unboundedly
+    new KademliaSearchJobHousekeeper(serverContext).start();
     new NodeInfoSetRefreshJob(serverContext).start();
     new NodeConnectionPointsSeenJob(serverContext).start();
     new UpTimeReporterJob(serverContext).start();

--- a/src/main/java/im/redpanda/jobs/KademliaSearchJob.java
+++ b/src/main/java/im/redpanda/jobs/KademliaSearchJob.java
@@ -32,8 +32,12 @@ public class KademliaSearchJob extends Job {
       new HashMap<KademliaId, Long>();
 
   private static final ReentrantLock kademliaIdSearchBlacklistLock = new ReentrantLock();
-  private static final long BLACKLIST_KEY_FOR = 1000L * 30L;
-  // todo: we need a housekeeper for this hashmap!
+
+  /**
+   * How long a KademliaId stays blacklisted. Expired entries are evicted by {@link
+   * KademliaSearchJobHousekeeper}, which is started in {@code App}.
+   */
+  static final long BLACKLIST_KEY_FOR = 1000L * 30L;
 
   public static final int SEND_TO_NODES = 2;
   private static final int NONE = 0;

--- a/src/main/java/im/redpanda/jobs/KademliaSearchJobHousekeeper.java
+++ b/src/main/java/im/redpanda/jobs/KademliaSearchJobHousekeeper.java
@@ -7,9 +7,18 @@ public class KademliaSearchJobHousekeeper extends Job {
 
   private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
 
+  /**
+   * Run interval of this job. The blacklist entries themselves expire after {@link
+   * KademliaSearchJob#BLACKLIST_KEY_FOR} (30 s), so this interval is the only bound on how many
+   * stale entries the map can hold. Entries are created from inbound, peer-controlled search
+   * requests, so the sweep has to run often enough that a remote peer cannot grow the map
+   * unboundedly. The sweep itself is a single O(n) pass over a small map.
+   */
+  static final long RUN_INTERVAL = 1000L * 60L;
+
   /** This Job maintains the kademliaIdSearchBlacklist from the KademliaSearchJob class. */
   public KademliaSearchJobHousekeeper(ServerContext serverContext) {
-    super(serverContext, 1000L * 60L * 10L, true);
+    super(serverContext, RUN_INTERVAL, true);
   }
 
   @Override
@@ -18,17 +27,19 @@ public class KademliaSearchJobHousekeeper extends Job {
   @Override
   public void work() {
 
-    logger.info("refresh the KadContent");
-
+    int removed;
     KademliaSearchJob.getKademliaIdSearchBlacklistLock().lock();
     try {
-      // todo: remove expired entries
+      long now = System.currentTimeMillis();
+      int sizeBefore = KademliaSearchJob.getKademliaIdSearchBlacklist().size();
       KademliaSearchJob.getKademliaIdSearchBlacklist()
           .entrySet()
-          .removeIf(entry -> entry.getValue() < System.currentTimeMillis());
-
+          .removeIf(entry -> entry.getValue() < now);
+      removed = sizeBefore - KademliaSearchJob.getKademliaIdSearchBlacklist().size();
     } finally {
       KademliaSearchJob.getKademliaIdSearchBlacklistLock().unlock();
     }
+
+    logger.debug("evicted {} expired entries from the KademliaSearchJob blacklist", removed);
   }
 }

--- a/src/main/java/im/redpanda/jobs/KademliaSearchJobHousekeeper.java
+++ b/src/main/java/im/redpanda/jobs/KademliaSearchJobHousekeeper.java
@@ -9,10 +9,10 @@ public class KademliaSearchJobHousekeeper extends Job {
 
   /**
    * Run interval of this job. The blacklist entries themselves expire after {@link
-   * KademliaSearchJob#BLACKLIST_KEY_FOR} (30 s), so this interval is the only bound on how many
-   * stale entries the map can hold. Entries are created from inbound, peer-controlled search
-   * requests, so the sweep has to run often enough that a remote peer cannot grow the map
-   * unboundedly. The sweep itself is a single O(n) pass over a small map.
+   * KademliaSearchJob#BLACKLIST_KEY_FOR}, so this interval is the only bound on how many stale
+   * entries the map can hold. Entries are created from inbound, peer-controlled search requests, so
+   * the sweep has to run often enough that a remote peer cannot grow the map unboundedly. The sweep
+   * itself is a single O(n) pass over a small map.
    */
   static final long RUN_INTERVAL = 1000L * 60L;
 
@@ -32,9 +32,11 @@ public class KademliaSearchJobHousekeeper extends Job {
     try {
       long now = System.currentTimeMillis();
       int sizeBefore = KademliaSearchJob.getKademliaIdSearchBlacklist().size();
+      // <= now, matching KademliaSearchJob.init(), which treats an entry as expired once
+      // `currentTimeMillis - blacklistedTill >= 0`
       KademliaSearchJob.getKademliaIdSearchBlacklist()
           .entrySet()
-          .removeIf(entry -> entry.getValue() < now);
+          .removeIf(entry -> entry.getValue() <= now);
       removed = sizeBefore - KademliaSearchJob.getKademliaIdSearchBlacklist().size();
     } finally {
       KademliaSearchJob.getKademliaIdSearchBlacklistLock().unlock();

--- a/src/test/java/im/redpanda/jobs/KademliaSearchJobHousekeeperTest.java
+++ b/src/test/java/im/redpanda/jobs/KademliaSearchJobHousekeeperTest.java
@@ -48,15 +48,28 @@ public class KademliaSearchJobHousekeeperTest {
     KademliaSearchJob.getKademliaIdSearchBlacklistLock().lock();
     try {
       KademliaSearchJob.getKademliaIdSearchBlacklist().put(expired, now - 1000L);
-      KademliaSearchJob.getKademliaIdSearchBlacklist().put(live, now + 60_000L);
+      // same lifetime the production code hands out
+      KademliaSearchJob.getKademliaIdSearchBlacklist()
+          .put(live, now + KademliaSearchJob.BLACKLIST_KEY_FOR);
     } finally {
       KademliaSearchJob.getKademliaIdSearchBlacklistLock().unlock();
     }
 
     new KademliaSearchJobHousekeeper(null).work();
 
-    assertThat(KademliaSearchJob.getKademliaIdSearchBlacklist()).doesNotContainKey(expired);
-    assertThat(KademliaSearchJob.getKademliaIdSearchBlacklist()).containsKey(live);
+    Map<KademliaId, Long> blacklist = snapshotBlacklist();
+    assertThat(blacklist).doesNotContainKey(expired);
+    assertThat(blacklist).containsKey(live);
+  }
+
+  /** The blacklist is a plain HashMap guarded by its own lock — never read it unsynchronized. */
+  private static Map<KademliaId, Long> snapshotBlacklist() {
+    KademliaSearchJob.getKademliaIdSearchBlacklistLock().lock();
+    try {
+      return new HashMap<>(KademliaSearchJob.getKademliaIdSearchBlacklist());
+    } finally {
+      KademliaSearchJob.getKademliaIdSearchBlacklistLock().unlock();
+    }
   }
 
   /**

--- a/src/test/java/im/redpanda/jobs/KademliaSearchJobHousekeeperTest.java
+++ b/src/test/java/im/redpanda/jobs/KademliaSearchJobHousekeeperTest.java
@@ -1,0 +1,92 @@
+package im.redpanda.jobs;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchRule;
+import im.redpanda.core.KademliaId;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class KademliaSearchJobHousekeeperTest {
+
+  private final Map<KademliaId, Long> blacklistBackup = new HashMap<>();
+
+  @Before
+  public void backupBlacklist() {
+    KademliaSearchJob.getKademliaIdSearchBlacklistLock().lock();
+    try {
+      blacklistBackup.putAll(KademliaSearchJob.getKademliaIdSearchBlacklist());
+      KademliaSearchJob.getKademliaIdSearchBlacklist().clear();
+    } finally {
+      KademliaSearchJob.getKademliaIdSearchBlacklistLock().unlock();
+    }
+  }
+
+  @After
+  public void restoreBlacklist() {
+    KademliaSearchJob.getKademliaIdSearchBlacklistLock().lock();
+    try {
+      KademliaSearchJob.getKademliaIdSearchBlacklist().clear();
+      KademliaSearchJob.getKademliaIdSearchBlacklist().putAll(blacklistBackup);
+    } finally {
+      KademliaSearchJob.getKademliaIdSearchBlacklistLock().unlock();
+    }
+  }
+
+  @Test
+  public void work_evictsExpiredEntriesAndKeepsLiveOnes() {
+    KademliaId expired = new KademliaId();
+    KademliaId live = new KademliaId();
+
+    long now = System.currentTimeMillis();
+    KademliaSearchJob.getKademliaIdSearchBlacklistLock().lock();
+    try {
+      KademliaSearchJob.getKademliaIdSearchBlacklist().put(expired, now - 1000L);
+      KademliaSearchJob.getKademliaIdSearchBlacklist().put(live, now + 60_000L);
+    } finally {
+      KademliaSearchJob.getKademliaIdSearchBlacklistLock().unlock();
+    }
+
+    new KademliaSearchJobHousekeeper(null).work();
+
+    assertThat(KademliaSearchJob.getKademliaIdSearchBlacklist()).doesNotContainKey(expired);
+    assertThat(KademliaSearchJob.getKademliaIdSearchBlacklist()).containsKey(live);
+  }
+
+  /**
+   * The blacklist is fed from inbound, peer-controlled search requests, so the eviction interval is
+   * the only bound on its size. It must stay in the same order of magnitude as the entry lifetime.
+   */
+  @Test
+  public void runIntervalIsBoundedByTheBlacklistLifetime() {
+    assertThat(KademliaSearchJobHousekeeper.RUN_INTERVAL)
+        .isLessThanOrEqualTo(4L * KademliaSearchJob.BLACKLIST_KEY_FOR);
+  }
+
+  /**
+   * Regression for the bug hunt finding "housekeeper is never started": the class existed and was
+   * correct, but nothing instantiated it, so the blacklist grew for the whole process lifetime.
+   */
+  @Test
+  public void housekeeperIsWiredUpInApp() {
+    JavaClasses importedClasses = new ClassFileImporter().importPackages("im.redpanda");
+
+    ArchRule rule =
+        classes()
+            .that()
+            .haveFullyQualifiedName("im.redpanda.App")
+            .should()
+            .dependOnClassesThat()
+            .haveFullyQualifiedName("im.redpanda.jobs.KademliaSearchJobHousekeeper")
+            .because(
+                "the KademliaSearchJob blacklist is only bounded if the housekeeper is started");
+
+    rule.check(importedClasses);
+  }
+}


### PR DESCRIPTION
Bug-hunt finding **H5** (`plans/bug-hunt-2026-07-26.md`).

## Problem

`KademliaSearchJobHousekeeper` evicts expired entries from `KademliaSearchJob`'s static
`kademliaIdSearchBlacklist` — but nothing ever instantiated or started it.
`App.startPermanentJobsWithServerContext()` starts every other permanent job and omits this one,
so entries were only ever *added* (`KademliaSearchJob.init()`).

That add path is reached from inbound, peer-controlled search requests (`GMParser`), so a remote
peer could drive arbitrary distinct `KademliaId`s into a static `HashMap` that grew for the whole
process lifetime.

## Changes

- start `KademliaSearchJobHousekeeper` in `App`
- **eviction interval verified and tightened**: entries expire after `BLACKLIST_KEY_FOR` = 30 s, and
  the housekeeper interval is the only bound on the map size. 10 min meant up to 10 min of
  peer-driven entries were retained; now 1 min. The sweep is a single `removeIf` pass over a small
  map, so the extra runs are free.
- fix the copy-pasted log line (`"refresh the KadContent"`), log the eviction count at `debug`
  instead of `info`
- drop the obsolete `// todo: we need a housekeeper for this hashmap!`

## Tests

`KademliaSearchJobHousekeeperTest`:
- `work()` evicts expired entries and keeps live ones
- the run interval stays bounded relative to the entry lifetime
- ArchUnit rule: `App` must depend on `KademliaSearchJobHousekeeper` — this is the actual
  regression guard, since the class itself was always correct, just never wired up

Full local suite: `Tests run: 408, Failures: 0, Errors: 0, Skipped: 1`.