### PR TITLE
fix(core): save LocalSettings atomically so a failed save keeps the file (REDPANDAJ-2E6)

### DIFF
--- a/src/main/java/im/redpanda/core/LocalSettings.java
+++ b/src/main/java/im/redpanda/core/LocalSettings.java
@@ -80,12 +80,13 @@ public class LocalSettings implements Serializable {
     File tmpFile = new File(Settings.SAVE_DIR + "/localSettings" + port + ".dat.tmp");
 
     try {
-      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile)) {
-        ObjectOutputStream objectOutputStream = new ObjectOutputStream(fileOutputStream);
+      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
+          ObjectOutputStream objectOutputStream = new ObjectOutputStream(fileOutputStream)) {
         objectOutputStream.writeObject(this);
         objectOutputStream.flush();
         // force the bytes to disk before the rename, otherwise a crash right after the rename
-        // could leave an empty file where a complete old one used to be
+        // could leave an empty file where a complete old one used to be. Both streams are still
+        // open here, try-with-resources closes them at the end of the block.
         fileOutputStream.getFD().sync();
       }
 

--- a/src/main/java/im/redpanda/core/LocalSettings.java
+++ b/src/main/java/im/redpanda/core/LocalSettings.java
@@ -9,6 +9,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import lombok.extern.slf4j.Slf4j;
 import org.jgrapht.graph.DefaultDirectedWeightedGraph;
 
@@ -59,25 +61,47 @@ public class LocalSettings implements Serializable {
     this.updateAndroidSignature = updateAndroidSignature;
   }
 
-  public void save(int port) {
+  /**
+   * Writes the settings to disk atomically: the object graph is serialized into a temporary file
+   * which only replaces the live file once it is complete. Serializing straight into the live file
+   * truncates it first, so any failure half way through (a {@link
+   * java.util.ConcurrentModificationException} from a collection mutated by another thread —
+   * REDPANDAJ-2E6 —, a full disk, ...) left behind a truncated file that {@link #load(int)} cannot
+   * read, and the node silently generated a new identity on the next start.
+   *
+   * <p>Synchronized because both the {@code SaveJobs} job and the update handling in {@code
+   * InboundCommandProcessor} call this, and two saves running at once would write the same file.
+   */
+  public synchronized void save(int port) {
+    File mkdirs = new File(Settings.SAVE_DIR);
+    mkdirs.mkdir();
+
+    File file = new File(Settings.SAVE_DIR + "/localSettings" + port + ".dat");
+    File tmpFile = new File(Settings.SAVE_DIR + "/localSettings" + port + ".dat.tmp");
+
     try {
-
-      File mkdirs = new File(Settings.SAVE_DIR);
-      mkdirs.mkdir();
-
-      File file = new File(Settings.SAVE_DIR + "/localSettings" + port + ".dat");
-
-      if (!file.createNewFile() && !file.exists()) {
-        throw new IOException("Could not create file " + file);
+      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile)) {
+        ObjectOutputStream objectOutputStream = new ObjectOutputStream(fileOutputStream);
+        objectOutputStream.writeObject(this);
+        objectOutputStream.flush();
+        // force the bytes to disk before the rename, otherwise a crash right after the rename
+        // could leave an empty file where a complete old one used to be
+        fileOutputStream.getFD().sync();
       }
-      try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
-        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(fileOutputStream)) {
-          objectOutputStream.writeObject(this);
-        }
-      }
+
+      Files.move(
+          tmpFile.toPath(),
+          file.toPath(),
+          StandardCopyOption.REPLACE_EXISTING,
+          StandardCopyOption.ATOMIC_MOVE);
 
     } catch (IOException ex) {
       log.info("error saving local settings", ex);
+    } finally {
+      // on success the temporary file has been renamed away, on failure it is incomplete
+      if (tmpFile.exists() && !tmpFile.delete()) {
+        log.info("could not delete temporary settings file {}", tmpFile);
+      }
     }
   }
 

--- a/src/test/java/im/redpanda/core/LocalSettingsPersistenceTest.java
+++ b/src/test/java/im/redpanda/core/LocalSettingsPersistenceTest.java
@@ -4,8 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.security.Security;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.jgrapht.graph.DefaultDirectedWeightedGraph;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,20 +27,27 @@ public class LocalSettingsPersistenceTest {
   public void setUp() {
     // Use a unique, unlikely port to avoid clobbering other tests/files
     port = 49123;
-    // Cleanup pre-existing file if any
-    File f = new File(Settings.SAVE_DIR + "/localSettings" + port + ".dat");
-    if (f.exists()) {
-      // best effort
-      f.delete();
-    }
+    // Cleanup pre-existing files if any
+    deleteSettingsFiles();
   }
 
   @After
   public void tearDown() {
-    File f = new File(Settings.SAVE_DIR + "/localSettings" + port + ".dat");
-    if (f.exists()) {
-      f.delete();
-    }
+    deleteSettingsFiles();
+  }
+
+  private void deleteSettingsFiles() {
+    // best effort
+    settingsFile().delete();
+    tmpSettingsFile().delete();
+  }
+
+  private File settingsFile() {
+    return new File(Settings.SAVE_DIR + "/localSettings" + port + ".dat");
+  }
+
+  private File tmpSettingsFile() {
+    return new File(Settings.SAVE_DIR + "/localSettings" + port + ".dat.tmp");
   }
 
   @Test
@@ -59,5 +71,70 @@ public class LocalSettingsPersistenceTest {
     assertNotNull(loaded.getMyIdentity());
     assertNotNull(loaded.getNodeGraph());
     assertNotNull(loaded.getSystemUpTimeData());
+    assertThat(tmpSettingsFile()).doesNotExist();
+  }
+
+  /**
+   * Regression test for REDPANDAJ-2E6: a save that blows up half way through serialization (there:
+   * a ConcurrentModificationException on a collection another thread was mutating) must not destroy
+   * the settings file that is already on disk — it holds the node identity.
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Test
+  public void failedSaveKeepsPreviousFile() throws Exception {
+    LocalSettings ls = new LocalSettings();
+    ls.setUpdateTimestamp(4711L);
+    ls.save(port);
+
+    byte[] savedFile = Files.readAllBytes(settingsFile().toPath());
+
+    // a vertex that is not serializable makes writeObject fail in the middle of the object graph,
+    // just like the ConcurrentModificationException did
+    ((DefaultDirectedWeightedGraph) ls.getNodeGraph()).addVertex(new Object());
+    ls.setUpdateTimestamp(999L);
+
+    ls.save(port);
+
+    assertThat(LocalSettings.load(port).getUpdateTimestamp()).isEqualTo(4711L);
+    // asserted as a boolean, an array comparison would dump both files into the failure message
+    assertThat(Arrays.equals(savedFile, Files.readAllBytes(settingsFile().toPath())))
+        .as("the settings file on disk must be byte identical to the last successful save")
+        .isTrue();
+    assertThat(tmpSettingsFile()).doesNotExist();
+  }
+
+  /**
+   * SaveJobs and the update handling in InboundCommandProcessor both call save(), and both saves
+   * write the same file (and the same temporary file). save() therefore has to hold the monitor of
+   * the settings instance for the whole write.
+   */
+  @Test(timeout = 60_000)
+  public void savesExcludeEachOther() throws Exception {
+    LocalSettings ls = new LocalSettings();
+    ls.setUpdateTimestamp(4711L);
+
+    CountDownLatch saveStarted = new CountDownLatch(1);
+    CountDownLatch saveFinished = new CountDownLatch(1);
+    Thread saver =
+        new Thread(
+            () -> {
+              saveStarted.countDown();
+              ls.save(port);
+              saveFinished.countDown();
+            });
+
+    synchronized (ls) {
+      saver.start();
+      assertThat(saveStarted.await(30, TimeUnit.SECONDS)).isTrue();
+      // a save that does not take the monitor would be through in well under a second
+      assertThat(saveFinished.await(1, TimeUnit.SECONDS))
+          .as("save() must not write while another thread holds the settings monitor")
+          .isFalse();
+    }
+
+    assertThat(saveFinished.await(30, TimeUnit.SECONDS)).isTrue();
+    saver.join();
+    assertThat(LocalSettings.load(port).getUpdateTimestamp()).isEqualTo(4711L);
+    assertThat(tmpSettingsFile()).doesNotExist();
   }
 }


