### PR TITLE
fix(H1): compare the full 160-bit id in KademliaId.equals

### DIFF
--- a/src/main/java/im/redpanda/core/KademliaId.java
+++ b/src/main/java/im/redpanda/core/KademliaId.java
@@ -84,7 +84,24 @@ public class KademliaId implements Serializable {
   }
 
   /**
-   * Compares a KademliaId to this KademliaId
+   * Compares a KademliaId to this KademliaId.
+   *
+   * <p>This compares the full 160-bit id, byte for byte. It used to compare {@link #hashCode()}
+   * instead — i.e. a 32-bit {@link Arrays#hashCode(byte[])} digest of the 20 id bytes — so any two
+   * ids colliding on that digest were considered equal. That is a ~2^32 search, which is seconds of
+   * offline grinding, and it defeated every identity check built on this method: the handshake
+   * public-key/id binding ({@code ConnectionHandler}, {@code ConnectionReaderThread}), {@code
+   * NodeId.setKeys}'s keypair check, the {@code ChannelDht} anti-smuggling filter on DHT answers,
+   * and {@code isForUs}/next-hop checks in the flaschenpost layer. It also silently conflated two
+   * unrelated peers or DHT records into one slot in every map keyed by a KademliaId ({@code
+   * PeerList.peerHashMap}, {@code KadStoreManager.entries}, {@code
+   * KademliaSearchJob.kademliaIdSearchBlacklist}, the MapDB node stores, and — via {@link
+   * NodeId#equals} / {@code Node.equals} — the JGraphT routing graph).
+   *
+   * <p>{@link #hashCode()} is deliberately left unchanged: equal ids still produce equal hashes, so
+   * the equals/hashCode contract holds, and no hash-based container (including the persisted MapDB
+   * {@code nodeids*.mapdb} and the serialized node graph) changes its bucket layout — colliding
+   * entries simply stop being merged.
    *
    * @param o The KademliaId to compare to this KademliaId
    * @return boolean Whether the 2 KademliaIds are equal
@@ -100,11 +117,16 @@ public class KademliaId implements Serializable {
     }
 
     if (o instanceof KademliaId nid) {
-      return this.hashCode() == nid.hashCode();
+      return Arrays.equals(this.keyBytes, nid.keyBytes);
     }
     throw new RuntimeException("do not compare KademliaId to other objects!");
   }
 
+  /**
+   * Note: this is a 32-bit digest of the id and must therefore never be used as an equality or
+   * identity test on its own — see {@link #equals(Object)}. It is kept as-is so equal ids keep
+   * equal hashes and existing hash-based containers need no rehash/migration.
+   */
   @Override
   public int hashCode() {
     int hash = 7;

--- a/src/main/java/im/redpanda/core/KademliaId.java
+++ b/src/main/java/im/redpanda/core/KademliaId.java
@@ -119,6 +119,12 @@ public class KademliaId implements Serializable {
     if (o instanceof KademliaId nid) {
       return Arrays.equals(this.keyBytes, nid.keyBytes);
     }
+    // Pre-existing, deliberate strictness: a cross-type comparison is always a programming error
+    // here, and failing loudly beats silently returning false. It does technically deviate from the
+    // Object.equals contract, but nothing can reach it today — NodeId.equals and Node.equals both
+    // type-guard before delegating, and every container keyed by a KademliaId is homogeneously
+    // typed (audited for the H1 fix). Turning it into `return false` would be an orthogonal
+    // behaviour change that could mask real type confusion, so it is left as is.
     throw new RuntimeException("do not compare KademliaId to other objects!");
   }
 

--- a/src/test/java/im/redpanda/core/KademliaIdTest.java
+++ b/src/test/java/im/redpanda/core/KademliaIdTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.*;
 
 import java.nio.ByteBuffer;
 import java.security.Security;
+import java.util.Arrays;
+import java.util.HashMap;
 import org.junit.Test;
 
 public class KademliaIdTest {
@@ -24,5 +26,121 @@ public class KademliaIdTest {
     assertEquals(kademliaId, clonedByBytes);
 
     assertTrue(kademliaId.equals(clonedByBytes));
+  }
+
+  /**
+   * Two distinct 20-byte ids that collide under {@link Arrays#hashCode(byte[])}.
+   *
+   * <p>How they were produced (no search needed): {@code Arrays.hashCode} is the polynomial {@code
+   * h = 31*h + b_i} over the bytes, so the contribution of two adjacent positions {@code i, i+1} to
+   * the final value differs by {@code 31^k * (31*d_i + d_i+1)}, where {@code d} is the per-byte
+   * difference between the two arrays. Choosing {@code d_i = +1} and {@code d_i+1 = -31} makes that
+   * factor exactly zero, so the two hashes are identical — no modular arithmetic and no brute force
+   * involved. Concretely: {@code {0, 31, 0...}} vs. {@code {1, 0, 0...}}.
+   *
+   * <p>An attacker grinding a keypair whose derived id collides with a target id faces the same
+   * 2^32 problem, which is seconds of offline work — hence H1.
+   */
+  private static KademliaId collidingIdA() {
+    byte[] bytes = new byte[KademliaId.ID_LENGTH_BYTES];
+    bytes[0] = 0;
+    bytes[1] = 31;
+    return new KademliaId(bytes);
+  }
+
+  private static KademliaId collidingIdB() {
+    byte[] bytes = new byte[KademliaId.ID_LENGTH_BYTES];
+    bytes[0] = 1;
+    bytes[1] = 0;
+    return new KademliaId(bytes);
+  }
+
+  /**
+   * Guards the fixture itself: if this ever stops holding, the regression tests below would
+   * silently stop testing anything.
+   */
+  @Test
+  public void collidingFixture_reallyCollidesOn32Bits() {
+    KademliaId a = collidingIdA();
+    KademliaId b = collidingIdB();
+
+    assertFalse("fixture must be two DIFFERENT ids", Arrays.equals(a.getBytes(), b.getBytes()));
+    assertEquals(
+        "fixture must collide under Arrays.hashCode",
+        Arrays.hashCode(a.getBytes()),
+        Arrays.hashCode(b.getBytes()));
+    // and therefore also under KademliaId.hashCode(), which is a pure function of it
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  /**
+   * H1 regression: {@code equals()} used to return {@code this.hashCode() == nid.hashCode()} — a
+   * 32-bit digest of the 20 id bytes — so two distinct ids colliding on that digest compared equal.
+   * Every identity check in the codebase is built on this: the handshake public-key/id binding
+   * ({@code ConnectionHandler}, {@code ConnectionReaderThread}), {@code NodeId.setKeys}, the {@code
+   * ChannelDht} anti-smuggling filter, {@code Flaschenpost.isForUs}, the next-hop check in {@code
+   * GarlicRouter}. Equality must compare the full 160-bit id.
+   */
+  @Test
+  public void equals_distinctIdsCollidingOn32BitHash_areNotEqual() {
+    KademliaId a = collidingIdA();
+    KademliaId b = collidingIdB();
+
+    assertNotEquals(a, b);
+    assertNotEquals(b, a);
+    assertFalse(a.equals(b));
+    assertFalse(b.equals(a));
+  }
+
+  /**
+   * The equals/hashCode contract must still hold after the change: equal ids keep equal hashes.
+   * That is what lets {@code hashCode()} stay untouched — no hash-based container (including the
+   * persisted MapDB node store and the serialized JGraphT graph) needs a rehash or a migration.
+   */
+  @Test
+  public void hashCode_isStillConsistentWithEquals() {
+    KademliaId id = new KademliaId();
+    KademliaId sameBytes = new KademliaId(Arrays.copyOf(id.getBytes(), id.getBytes().length));
+
+    assertEquals(id, sameBytes);
+    assertEquals(id.hashCode(), sameBytes.hashCode());
+  }
+
+  /**
+   * The concrete consequence for every map keyed by a KademliaId ({@code PeerList.peerHashMap},
+   * {@code KadStoreManager.entries}, {@code KademliaSearchJob.kademliaIdSearchBlacklist}, the MapDB
+   * node stores, and via {@code NodeId}/{@code Node} the routing graph): two colliding ids used to
+   * land in the same slot, so the second {@code put} silently overwrote the first and a lookup with
+   * one id returned the other's value. They must now be two independent entries — deliberately in
+   * the same hash bucket, so this also exercises the bucket's equals-based collision handling.
+   */
+  @Test
+  public void hashMapKeyedByKademliaId_keepsCollidingIdsApart() {
+    KademliaId a = collidingIdA();
+    KademliaId b = collidingIdB();
+
+    HashMap<KademliaId, String> map = new HashMap<>();
+    map.put(a, "valueA");
+    map.put(b, "valueB");
+
+    assertEquals(2, map.size());
+    assertEquals("valueA", map.get(a));
+    assertEquals("valueB", map.get(b));
+  }
+
+  /**
+   * H1 propagates through {@code NodeId.equals}, which delegates to {@code KademliaId.equals} — and
+   * that in turn is what {@code Node.equals} (the JGraphT vertex type) uses. Two NodeIds built from
+   * colliding KademliaIds must be distinct identities.
+   */
+  @Test
+  public void nodeIdEquals_inheritsTheStricterComparison() {
+    NodeId a = new NodeId(collidingIdA());
+    NodeId b = new NodeId(collidingIdB());
+
+    assertNotEquals(a, b);
+    // still consistent: the delegated hashCode collides, which is allowed and is exactly the case
+    // hash containers must resolve via equals
+    assertEquals(a.hashCode(), b.hashCode());
   }
 }


### PR DESCRIPTION
Finding **H1** of the 2026-07-26 bug hunt (backlog **T62**). Re-verified against current `main` — still present.

```java
if (o instanceof KademliaId nid) {
  return this.hashCode() == nid.hashCode();   // 83*7 + Arrays.hashCode(keyBytes)
}
```

`equals()` compared a **32-bit `Arrays.hashCode` digest** of the 20 id bytes instead of the bytes. Two distinct ids colliding on that digest were equal. A 32-bit collision is seconds of offline grinding.

## Why it matters

Every identity check in the codebase is built on this method:

| Site | What it is supposed to prove |
| --- | --- |
| `ConnectionHandler:551`, `ConnectionReaderThread:212` | the presented public key really belongs to the claimed `KademliaId` |
| `NodeId.setKeys` (`NodeId.java:267`) | the keypair matches the identity (`KeypairDoesNotMatchException`) |
| `ChannelDht:167` | anti-smuggling: a peer cannot slip a foreign (but validly signed) record into a DHT answer |
| `Flaschenpost.isForUs:53`, `GarlicRouter:95`, `OhForwarder:241` | "is this message / next hop actually me" |

It also silently conflated two unrelated peers or DHT records into a single slot in every map keyed by a `KademliaId`: `PeerList.peerHashMap`, `KadStoreManager.entries`, `KademliaSearchJob.kademliaIdSearchBlacklist`, the MapDB node stores, and — via `NodeId.equals` / `Node.equals` — the JGraphT routing graph's vertex identity.

## The fix

`Arrays.equals(this.keyBytes, nid.keyBytes)`.

**`hashCode()` is deliberately left unchanged.** Equal ids still produce equal hashes, so the equals/hashCode contract holds, and no hash-based container changes its bucket layout — the persisted `data/nodeids<port>.mapdb` and the serialized node graph in `LocalSettings` need **no rehash and no migration**. (MapDB 3.0.9's default serializer buckets via `Object.hashCode` and matches via `Object.equals`; no custom key serializer is configured on any of the three `HTreeMap`s.) Colliding entries simply stop being merged.

The cross-type `RuntimeException` is kept as-is: nothing relies on it and nothing can currently reach it (`NodeId.equals` and `Node.equals` both type-guard, and every hash container is homogeneously typed), so changing it would be an unrelated behaviour change.

## Caller audit

Audited every map/set/collection keyed by `KademliaId`/`NodeId`/`Node`, every `.equals` site involving them, and every id re-derivation path. **Nothing depends on the loose behaviour:**

- All ids are exactly 20 bytes — both constructors reject other lengths, so `Arrays.equals` can never trip on a length mismatch.
- Every re-derivation is byte-deterministic: `fromFirstBytes` (SHA-256 truncation in `NodeId.fromVerifyKey`, `KadContent.createKademliaId`), `fromBuffer` (all wire parsers), protobuf round-trip, Java/Elsa serialization (`keyBytes` is a plain final field; `NodeId.readObject` re-derives from the verify key).
- `KademliaId` is **not** `Comparable` and has no `Comparator`, so there is no `TreeMap`/`TreeSet` whose ordering could now disagree with equality. `PeerComparator` returns `0` **iff** the two ids are byte-identical — i.e. ordering and equality now *agree*, where today they disagree for colliding ids.
- The `LegacyNodeId` tombstone holds no `KademliaId`.
- No `catch`, test or doc relies on the cross-type `RuntimeException`.

**Behaviour that does change** (all in the desirable direction): colliding ids stop being merged — `PeerList` registers both peers instead of reporting a false duplicate, two DHT records stop clobbering each other, a colliding search id is no longer wrongly treated as blacklisted, and `GMParser`'s `peerNode.equals(targetNode)` shortcut no longer hands a colliding peer a bogus zero-cost route.

## Tests

The collision fixture is built **analytically, not by brute force**: `Arrays.hashCode` is the polynomial `h = 31*h + b_i`, so two adjacent-position byte differences of `d_i = +1` and `d_i+1 = -31` contribute `31^k * (31*1 - 31) = 0` — exactly zero, no modular arithmetic. Hence `{0, 31, 0…}` and `{1, 0, 0…}` collide on all 32 bits.

- `collidingFixture_reallyCollidesOn32Bits` — guards the fixture, so the regressions below cannot silently stop testing anything.
- `equals_distinctIdsCollidingOn32BitHash_areNotEqual` — the finding itself.
- `hashCode_isStillConsistentWithEquals` — the contract that lets `hashCode()` stay untouched.
- `hashMapKeyedByKademliaId_keepsCollidingIdsApart` — two entries, deliberately in the same bucket, exercising equals-based collision resolution.
- `nodeIdEquals_inheritsTheStricterComparison` — the propagation through `NodeId` (and hence `Node`, the graph vertex type).

**Negative control** (run explicitly): with the `equals` change reverted and only the tests in place, 3 of the 5 fail — `equals_distinctIdsCollidingOn32BitHash_areNotEqual`, `hashMapKeyedByKademliaId_keepsCollidingIdsApart` (`expected:<2> but was:<1>`) and `nodeIdEquals_inheritsTheStricterComparison`. The other two are invariants that must hold either way.

Full local suite: `Tests run: 421, Failures: 0, Errors: 0, Skipped: 1` — BUILD SUCCESS.

## Note for follow-up (not fixed here)

`OhForwarder.selectNextPeer`'s TreeSet tie-break is `.thenComparing(peer -> peer.getKademliaId().toString())`, and `KademliaId.toString()` returns only the **first 10 Base58 characters**. Two ids sharing that prefix still compare `0`, so one candidate is silently dropped — the same "truncated digest used as identity" class this PR fixes, in a place where the consequence is only a lost routing candidate. `hexRepresentation()` or `Arrays.compare(getBytes(), …)` would be exact. Left out to keep this PR to one change; worth a backlog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm
