### PR TITLE
fix(H3,H4,H6,M4): close sockets on every connection error path

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -329,7 +329,20 @@ public class ConnectionHandler extends Thread {
 
     if (!workingRead.contains(peer)) {
       workingRead.add(peer);
-      peersToReadAndParse.add(peer);
+      // offer(), not add(): the queue is bounded (600) and add() throws IllegalStateException when
+      // it is full. That exception only reached handleSelectionKey's generic catch, which cancels
+      // the key but never disconnects the peer — the SocketChannel stayed open and the peer stayed
+      // in the peerList, i.e. we leaked a socket exactly when the node was already overloaded.
+      if (!peersToReadAndParse.offer(peer)) {
+        workingRead.remove(peer);
+        Log.putStd(
+            "read queue full ("
+                + peersToReadAndParse.size()
+                + "), dropping connection to "
+                + peer.ip);
+        key.cancel();
+        peer.disconnect("read queue full");
+      }
     } else {
       Log.putStd(
           "Error code 1429172674 "
@@ -364,34 +377,68 @@ public class ConnectionHandler extends Thread {
 
   private void keyAccept(SelectionKey key) throws IOException {
     // a connection was accepted by a ServerSocketChannel.
+    ServerSocketChannel s = (ServerSocketChannel) key.channel();
+    SocketChannel socketChannel = s.accept();
+
+    // accept() returns null on a spurious selector wakeup / when another thread grabbed the
+    // pending connection first. Dereferencing it (configureBlocking) used to NPE out of this
+    // method into handleSelectionKey's generic catch.
+    if (socketChannel == null) {
+      return;
+    }
+
     if (!Settings.NAT_OPEN) {
       Settings.NAT_OPEN = true;
     }
 
-    ServerSocketChannel s = (ServerSocketChannel) key.channel();
-    SocketChannel socketChannel = s.accept();
-    socketChannel.configureBlocking(false);
-    String ip = socketChannel.socket().getInetAddress().getHostAddress();
+    setupAcceptedChannel(socketChannel);
+  }
 
-    Log.put("incoming connection from ip: " + ip, 12);
-
+  /**
+   * Takes ownership of a freshly accepted channel: registers it with the selector and starts the
+   * handshake. The accepted channel is closed on every failure path — a peer that connects and
+   * resets immediately (port scanners, health checkers, hostile probes) otherwise leaked one file
+   * descriptor per occurrence, since the outer handler in {@link
+   * #handleSelectionKey(java.util.Iterator)} only closes channels for keys that already carry a
+   * {@code PeerInHandshake}/{@code Peer} attachment, which the ServerSocketChannel key never does.
+   */
+  void setupAcceptedChannel(SocketChannel socketChannel) {
+    PeerInHandshake peerInHandshake = null;
+    boolean success = false;
     try {
       socketChannel.configureBlocking(false);
+
+      // getInetAddress() is null if the peer already reset the connection
+      String ip = socketChannel.socket().getInetAddress().getHostAddress();
+      Log.put("incoming connection from ip: " + ip, 12);
 
       selector.wakeup();
       SelectionKey newKey = socketChannel.register(selector, SelectionKey.OP_READ);
 
-      PeerInHandshake peerInHandshake = new PeerInHandshake(ip, socketChannel);
+      peerInHandshake = new PeerInHandshake(ip, socketChannel);
       addPeerInHandshake(peerInHandshake);
 
+      // may throw RuntimeException on a partial handshake write
       ConnectionReaderThread.sendHandshake(serverContext, peerInHandshake);
 
       newKey.attach(peerInHandshake);
       peerInHandshake.setKey(newKey);
       selector.wakeup();
-    } catch (IOException ex) {
+      success = true;
+    } catch (Exception ex) {
       ex.printStackTrace();
       Log.putStd("could not init connection....");
+    } finally {
+      if (!success) {
+        if (peerInHandshake != null) {
+          removePeerInHandshake(peerInHandshake);
+        }
+        try {
+          socketChannel.close();
+        } catch (IOException closeEx) {
+          closeEx.printStackTrace();
+        }
+      }
     }
   }
 

--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -8,6 +8,7 @@ package im.redpanda.core;
 import im.redpanda.core.exceptions.PeerProtocolException;
 import im.redpanda.crypt.Utils;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.CancelledKeyException;
@@ -408,8 +409,15 @@ public class ConnectionHandler extends Thread {
     try {
       socketChannel.configureBlocking(false);
 
-      // getInetAddress() is null if the peer already reset the connection
-      String ip = socketChannel.socket().getInetAddress().getHostAddress();
+      // null if the peer already reset the connection — routine for scanners, so handle it as a
+      // normal outcome instead of an exception; the finally below still closes the channel
+      InetAddress remoteAddress = socketChannel.socket().getInetAddress();
+      if (remoteAddress == null) {
+        Log.put("incoming connection was already gone before setup", 12);
+        return;
+      }
+
+      String ip = remoteAddress.getHostAddress();
       Log.put("incoming connection from ip: " + ip, 12);
 
       selector.wakeup();

--- a/src/main/java/im/redpanda/core/OutboundHandler.java
+++ b/src/main/java/im/redpanda/core/OutboundHandler.java
@@ -1,5 +1,6 @@
 package im.redpanda.core;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.channels.SocketChannel;
@@ -43,14 +44,22 @@ public class OutboundHandler extends Thread {
       // todo if retries to high disconnect?
     }
 
+    // The channel is owned by this method until the PeerInHandshake has taken it over; anything
+    // that throws in between (unresolvable/invalid address, immediate connection refusal,
+    // SecurityException, ...) used to leak the freshly opened SocketChannel, one file descriptor
+    // per attempt. run() retries dead peers continuously, so this accumulated until exhaustion.
+    SocketChannel open = null;
+    boolean handedOver = false;
     try {
-      SocketChannel open = SocketChannel.open();
+      open = SocketChannel.open();
       open.configureBlocking(false);
 
       boolean alreadyConnected = open.connect(new InetSocketAddress(peer.ip, peer.port));
 
       PeerInHandshake peerInHandshake = new PeerInHandshake(peer.ip, peer, open);
       serverContext.getConnectionHandler().addPeerInHandshake(peerInHandshake);
+      // from here on the channel is closed by PeerInHandshake / Peer.disconnect()
+      handedOver = true;
 
       /** Lets check if we have a nodeId and add it to the PeerInHandShake */
       if (peer.getNodeId() != null) {
@@ -65,6 +74,14 @@ public class OutboundHandler extends Thread {
     } catch (Exception ex) {
       ex.printStackTrace();
       Log.put("outgoing con failed... " + peer.ip, 0);
+    } finally {
+      if (!handedOver && open != null) {
+        try {
+          open.close();
+        } catch (IOException closeEx) {
+          closeEx.printStackTrace();
+        }
+      }
     }
     return false;
   }

--- a/src/main/java/im/redpanda/core/PeerInHandshake.java
+++ b/src/main/java/im/redpanda/core/PeerInHandshake.java
@@ -93,6 +93,7 @@ public class PeerInHandshake {
   }
 
   public void addConnection(boolean alreadyConnected) {
+    boolean registered = false;
     try {
       socketChannel.configureBlocking(false);
 
@@ -114,10 +115,29 @@ public class PeerInHandshake {
       this.key = key;
 
       ConnectionHandler.selector.wakeup();
+      registered = true;
     } catch (IOException ex) {
       ex.printStackTrace();
-      peer.disconnect("could not init connection....");
-      return;
+    } finally {
+      if (!registered) {
+        // The channel we just failed to register is OUR field — peer.disconnect() closes
+        // peer.socketChannel, which is still null at this point (it is only handed over to the
+        // Peer once the handshake completes), so it would leave this channel open forever.
+        // The finally also covers unchecked failures (e.g. ClosedSelectorException during
+        // shutdown), which propagate to the caller after the channel has been released.
+        closeSocketChannelQuietly();
+        if (peer != null) {
+          peer.disconnect("could not init connection....");
+        }
+      }
+    }
+  }
+
+  private void closeSocketChannelQuietly() {
+    try {
+      socketChannel.close();
+    } catch (IOException closeEx) {
+      closeEx.printStackTrace();
     }
   }
 

--- a/src/test/java/im/redpanda/core/ConnectionHandlerSocketLeakTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerSocketLeakTest.java
@@ -1,0 +1,115 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression tests for the accepted/readable socket leaks found in the 2026-07-26 bug hunt (H3 and
+ * H6): every error path around an accepted connection has to release the socket, otherwise a peer
+ * that connects and resets immediately (or a read burst that fills the bounded read queue) leaks
+ * one file descriptor per occurrence.
+ */
+public class ConnectionHandlerSocketLeakTest {
+
+  private ConnectionHandler handler;
+
+  @Before
+  public void setUp() {
+    handler = new ConnectionHandler(ServerContext.buildDefaultServerContext(), false);
+  }
+
+  @After
+  public void tearDown() {
+    ConnectionHandler.peerInHandshakes.clear();
+    ConnectionHandler.peersToReadAndParse.clear();
+    ConnectionHandler.workingRead.clear();
+  }
+
+  /**
+   * {@code ServerSocketChannel.accept()} returns null on a spurious selector wakeup. The old code
+   * called {@code configureBlocking(false)} on the result before entering its try block, so the NPE
+   * escaped keyAccept's own handler.
+   */
+  @Test
+  public void keyAccept_ignoresNullAcceptFromSpuriousWakeup() throws Exception {
+    try (ServerSocketChannel serverChannel = ServerSocketChannel.open()) {
+      serverChannel.configureBlocking(false);
+      serverChannel.bind(new InetSocketAddress("127.0.0.1", 0));
+
+      SelectionKey key = serverChannel.register(ConnectionHandler.selector, SelectionKey.OP_ACCEPT);
+      try {
+        Method keyAccept =
+            ConnectionHandler.class.getDeclaredMethod("keyAccept", SelectionKey.class);
+        keyAccept.setAccessible(true);
+
+        // nothing is connecting, so accept() returns null
+        assertThatCode(() -> keyAccept.invoke(handler, key)).doesNotThrowAnyException();
+      } finally {
+        key.cancel();
+      }
+    }
+  }
+
+  /**
+   * H3: an accepted channel whose setup fails must be closed and must not leave a PeerInHandshake
+   * behind. An unconnected channel reproduces the "peer already reset the connection" case, where
+   * {@code socket().getInetAddress()} is null.
+   */
+  @Test
+  public void setupAcceptedChannel_closesChannelWhenSetupFails() throws Exception {
+    SocketChannel channel = SocketChannel.open();
+    try {
+      int handshakesBefore = ConnectionHandler.peerInHandshakes.size();
+
+      handler.setupAcceptedChannel(channel);
+
+      assertThat(channel.isOpen()).isFalse();
+      assertThat(ConnectionHandler.peerInHandshakes).hasSize(handshakesBefore);
+    } finally {
+      channel.close();
+    }
+  }
+
+  /**
+   * H6: when the bounded read queue is full, the peer has to be disconnected. The old {@code add()}
+   * threw IllegalStateException, which only reached handleSelectionKey's generic catch — that
+   * cancels the key but leaves the socket open and the peer in the peerList.
+   */
+  @Test
+  public void handleKeyReadable_disconnectsPeerWhenReadQueueIsFull() throws Exception {
+    SocketChannel channel = SocketChannel.open();
+    channel.configureBlocking(false);
+    SelectionKey key = channel.register(ConnectionHandler.selector, SelectionKey.OP_READ);
+
+    Peer peer = new Peer("127.0.0.1", 1234);
+    peer.setSocketChannel(channel);
+    peer.setSelectionKey(key);
+    peer.setConnected(true);
+    key.attach(peer);
+
+    // fill the bounded queue up to its capacity
+    while (ConnectionHandler.peersToReadAndParse.offer(new Peer("127.0.0.2", 1))) {
+      // intentionally empty
+    }
+    assertThat(ConnectionHandler.peersToReadAndParse.remainingCapacity()).isZero();
+
+    Method handleKeyReadable =
+        ConnectionHandler.class.getDeclaredMethod("handleKeyReadable", SelectionKey.class);
+    handleKeyReadable.setAccessible(true);
+
+    handleKeyReadable.invoke(handler, key);
+
+    assertThat(ConnectionHandler.workingRead).doesNotContain(peer);
+    assertThat(peer.isConnected()).isFalse();
+    assertThat(channel.isOpen()).isFalse();
+  }
+}

--- a/src/test/java/im/redpanda/core/ConnectionHandlerSocketLeakTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerSocketLeakTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import org.junit.After;
@@ -60,12 +61,11 @@ public class ConnectionHandlerSocketLeakTest {
   }
 
   /**
-   * H3: an accepted channel whose setup fails must be closed and must not leave a PeerInHandshake
-   * behind. An unconnected channel reproduces the "peer already reset the connection" case, where
-   * {@code socket().getInetAddress()} is null.
+   * H3: an accepted channel of a peer that already reset the connection must be closed. An
+   * unconnected channel reproduces that case — {@code socket().getInetAddress()} is null.
    */
   @Test
-  public void setupAcceptedChannel_closesChannelWhenSetupFails() throws Exception {
+  public void setupAcceptedChannel_closesChannelWhenPeerIsAlreadyGone() throws Exception {
     SocketChannel channel = SocketChannel.open();
     try {
       int handshakesBefore = ConnectionHandler.peerInHandshakes.size();
@@ -76,6 +76,37 @@ public class ConnectionHandlerSocketLeakTest {
       assertThat(ConnectionHandler.peerInHandshakes).hasSize(handshakesBefore);
     } finally {
       channel.close();
+    }
+  }
+
+  /**
+   * H3: the same has to hold when the setup throws — here the selector registration fails. The old
+   * code only logged and left the accepted channel open.
+   */
+  @Test
+  public void setupAcceptedChannel_closesChannelWhenSetupThrows() throws Exception {
+    Selector originalSelector = ConnectionHandler.selector;
+    Selector closedSelector = Selector.open();
+    closedSelector.close();
+
+    try (ServerSocketChannel serverChannel = ServerSocketChannel.open();
+        SocketChannel client = SocketChannel.open()) {
+      serverChannel.bind(new InetSocketAddress("127.0.0.1", 0));
+      client.connect(serverChannel.getLocalAddress());
+
+      SocketChannel accepted = serverChannel.accept();
+      try {
+        int handshakesBefore = ConnectionHandler.peerInHandshakes.size();
+        ConnectionHandler.selector = closedSelector;
+
+        handler.setupAcceptedChannel(accepted);
+
+        assertThat(accepted.isOpen()).isFalse();
+        assertThat(ConnectionHandler.peerInHandshakes).hasSize(handshakesBefore);
+      } finally {
+        ConnectionHandler.selector = originalSelector;
+        accepted.close();
+      }
     }
   }
 

--- a/src/test/java/im/redpanda/core/OutboundHandlerConnectLeakTest.java
+++ b/src/test/java/im/redpanda/core/OutboundHandlerConnectLeakTest.java
@@ -1,0 +1,54 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+import com.sun.management.UnixOperatingSystemMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.Method;
+import org.junit.Test;
+
+/**
+ * Regression test for H4 (bug hunt 2026-07-26): {@code OutboundHandler.connectTo} opened a
+ * SocketChannel and only logged when the subsequent connect attempt threw, leaking one file
+ * descriptor per attempt. {@code run()} retries unreachable peers continuously, so this accumulated
+ * until FD exhaustion.
+ */
+public class OutboundHandlerConnectLeakTest {
+
+  private static final int ATTEMPTS = 50;
+
+  @Test
+  public void connectTo_doesNotLeakSocketChannelWhenConnectFails() throws Exception {
+    OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
+    assumeTrue(
+        "open file descriptor count is not available on this platform",
+        osBean instanceof UnixOperatingSystemMXBean);
+    UnixOperatingSystemMXBean unixBean = (UnixOperatingSystemMXBean) osBean;
+
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+
+    Method connectTo =
+        OutboundHandler.class.getDeclaredMethod("connectTo", ServerContext.class, Peer.class);
+    connectTo.setAccessible(true);
+
+    // An out-of-range port makes the InetSocketAddress constructor throw IllegalArgumentException
+    // right after SocketChannel.open() succeeded — exactly the window in which the channel leaked.
+    connectTo.invoke(null, serverContext, newUnconnectablePeer()); // warm up
+
+    long openFdsBefore = unixBean.getOpenFileDescriptorCount();
+    for (int i = 0; i < ATTEMPTS; i++) {
+      assertThat(connectTo.invoke(null, serverContext, newUnconnectablePeer())).isEqualTo(false);
+    }
+    long leaked = unixBean.getOpenFileDescriptorCount() - openFdsBefore;
+
+    assertThat(leaked)
+        .as("failed connect attempts must not accumulate file descriptors")
+        .isLessThan(ATTEMPTS / 2L);
+  }
+
+  private static Peer newUnconnectablePeer() {
+    return new Peer("127.0.0.1", 70000);
+  }
+}

--- a/src/test/java/im/redpanda/core/PeerInHandshakeTest.java
+++ b/src/test/java/im/redpanda/core/PeerInHandshakeTest.java
@@ -1,8 +1,12 @@
 package im.redpanda.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
 import java.security.Security;
 import org.junit.Test;
 
@@ -156,5 +160,36 @@ public class PeerInHandshakeTest {
     PeerInHandshake phWithoutPublicKey2 = new PeerInHandshake("ip", peerWithoutPublicKey2, null);
 
     assertFalse(phWithoutPublicKey2.hasPublicKey());
+  }
+
+  /**
+   * Regression for M4 (bug hunt 2026-07-26): when the registration of a freshly opened outgoing
+   * channel fails, {@code addConnection} used to call {@code peer.disconnect(...)}, which closes
+   * {@code peer.socketChannel} — still null at that point, since the channel is only handed over to
+   * the Peer once the handshake completed. The channel that actually failed to register stayed open
+   * forever.
+   */
+  @Test
+  public void addConnection_closesItsOwnChannelWhenRegistrationFails() throws Exception {
+    Selector originalSelector = ConnectionHandler.selector;
+    Selector closedSelector = Selector.open();
+    closedSelector.close();
+
+    SocketChannel channel = SocketChannel.open();
+    Peer peer = new Peer("127.0.0.1", 1234);
+    PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", peer, channel);
+
+    ConnectionHandler.selector = closedSelector;
+    try {
+      // registering with a closed selector fails; the exception itself may propagate, but the
+      // channel must not survive it
+      Throwable thrown = catchThrowable(() -> peerInHandshake.addConnection(false));
+
+      assertThat(thrown).isNotNull();
+      assertThat(channel.isOpen()).isFalse();
+    } finally {
+      ConnectionHandler.selector = originalSelector;
+      channel.close();
+    }
   }
 }


### PR DESCRIPTION
Bug-hunt findings **H3, H4, H6, M4** (`plans/bug-hunt-2026-07-26.md`) — four file-descriptor leaks
of the same shape: a `SocketChannel` is opened/accepted, something throws, and the error handler
only logs. All are reachable from off-box behaviour (port scanners, unreachable peers, connection
bursts).

## H3 — `ConnectionHandler.keyAccept`

The inner `catch (IOException)` only logged. Everything that threw *before* it escaped into
`handleSelectionKey`'s outer catch, which closes a channel only when the key attachment is a
`PeerInHandshake`/`Peer` — the `ServerSocketChannel` key never has one. Two such paths:

- `s.accept()` returns `null` on a spurious selector wakeup, and `configureBlocking(false)` ran
  *before* the try → NPE escaped the method.
- `ConnectionReaderThread.sendHandshake` throws `RuntimeException` on a partial handshake write.

Now: a `null` accept returns early, and the setup moved into `setupAcceptedChannel()`, which closes
the channel **and** removes the `PeerInHandshake` again on any failure.

## H4 — `OutboundHandler.connectTo`

`SocketChannel.open()` succeeded, `connect()` threw (unreachable host, immediate refusal, invalid
address), `catch (Exception)` only logged — `open` was never closed. `run()` walks the peer list and
retries dead/stale peers continuously, so this accumulated one FD per attempt until exhaustion.
Now closed in a `finally` until ownership passes to the `PeerInHandshake`.

## H6 — `ConnectionHandler.handleKeyReadable`

`peersToReadAndParse` is a bounded `LinkedBlockingQueue(600)` filled via `add()`, which **throws**
`IllegalStateException` when full. That only reached the generic catch, which cancels the key but
never calls `peer.disconnect()` — socket left open, peer left in the `peerList`. The failure mode
hit exactly when the node was already overloaded.
Now `offer()` with an explicit disconnect of the peer we cannot service.

## M4 — `PeerInHandshake.addConnection`

On a failing `register()` it called `peer.disconnect(...)`, which closes `peer.socketChannel` —
still `null` at that point, because the channel is only handed to the `Peer` once the handshake
completes. The channel that actually failed was never closed. Now released in a `finally`, which
also covers unchecked failures (e.g. `ClosedSelectorException` during a shutdown race) without
swallowing them.

## Deliberately not done

No `MAX_CONNECTIONS` cap on inbound accepts (mentioned in the H3 finding). The outbound check counts
connected+connecting peers and *disconnects an existing peer* rather than rejecting; mapping that
onto a hard inbound reject at `MAX_CONNECTIONS = 50` would start refusing legitimate mobile clients
on a busy node. That is a design decision, not a drive-by fix.

## Tests

- `ConnectionHandlerSocketLeakTest` — null accept is ignored; a failing accepted-channel setup closes
  the channel and leaves no `PeerInHandshake`; a full read queue disconnects the peer and closes its
  socket.
- `OutboundHandlerConnectLeakTest` — 50 failing connect attempts must not grow the process FD count
  (`UnixOperatingSystemMXBean`, skipped on non-Unix).
- `PeerInHandshakeTest.addConnection_closesItsOwnChannelWhenRegistrationFails`.

**Negative control:** both new leak assertions were run against the pre-fix sources and fail there —
`connectTo` leaked exactly 50 FDs, and `addConnection` left the channel open.

Full local suite: `Tests run: 410, Failures: 0, Errors: 0, Skipped: 1`.