### PR DESCRIPTION
Sentry: REDPANDAJ-2E6 (`ConcurrentModificationException` in `LocalSettings.save`).

## What the Sentry issue really shows

Both events (2026-07-17, 2026-07-27) carry `release=bdcfe11`, a commit from **2026-02-27**, i.e. one
node that never picked up an update. The `TreeSet` in the stack trace is
`SystemUpTimeData.upHits`, and the CME itself was already fixed in `41e203d`
(*fix(core): synchronize SystemUpTimeData mutation and serialization*, 2026-07-18) — the
`synchronized writeObject` there is not in the build that reported. So the exception is fixed on
`main`; nothing to do for the CME as such.

What was **not** fixed is the damage such a failure does, and that is what this PR addresses.

## The remaining bug: a failed save destroys the settings file

`save()` serialized straight into `data/localSettings<port>.dat`. `new FileOutputStream(file)`
truncates the file before the first byte is written, so *any* failure mid-serialization (the CME
above, a full disk, a `NotSerializableException`) left a truncated file behind. `load()` cannot read
it, falls through to `new LocalSettings()` and saves that — the node loses its identity (`myIdentity`
/ KademliaId), its uptime statistics and its node graph, permanently. The node in Sentry hit this
twice.

Additionally `save()` was called from two threads: `SaveJobs` and the update handling in
`InboundCommandProcessor` (`installJarUpdate` / `installApkUpdate`, both on the reader thread pool).
Two saves at once wrote the same file through two `FileOutputStream`s with independent file
positions — interleaved garbage.

## Change

* `save()` serializes into `localSettings<port>.dat.tmp`, `fsync`s it and only then replaces the
  live file with an atomic rename. A failed save now leaves the last good file untouched (the same
  write-tmp-then-`Files.move` pattern the jar update in `InboundCommandProcessor#installJarUpdate`
  already uses).
* `save()` is `synchronized`, so the two callers cannot write the file (or the temporary file) at
  the same time.
* Runtime exceptions still propagate as before — Sentry keeps seeing concurrency bugs instead of
  them being swallowed. The temporary file is cleaned up either way.

## Tests

`LocalSettingsPersistenceTest`:

* `failedSaveKeepsPreviousFile` — deterministic: save, then make serialization fail (a
  non-serializable vertex in the node graph), save again; the file on disk must still be byte
  identical and load with the old values.
  Negative control against the pre-fix `save()`: **fails** (file overwritten with a partial stream).
* `savesExcludeEachOther` — a save started while another thread holds the settings monitor must not
  write. Negative control with `synchronized` removed: **fails**.
* `saveAndLoadRoundtrip` additionally asserts that no temporary file is left behind.

## Related, deliberately not touched here

* `LocalSettings.save()` serializes `nodeGraph`, the very object `NodeStore` mutates under its
  `readWriteLock` write lock (see the REDPANDAJ-2DW comment in `NodeStore#maintainNodes`). The save
  path takes no read lock, so a CME on the graph is still possible — it needs a decision about who
  owns the graph save and touches `NodeStore`.
* `Saver.savePeers` iterates `PeerList#getPeerArrayList()`, which returns the live list, without the
  peer list read lock.

Both are being worked on in parallel on the node graph / peer list locking, so they are out of scope
for this PR.
