### PR TITLE
fix(H7,M1,M2): take the missing locks on the node graph and the peer list

### DIFF
--- a/src/main/java/im/redpanda/core/PeerList.java
+++ b/src/main/java/im/redpanda/core/PeerList.java
@@ -51,49 +51,63 @@ public class PeerList {
    * @return old peer, null if no old peer or old peer null.
    */
   public Peer add(Peer peer) {
-    Peer oldPeer = null;
+    // The duplicate lookups below used to run without any lock while other threads structurally
+    // modified the same plain HashMaps under the write lock (remove(), updateKademliaId(),
+    // addPeer()). An unsynchronized read during a put/resize/treeify is undefined behaviour:
+    // false-negative miss, a torn `oldPeer`, or an NPE inside HashMap.get. add() is called
+    // concurrently from the reader threads, the incoming handler and the outbound thread, so the
+    // whole check-and-add now runs under the write lock — which also makes it atomic, closing the
+    // check-then-add TOCTOU that let two threads both pass the duplicate check for the same peer.
+    // The write lock (not a read lock for the lookups) is required precisely because we must not
+    // release it between the check and addPeer(), and because ReentrantReadWriteLock cannot
+    // upgrade a read lock to a write lock. addPeer() re-acquires it reentrantly.
+    readWriteLock.writeLock().lock();
+    try {
+      Peer oldPeer = null;
 
-    // we have to check if the peer is already in the PeerList, for this we use the
-    // HashMaps since they are much faster
-    if (peer.getKademliaId() != null) {
-      oldPeer = peerHashMap.get(peer.getKademliaId());
-      if (oldPeer != null) {
-        // Peer with same KademliaId exists already
-        Log.put("Peer with same KademliaId exists already", 100);
-        return oldPeer;
-      } else {
-        /**
-         * Peer has a NodeId but was not found in list. If we would return without checking for ip
-         * and port, fast connections to same peer might make a problem.
-         */
-      }
-    }
-
-    /**
-     * We allow peers without connection details (ip,port) in the PeerList, since after a wipe of
-     * data the new Node has the same (ip,port) but different Identity. The (ip,port) will then be
-     * removed from the old Peer. Since we allow Peers without (ip,port) in general we allow to add
-     * Peers without (ip,port) here.
-     */
-    if (peer.getIp() != null) {
-      oldPeer = peerlistIpPort.get(getIpPortHash(peer));
-      if (oldPeer != null) {
-        // Peer with same Ip+Port exists already
-
-        if (peer.getNodeId() == null) {
-          // new peer to add has no node id, lets not add it
+      // we have to check if the peer is already in the PeerList, for this we use the
+      // HashMaps since they are much faster
+      if (peer.getKademliaId() != null) {
+        oldPeer = peerHashMap.get(peer.getKademliaId());
+        if (oldPeer != null) {
+          // Peer with same KademliaId exists already
+          Log.put("Peer with same KademliaId exists already", 100);
           return oldPeer;
-        }
-
-        if (oldPeer.getNodeId() == null || !oldPeer.getNodeId().equals(peer.getNodeId())) {
         } else {
-          return oldPeer;
+          /**
+           * Peer has a NodeId but was not found in list. If we would return without checking for ip
+           * and port, fast connections to same peer might make a problem.
+           */
         }
       }
-    }
 
-    oldPeer = addPeer(peer);
-    return oldPeer;
+      /**
+       * We allow peers without connection details (ip,port) in the PeerList, since after a wipe of
+       * data the new Node has the same (ip,port) but different Identity. The (ip,port) will then be
+       * removed from the old Peer. Since we allow Peers without (ip,port) in general we allow to
+       * add Peers without (ip,port) here.
+       */
+      if (peer.getIp() != null) {
+        oldPeer = peerlistIpPort.get(getIpPortHash(peer));
+        if (oldPeer != null) {
+          // Peer with same Ip+Port exists already
+
+          if (peer.getNodeId() == null) {
+            // new peer to add has no node id, lets not add it
+            return oldPeer;
+          }
+
+          if (oldPeer.getNodeId() == null || !oldPeer.getNodeId().equals(peer.getNodeId())) {
+          } else {
+            return oldPeer;
+          }
+        }
+      }
+
+      return addPeer(peer);
+    } finally {
+      readWriteLock.writeLock().unlock();
+    }
   }
 
   @Nullable

--- a/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
+++ b/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
@@ -10,6 +10,7 @@ import im.redpanda.jobs.OhResolveJob;
 import im.redpanda.kademlia.PeerComparator;
 import im.redpanda.outbound.OutboundService;
 import im.redpanda.store.NodeEdge;
+import im.redpanda.store.NodeStore;
 import java.util.ArrayList;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -350,12 +351,17 @@ public final class OhForwarder {
       // The peer-list read lock above is already released, so no lock is nested here; the
       // established order elsewhere (NodeStore -> PeerList, see NodeStore.addServerEdges) is
       // therefore not violated.
-      Lock nodeStoreLock = serverContext.getNodeStore().getReadWriteLock().readLock();
+      // The NodeStore reference is resolved ONCE and lock, target lookup and graph all come from
+      // it: NodeStore.saveToDisk() replaces serverContext's NodeStore on its recovery path, so
+      // re-reading getNodeStore() per access could guard one store while traversing another's
+      // graph, defeating the mutual exclusion this lock exists for.
+      NodeStore nodeStore = serverContext.getNodeStore();
+      Lock nodeStoreLock = nodeStore.getReadWriteLock().readLock();
       GMParser.RouteSelection selection;
       nodeStoreLock.lock();
       try {
-        Node targetNode = serverContext.getNodeStore().get(targetNodeId);
-        org.jgrapht.Graph<Node, NodeEdge> graph = serverContext.getNodeStore().getNodeGraph();
+        Node targetNode = nodeStore.get(targetNodeId);
+        org.jgrapht.Graph<Node, NodeEdge> graph = nodeStore.getNodeGraph();
         selection =
             GMParser.selectBestRoutePeer(
                 graph, self, candidates, targetNode, GMParser.MAX_ROUTE_WEIGHT);

--- a/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
+++ b/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
@@ -342,11 +342,26 @@ public final class OhForwarder {
     // greedy Kademlia step below until it is available.
     Node self = serverContext.getNode();
     if (self != null) {
-      Node targetNode = serverContext.getNodeStore().get(targetNodeId);
-      org.jgrapht.Graph<Node, NodeEdge> graph = serverContext.getNodeStore().getNodeGraph();
-      GMParser.RouteSelection selection =
-          GMParser.selectBestRoutePeer(
-              graph, self, candidates, targetNode, GMParser.MAX_ROUTE_WEIGHT);
+      // maintainNodes() restructures the graph under the NodeStore write lock (Sentry
+      // REDPANDAJ-2DW/2E5 fix). selectBestRoutePeer() walks it with containsVertex/getEdge/
+      // getEdgeWeight plus a full Dijkstra traversal, so it needs the read lock here — exactly
+      // like the other caller in GMParser.route(). Without it a concurrent removeVertex/addEdge
+      // yields a CME (dropped OH/garlic message) or an inconsistent path.
+      // The peer-list read lock above is already released, so no lock is nested here; the
+      // established order elsewhere (NodeStore -> PeerList, see NodeStore.addServerEdges) is
+      // therefore not violated.
+      Lock nodeStoreLock = serverContext.getNodeStore().getReadWriteLock().readLock();
+      GMParser.RouteSelection selection;
+      nodeStoreLock.lock();
+      try {
+        Node targetNode = serverContext.getNodeStore().get(targetNodeId);
+        org.jgrapht.Graph<Node, NodeEdge> graph = serverContext.getNodeStore().getNodeGraph();
+        selection =
+            GMParser.selectBestRoutePeer(
+                graph, self, candidates, targetNode, GMParser.MAX_ROUTE_WEIGHT);
+      } finally {
+        nodeStoreLock.unlock();
+      }
 
       if (selection.peer() != null) {
         return selection.peer();

--- a/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
+++ b/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
@@ -9,12 +9,14 @@ import im.redpanda.core.ServerContext;
 import im.redpanda.flaschenpost.GMAck;
 import im.redpanda.flaschenpost.GarlicMessage;
 import im.redpanda.store.NodeEdge;
+import im.redpanda.store.NodeStore;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
 import org.jgrapht.graph.DefaultDirectedWeightedGraph;
 
 public class PeerPerformanceTestGarlicMessageJob extends Job {
@@ -93,13 +95,17 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
 
   @Override
   public void init() {
-    serverContext.getNodeStore().getReadWriteLock().writeLock().lock();
+    // Same lock object for lock and unlock: serverContext's NodeStore can be replaced by
+    // NodeStore.saveToDisk()'s recovery path, and re-reading getNodeStore() for the unlock would
+    // then release a lock this thread never took (IllegalMonitorStateException).
+    Lock initGraphLock = serverContext.getNodeStore().getReadWriteLock().writeLock();
+    initGraphLock.lock();
     try {
       if (calculatePathOrAbort()) {
         return;
       }
     } finally {
-      serverContext.getNodeStore().getReadWriteLock().writeLock().unlock();
+      initGraphLock.unlock();
     }
     byte[] content = calculateNestedGarlicMessages(this.nodes, getJobId());
 
@@ -333,9 +339,6 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
       scoreToAdd = DELTA_FAIL;
     }
 
-    DefaultDirectedWeightedGraph<Node, NodeEdge> nodeGraph =
-        serverContext.getNodeStore().getNodeGraph();
-
     // The scoring loop below WRITES the shared JGraphT graph (setEdgeWeight) while reading its
     // structure (getEdge/containsEdge/getEdgeWeight). NodeStore.maintainNodes() mutates the same
     // graph (removeVertex/addEdge/setEdgeWeight) under the NodeStore write lock, so this loop must
@@ -345,9 +348,16 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
     // against the maintainer thread. init() takes the same write lock (see above).
     // No blocking I/O runs under the lock: the path string is only assembled here and printed
     // after the lock is released.
+    // The NodeStore reference is resolved ONCE and both the lock and the graph are taken from it:
+    // NodeStore.saveToDisk() replaces serverContext's NodeStore on its recovery path, so re-reading
+    // getNodeStore() per access could unlock a different lock than was locked
+    // (IllegalMonitorStateException) or guard a different graph than the one being mutated.
+    NodeStore nodeStore = serverContext.getNodeStore();
+    Lock graphLock = nodeStore.getReadWriteLock().writeLock();
     String pathString = "";
-    serverContext.getNodeStore().getReadWriteLock().writeLock().lock();
+    graphLock.lock();
     try {
+      DefaultDirectedWeightedGraph<Node, NodeEdge> nodeGraph = nodeStore.getNodeGraph();
       Node nodeBefore = null;
       for (Node node : nodes) {
         if (nodeBefore != null) {
@@ -370,7 +380,7 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
         nodeBefore = node;
       }
     } finally {
-      serverContext.getNodeStore().getReadWriteLock().writeLock().unlock();
+      graphLock.unlock();
     }
 
     // if (!success) {

--- a/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
+++ b/src/main/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJob.java
@@ -336,27 +336,41 @@ public class PeerPerformanceTestGarlicMessageJob extends Job {
     DefaultDirectedWeightedGraph<Node, NodeEdge> nodeGraph =
         serverContext.getNodeStore().getNodeGraph();
 
+    // The scoring loop below WRITES the shared JGraphT graph (setEdgeWeight) while reading its
+    // structure (getEdge/containsEdge/getEdgeWeight). NodeStore.maintainNodes() mutates the same
+    // graph (removeVertex/addEdge/setEdgeWeight) under the NodeStore write lock, so this loop must
+    // hold it too — otherwise two writers race inside the graph's non-thread-safe LinkedHashMaps
+    // (Sentry REDPANDAJ-2DW class: CME or silent structural corruption of the routing graph).
+    // The `scored` CAS above only dedups done() against itself, it gives no mutual exclusion
+    // against the maintainer thread. init() takes the same write lock (see above).
+    // No blocking I/O runs under the lock: the path string is only assembled here and printed
+    // after the lock is released.
     String pathString = "";
-    Node nodeBefore = null;
-    for (Node node : nodes) {
-      if (nodeBefore != null) {
-        NodeEdge edge = nodeGraph.getEdge(nodeBefore, node);
-        if (!nodeGraph.containsEdge(edge)) {
-          continue;
+    serverContext.getNodeStore().getReadWriteLock().writeLock().lock();
+    try {
+      Node nodeBefore = null;
+      for (Node node : nodes) {
+        if (nodeBefore != null) {
+          NodeEdge edge = nodeGraph.getEdge(nodeBefore, node);
+          if (!nodeGraph.containsEdge(edge)) {
+            continue;
+          }
+          double newWeight = nodeGraph.getEdgeWeight(edge) + scoreToAdd;
+          if (newWeight > MAX_WEIGHT) {
+            newWeight = MAX_WEIGHT;
+          } else if (newWeight < MIN_WEIGHT) {
+            newWeight = MIN_WEIGHT;
+          }
+          nodeGraph.setEdgeWeight(edge, newWeight);
+          edge.setLastCheckFailed(!success);
+          pathString += " -(" + "%.0f".formatted(newWeight) + ")-> " + node;
+        } else {
+          pathString += node;
         }
-        double newWeight = nodeGraph.getEdgeWeight(edge) + scoreToAdd;
-        if (newWeight > MAX_WEIGHT) {
-          newWeight = MAX_WEIGHT;
-        } else if (newWeight < MIN_WEIGHT) {
-          newWeight = MIN_WEIGHT;
-        }
-        nodeGraph.setEdgeWeight(edge, newWeight);
-        edge.setLastCheckFailed(!success);
-        pathString += " -(" + "%.0f".formatted(newWeight) + ")-> " + node;
-      } else {
-        pathString += node;
+        nodeBefore = node;
       }
-      nodeBefore = node;
+    } finally {
+      serverContext.getNodeStore().getReadWriteLock().writeLock().unlock();
     }
 
     // if (!success) {

--- a/src/test/java/im/redpanda/core/ConcurrencyTestSupport.java
+++ b/src/test/java/im/redpanda/core/ConcurrencyTestSupport.java
@@ -1,0 +1,88 @@
+package im.redpanda.core;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
+
+/**
+ * Test helper for "does this code path actually take lock X?" regressions.
+ *
+ * <p>Writing a racing stress test for a missing lock is inherently flaky: it only fails when the
+ * interleaving happens to hit the window. This helper instead asserts the property directly and
+ * deterministically — a code path that takes the lock cannot make progress while another thread
+ * holds it in an incompatible mode.
+ *
+ * <p>The assertion is one-sided and therefore not timing-flaky: a slow machine only makes the
+ * "still blocked" observation more likely, never less. The only way {@link #assertBlockedWhileHeld}
+ * fails is if the action genuinely ran to completion without the lock, which is exactly the
+ * regression being guarded against.
+ */
+public final class ConcurrencyTestSupport {
+
+  /** How long the action must fail to complete while the lock is held. */
+  private static final long MUST_STAY_BLOCKED_MS = 500;
+
+  /** Upper bound for the action once the lock is released — generous, only guards a hang. */
+  private static final long MUST_FINISH_SECONDS = 30;
+
+  private ConcurrencyTestSupport() {}
+
+  /**
+   * Locks {@code blockingLock} on the calling thread, runs {@code action} on another thread and
+   * asserts that it does not complete while the lock is held, then releases the lock and asserts
+   * that the action completes (rethrowing anything it threw).
+   *
+   * @param blockingLock a lock held in a mode that conflicts with the lock the action must take
+   *     (e.g. the write lock when the action is expected to take the read lock)
+   * @param action the code path under test
+   */
+  public static void assertBlockedWhileHeld(Lock blockingLock, Runnable action) throws Exception {
+    ExecutorService executor =
+        Executors.newSingleThreadExecutor(
+            runnable -> {
+              Thread thread = new Thread(runnable, "lock-probe");
+              thread.setDaemon(true);
+              return thread;
+            });
+    boolean held = false;
+    try {
+      blockingLock.lock();
+      held = true;
+
+      CountDownLatch started = new CountDownLatch(1);
+      Future<?> probe =
+          executor.submit(
+              () -> {
+                started.countDown();
+                action.run();
+              });
+      assertTrue(
+          "probe thread never started", started.await(MUST_FINISH_SECONDS, TimeUnit.SECONDS));
+
+      try {
+        probe.get(MUST_STAY_BLOCKED_MS, TimeUnit.MILLISECONDS);
+        fail("action completed while the conflicting lock was held — it does not take the lock");
+      } catch (TimeoutException expected) {
+        // still blocked on the lock, as required
+      }
+
+      blockingLock.unlock();
+      held = false;
+
+      // rethrows (wrapped) whatever the action threw
+      probe.get(MUST_FINISH_SECONDS, TimeUnit.SECONDS);
+    } finally {
+      if (held) {
+        blockingLock.unlock();
+      }
+      executor.shutdownNow();
+    }
+  }
+}

--- a/src/test/java/im/redpanda/core/PeerListTest.java
+++ b/src/test/java/im/redpanda/core/PeerListTest.java
@@ -190,4 +190,53 @@ public class PeerListTest {
 
     assertEquals(peer, peerList.get(id.getKademliaId()));
   }
+
+  /**
+   * M2 regression: {@code add()} used to do its duplicate lookups — {@code
+   * peerHashMap.get(kademliaId)} and {@code peerlistIpPort.get(ipPortHash)} — completely outside
+   * the ReadWriteLock, and returned early from that fast path without ever taking a lock. Other
+   * threads structurally modify those plain HashMaps under the write lock ({@code remove()}, {@code
+   * updateKademliaId()}, {@code addPeer()}), so an unsynchronized read during a put/resize/treeify
+   * is undefined behaviour (false-negative miss, torn {@code oldPeer}, NPE inside {@code
+   * HashMap.get}).
+   *
+   * <p>The duplicate-by-KademliaId path is the strongest probe: it is the one that used to return
+   * without touching a lock at all, so it fails this test before the fix and passes after.
+   */
+  @Test
+  public void add_duplicateByKademliaId_stillTakesTheLock() throws Exception {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    PeerList peerList = serverContext.getPeerList();
+
+    NodeId nodeId = new NodeId();
+    Peer first = new Peer("127.0.0.9", 50560, nodeId);
+    peerList.add(first);
+
+    Peer duplicate = new Peer("127.0.0.9", 50560, nodeId);
+
+    ConcurrencyTestSupport.assertBlockedWhileHeld(
+        peerList.getReadWriteLock().writeLock(), () -> peerList.add(duplicate));
+
+    // the duplicate was still rejected once the lock became available
+    assertEquals(first, peerList.get(nodeId.getKademliaId()));
+  }
+
+  /**
+   * Same for the ip+port fast path, which also returned early without a lock (peer without a
+   * NodeId, existing entry for the same ip:port).
+   */
+  @Test
+  public void add_duplicateByIpPort_stillTakesTheLock() throws Exception {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    PeerList peerList = serverContext.getPeerList();
+
+    peerList.add(new Peer("127.0.0.10", 50561));
+    Peer duplicate = new Peer("127.0.0.10", 50561);
+    int sizeBefore = peerList.size();
+
+    ConcurrencyTestSupport.assertBlockedWhileHeld(
+        peerList.getReadWriteLock().writeLock(), () -> peerList.add(duplicate));
+
+    assertEquals(sizeBefore, peerList.size());
+  }
 }

--- a/src/test/java/im/redpanda/flaschenpost/OhForwarderTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/OhForwarderTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.ByteString;
 import im.redpanda.core.Command;
+import im.redpanda.core.ConcurrencyTestSupport;
 import im.redpanda.core.InboundCommandProcessor;
 import im.redpanda.core.KademliaId;
 import im.redpanda.core.NodeId;
@@ -344,5 +345,42 @@ public class OhForwarderTest {
     assertThat(mailboxA.fetchMessages(ackPath.ackOhId(), 10, 0))
         .as("hop-limit drop must not ack — the caller does")
         .isEmpty();
+  }
+
+  /**
+   * M1 regression: {@code selectNextPeer()} releases the peer-list read lock and then runs {@code
+   * GMParser.selectBestRoutePeer} — containsVertex/getEdge/getEdgeWeight plus a full Dijkstra
+   * traversal — over the shared node graph. It used to do so without the NodeStore read lock, while
+   * {@code NodeStore.maintainNodes()} restructures that very graph under the write lock
+   * (REDPANDAJ-2DW/2E5 class). The sibling caller in {@code GMParser} takes the read lock; this one
+   * has to as well.
+   *
+   * <p>Asserted directly: with the NodeStore write lock held by another thread, the graph-routing
+   * part of {@code selectNextPeer} must not be able to run.
+   *
+   * <p>Negative control: remove the read lock again and the call completes immediately (falling
+   * through to the greedy Kademlia fallback), failing this test.
+   */
+  @Test
+  public void selectNextPeer_graphRoutingBlocksWhileNodeStoreWriteLockIsHeldElsewhere()
+      throws Exception {
+    // graph routing is only attempted once our own Node is wired up
+    nodeA.setNode(new im.redpanda.core.Node(nodeA, nodeA.getNodeId()));
+
+    // one connected full-node candidate, so we get past the (locked) peer-list scan
+    // (Peer.getNode() only returns the node once the peer is authed and connected)
+    Peer candidate = new Peer("127.0.0.1", 9302, nodeB.getNodeId());
+    candidate.setConnected(true);
+    candidate.authed = true;
+    candidate.setNode(new im.redpanda.core.Node(nodeA, nodeB.getNodeId()));
+    nodeA.getPeerList().add(candidate);
+    assertThat(candidate.hasNode()).isTrue();
+
+    // a target we are not directly connected to, so the direct-peer shortcut does not apply
+    KademliaId unreachableTarget = new KademliaId();
+
+    ConcurrencyTestSupport.assertBlockedWhileHeld(
+        nodeA.getNodeStore().getReadWriteLock().writeLock(),
+        () -> OhForwarder.selectNextPeer(nodeA, unreachableTarget));
   }
 }

--- a/src/test/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJobTest.java
+++ b/src/test/java/im/redpanda/jobs/PeerPerformanceTestGarlicMessageJobTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import im.redpanda.core.ConcurrencyTestSupport;
 import im.redpanda.core.Node;
 import im.redpanda.core.NodeId;
 import im.redpanda.core.Peer;
@@ -239,6 +240,29 @@ public class PeerPerformanceTestGarlicMessageJobTest {
 
     // done() ran and scored the timed-out test as failed in exactly one scoring pass, counting
     // the insert node once (nodes.get(1), via the nodes loop; see TD007).
+    assertEquals(1, insertNode.getGmTestsFailed());
+  }
+
+  /**
+   * H7 regression: {@code done()} writes the shared JGraphT node graph ({@code setEdgeWeight},
+   * {@code edge.setLastCheckFailed}) while reading its structure, but used to hold no NodeStore
+   * lock at all — racing {@code NodeStore.maintainNodes()}, which does {@code removeVertex}/{@code
+   * addEdge} under the write lock (REDPANDAJ-2DW class: CME or silent corruption of the routing
+   * graph). Asserted directly: while another thread holds the NodeStore write lock, the scoring
+   * pass must not be able to run to completion.
+   *
+   * <p>Negative control: revert the lock in {@code done()} and this test fails immediately, because
+   * the scoring pass then finishes while the graph is locked by someone else.
+   */
+  @Test
+  public void done_scoringGraphBlocksWhileNodeStoreWriteLockIsHeldElsewhere() throws Exception {
+    PeerPerformanceTestGarlicMessageJob job = buildJobWithDisconnectedInsertPeer();
+    Node insertNode = (Node) getPrivateField(job, "insertNode");
+
+    ConcurrencyTestSupport.assertBlockedWhileHeld(
+        serverContext.getNodeStore().getReadWriteLock().writeLock(), job::done);
+
+    // and once the lock was released the scoring pass really did run
     assertEquals(1, insertNode.getGmTestsFailed());
   }
 


### PR DESCRIPTION
Concurrency batch from the 2026-07-26 bug hunt (backlog **T60**). Re-verified against current `main` (`ebfccb5`, i.e. after #277/#278/#279) — all three findings still present.

## H7 — `PeerPerformanceTestGarlicMessageJob.done()` mutated the node graph with no NodeStore lock

`done()` **writes** the shared JGraphT `DefaultDirectedWeightedGraph` (`setEdgeWeight`, `edge.setLastCheckFailed`) while reading its structure (`getEdge`/`containsEdge`/`getEdgeWeight`), holding nothing. `NodeStore.maintainNodes()` does `removeVertex`/`addEdge`/`setEdgeWeight` on that same graph under the NodeStore **write** lock. Two concurrent writers into JGraphT's internal `LinkedHashMap`s is exactly the REDPANDAJ-2DW failure class — CME or silent structural corruption of the routing graph. The `scored` CAS only dedups `done()` against itself; it gives no mutual exclusion against the maintainer thread.

Fixed by wrapping the scoring loop in the NodeStore write lock — same shape as this class's own `init()`. The path string is assembled under the lock but printed after it is released, so no I/O is held.

## M1 — `OhForwarder.selectNextPeer()` ran Dijkstra without the NodeStore read lock

After releasing the *peer-list* read lock, it called `GMParser.selectBestRoutePeer` (`containsVertex`/`getEdge`/`getEdgeWeight` + a full `DijkstraShortestPath.findPathBetween`) on the same graph with no NodeStore lock, from reader threads and job threads. The sibling caller in `GMParser` deliberately takes the read lock; this one did not.

Fixed by taking the read lock around the graph-routing block (including the `NodeStore.get(target)` that feeds it, mirroring `GMParser`).

## M2 — `PeerList.add()` read both HashMaps outside the ReadWriteLock

`add()` did its fast-path duplicate lookups (`peerHashMap.get`, `peerlistIpPort.get`) before acquiring anything, and **returned from that fast path without ever taking a lock**, while other threads structurally modify those plain `HashMap`s under the write lock (`remove()`, `updateKademliaId()`, `addPeer()`). Unsynchronized reads during a put/resize/treeify are undefined behaviour: false-negative miss, torn `oldPeer`, or NPE inside `HashMap.get`.

Fixed by running the whole method under the write lock, which additionally makes check-and-add atomic (closing the check-then-add TOCTOU). `addPeer()` re-acquires the lock reentrantly.

## Lock-ordering / deadlock review

- No lock is nested where one was not nested before. `selectNextPeer` releases the peer-list read lock *before* taking the NodeStore read lock, so the `NodeStore -> PeerList` order established by `NodeStore.addServerEdges` is preserved.
- No read-to-write upgrade is introduced. Every `peerList.add()` call site is either lock-free or already holds the peer-list **write** lock (`OutboundHandler.reseed`, reentrant); no caller holds the read lock.
- `done()` takes the NodeStore write lock only after `super.done()` has released `runningJobsLock`, and no caller of `done()`/`success()` holds a NodeStore lock (`init()` releases it before the `done()` on the disconnect path; `calculatePathOrAbort()` calls `super.done()`, which touches no graph).
- Nothing blocking runs under any of the three locks.

## Tests

New helper `ConcurrencyTestSupport.assertBlockedWhileHeld(lock, action)`: rather than racing for the interleaving (inherently flaky), it asserts the property directly — with a conflicting lock held by another thread, the code path must not run to completion, and must complete once the lock is released. The assertion is **one-sided**, so a slow machine only makes the "still blocked" observation more likely, never less.

Four new tests:
- `PeerPerformanceTestGarlicMessageJobTest.done_scoringGraphBlocksWhileNodeStoreWriteLockIsHeldElsewhere`
- `OhForwarderTest.selectNextPeer_graphRoutingBlocksWhileNodeStoreWriteLockIsHeldElsewhere`
- `PeerListTest.add_duplicateByKademliaId_stillTakesTheLock`
- `PeerListTest.add_duplicateByIpPort_stillTakesTheLock`

**Negative control** (run explicitly): with the three production changes reverted and only the tests in place, all four fail with `action completed while the conflicting lock was held — it does not take the lock`. With the fixes they pass.

Full local suite: `Tests run: 420, Failures: 0, Errors: 0, Skipped: 1` — BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm