### PR TITLE
fix(L6): restore the 10 MB gate for the KadStore eviction sweep

### DIFF
--- a/src/main/java/im/redpanda/kademlia/KadStoreManager.java
+++ b/src/main/java/im/redpanda/kademlia/KadStoreManager.java
@@ -25,7 +25,13 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public class KadStoreManager {
 
-  private static final int MIN_SIZE = 1024 * 1024 * 10 * 0; // size of content without key
+  /**
+   * Total stored content size (without keys) above which the periodic entry eviction sweep runs. A
+   * trailing {@code * 0} used to zero this out, so the sweep ran on every put once the store held
+   * anything at all, instead of only once it exceeds 10 MB.
+   */
+  private static final int MIN_SIZE = 1024 * 1024 * 10;
+
   private static final long MAX_KEEP_TIME = 1000L * 60L * 60L * 24L * 14L; // 7 days
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 

--- a/src/test/java/im/redpanda/kademlia/KadStoreManagerMinSizeTest.java
+++ b/src/test/java/im/redpanda/kademlia/KadStoreManagerMinSizeTest.java
@@ -1,0 +1,98 @@
+package im.redpanda.kademlia;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.ServerContext;
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression test for L6 (bug hunt 2026-07-26): {@code MIN_SIZE} was declared as {@code 1024 * 1024
+ * * 10 * 0}, so the periodic entry-eviction sweep was gated on {@code size > 0} and ran on every
+ * put (throttled to ~10 s) instead of only once the store exceeds 10 MB.
+ */
+public class KadStoreManagerMinSizeTest {
+
+  private static final long ONE_DAY_MS = 1000L * 60L * 60L * 24L;
+
+  private ServerContext serverContext;
+  private KadStoreManager kadStoreManager;
+
+  @Before
+  public void setUp() throws Exception {
+    serverContext = ServerContext.buildDefaultServerContext();
+    kadStoreManager = new KadStoreManager(serverContext);
+    resetStore();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    resetStore();
+  }
+
+  /** Below the threshold the sweep must not run, so even a long-expired entry survives a put. */
+  @Test
+  public void put_doesNotSweepWhileStoreIsBelowMinSize() throws Exception {
+    KadContent ancient = storeDirectly(100L * ONE_DAY_MS);
+
+    assertThat(kadStoreManager.put(freshContent())).isTrue();
+
+    assertThat(kadStoreManager.get(ancient.getId())).isNotNull();
+  }
+
+  /** Above the threshold the sweep runs and evicts entries past their keepTime. */
+  @Test
+  public void put_sweepsOnceStoreExceedsMinSize() throws Exception {
+    KadContent ancient = storeDirectly(100L * ONE_DAY_MS);
+    setStaticField("size", 11 * 1024 * 1024);
+
+    assertThat(kadStoreManager.put(freshContent())).isTrue();
+
+    assertThat(kadStoreManager.get(ancient.getId())).isNull();
+  }
+
+  private KadContent freshContent() {
+    return new KadContent(System.currentTimeMillis(), randomKey(), new byte[16]);
+  }
+
+  /**
+   * Puts an entry straight into the backing map: {@code put()} itself rejects anything older than
+   * MAX_KEEP_TIME, and this entry has to be older than any possible keepTime.
+   */
+  @SuppressWarnings("unchecked")
+  private KadContent storeDirectly(long ageMillis) throws Exception {
+    KadContent content =
+        new KadContent(System.currentTimeMillis() - ageMillis, randomKey(), new byte[16]);
+
+    Field entriesField = KadStoreManager.class.getDeclaredField("entries");
+    entriesField.setAccessible(true);
+    ((Map<KademliaId, KadContent>) entriesField.get(null)).put(content.getId(), content);
+    setStaticField("size", content.getContent().length);
+
+    return content;
+  }
+
+  private static byte[] randomKey() {
+    return new im.redpanda.core.NodeId().exportPublic();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void resetStore() throws Exception {
+    Field entriesField = KadStoreManager.class.getDeclaredField("entries");
+    entriesField.setAccessible(true);
+    ((Map<KademliaId, KadContent>) entriesField.get(null)).clear();
+
+    setStaticField("size", 0);
+    setStaticField("lastCleanup", 0L);
+  }
+
+  private static void setStaticField(String name, Object value) throws Exception {
+    Field field = KadStoreManager.class.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(null, value);
+  }
+}


### PR DESCRIPTION
Bug-hunt finding **L6** (`plans/bug-hunt-2026-07-26.md`).

```java
private static final int MIN_SIZE = 1024 * 1024 * 10 * 0; // size of content without key
```

The trailing `* 0` zeroed the intended 10 MB threshold, so `if (size > MIN_SIZE && ...)` held as
soon as the store contained anything at all and the O(n) eviction sweep ran on every `put()`
(throttled to ~10 s) instead of only once the store exceeds 10 MB.

## Trade-off (please sanity-check during triage)

With the gate restored, a store below 10 MB no longer evicts entries past their `keepTime`, so a
small node can keep serving a record older than `MAX_KEEP_TIME` — `get()` does not filter by age.
That *is* the documented intent of the gate, and `put()` still refuses to accept anything that old
from the network, so nothing stale can be re-injected. But if we would rather have time-based expiry
on every node regardless of size, the correct fix is to **drop** the size gate (keeping the 10 s
throttle), not to restore it. I did not want to make that call inside a quick-win PR.

## Tests

`KadStoreManagerMinSizeTest` covers the gate in both directions:
- below the threshold an entry aged 100 days survives a put (no sweep)
- with `size` pushed above 10 MB the same entry is evicted

**Negative control:** with `* 0` put back, the first test fails.

Full local suite: `Tests run: 407, Failures: 0, Errors: 0, Skipped: 1`.