### PR TITLE
fix(T68): connect backoff pacing, handshake reaping, doc drift

### DIFF
--- a/src/main/java/im/redpanda/core/OutboundHandler.java
+++ b/src/main/java/im/redpanda/core/OutboundHandler.java
@@ -66,9 +66,10 @@ public class OutboundHandler extends Thread {
         peerInHandshake.setNodeId(peer.getNodeId());
       }
 
-      peerInHandshake.addConnection(alreadyConnected);
-
-      return true;
+      // addConnection() closes the channel and disconnects the peer when the selector
+      // registration fails; reporting success in that case would suppress run()'s
+      // `newConnections += 5` backoff, so the attempt is paced like any other failure.
+      return peerInHandshake.addConnection(alreadyConnected);
     } catch (UnknownHostException ex) {
       System.out.println("outgoing con failed, unknown host...");
     } catch (Exception ex) {

--- a/src/main/java/im/redpanda/core/PeerInHandshake.java
+++ b/src/main/java/im/redpanda/core/PeerInHandshake.java
@@ -92,7 +92,15 @@ public class PeerInHandshake {
     return status;
   }
 
-  public void addConnection(boolean alreadyConnected) {
+  /**
+   * Registers this handshake's channel with the selector.
+   *
+   * @return {@code true} if the channel was registered and the handshake is now owned by the
+   *     selector loop; {@code false} if registration failed — in that case the channel has been
+   *     closed and the peer disconnected, so the caller must not treat the connection as
+   *     established (see {@code OutboundHandler.connectTo}, whose backoff pacing depends on it).
+   */
+  public boolean addConnection(boolean alreadyConnected) {
     boolean registered = false;
     try {
       socketChannel.configureBlocking(false);
@@ -131,6 +139,7 @@ public class PeerInHandshake {
         }
       }
     }
+    return registered;
   }
 
   private void closeSocketChannelQuietly() {

--- a/src/main/java/im/redpanda/core/PeerJobs.java
+++ b/src/main/java/im/redpanda/core/PeerJobs.java
@@ -6,6 +6,9 @@ import java.util.concurrent.locks.Lock;
 
 public class PeerJobs extends Thread {
 
+  /** A handshake that has not completed within this time is closed and dropped. */
+  static final long HANDSHAKE_TIMEOUT_MS = 1000L * 10L;
+
   private final ServerContext serverContext;
   private final PeerList peerList;
 
@@ -34,79 +37,100 @@ public class PeerJobs extends Thread {
         ex.printStackTrace();
       }
 
-      if (peerList.size() == 0) {
-        continue;
-      }
+      runOnce();
+    }
+  }
 
-      serverContext.getConnectionHandler().getPeerInHandshakesLock().lock();
-      try {
-        long currentTimeMillis = System.currentTimeMillis();
-        ArrayList<PeerInHandshake> toRemove = new ArrayList<>();
-        for (PeerInHandshake peerInHandshake : ConnectionHandler.peerInHandshakes) {
-          if (currentTimeMillis - peerInHandshake.getCreatedAt() > 1000L * 10L) {
-            try {
-              peerInHandshake.getSocketChannel().close();
-            } catch (IOException e) {
-              e.printStackTrace();
+  /**
+   * One pass of the chron loop. Package-private so the ordering below can be tested without
+   * starting the thread and waiting out its sleeps.
+   */
+  void runOnce() {
+    // Stale handshakes are reaped independently of the peer list: a handshake that never
+    // completes is not in the peer list yet, so gating this on `peerList.size() != 0` left
+    // those channels open forever whenever the node had no established peers (fresh start,
+    // total connection loss) — exactly the situation in which handshakes pile up.
+    reapStaleHandshakes();
+
+    if (peerList.size() == 0) {
+      return;
+    }
+
+    Lock lock = peerList.getReadWriteLock().readLock();
+    lock.lock();
+    try {
+      for (Peer peer : peerList.getPeerArrayList()) {
+
+        try {
+          Thread.sleep(20);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+
+        Log.put("running over peer: " + peer, 120);
+
+        if ((peer.isConnecting && peer.getLastAnswered() > 10000)
+            || (!peer.isConnecting && peer.getLastAnswered() > Settings.pingTimeout)) {
+
+          if (peer.isConnected() || peer.isConnecting) {
+
+            peer.disconnect("timeout");
+            if (peer.getNodeId() == null) {
+              Log.put(
+                  "removed peer from peerList, tried once and peer never connected before: "
+                      + peer.ip
+                      + ":"
+                      + peer.port,
+                  120);
             }
-            toRemove.add(peerInHandshake);
+
+            // todo: interrupt outbound thread?
+          } else if (peer.getLastAnswered() > Settings.pingTimeout * 2) {
+            peer.writeBuffer = null;
+            peer.writeBufferCrypted = null;
+          }
+
+        } else if (peer.isConnected()) {
+
+          peer.cnt++;
+          if (peer.cnt > Settings.peerListRequestDelay * 1000 / (Settings.pingDelay)) {
+            peer.sendPing();
+            peer.cnt = 0;
+          } else {
+            if (peer.isConnected() && peer.getLastAnswered() > Settings.pingDelay) {
+              peer.sendPing();
+            }
           }
         }
-        ConnectionHandler.peerInHandshakes.removeAll(toRemove);
-      } finally {
-        serverContext.getConnectionHandler().getPeerInHandshakesLock().unlock();
       }
+    } finally {
+      lock.unlock();
+    }
+  }
 
-      Lock lock = peerList.getReadWriteLock().readLock();
-      lock.lock();
-      try {
-        for (Peer peer : peerList.getPeerArrayList()) {
-
+  /**
+   * Closes and drops every {@link PeerInHandshake} that has not completed within {@link
+   * #HANDSHAKE_TIMEOUT_MS}. Package-private so the timeout behaviour is testable without starting
+   * the thread.
+   */
+  void reapStaleHandshakes() {
+    serverContext.getConnectionHandler().getPeerInHandshakesLock().lock();
+    try {
+      long currentTimeMillis = System.currentTimeMillis();
+      ArrayList<PeerInHandshake> toRemove = new ArrayList<>();
+      for (PeerInHandshake peerInHandshake : ConnectionHandler.peerInHandshakes) {
+        if (currentTimeMillis - peerInHandshake.getCreatedAt() > HANDSHAKE_TIMEOUT_MS) {
           try {
-            Thread.sleep(20);
-          } catch (InterruptedException e) {
+            peerInHandshake.getSocketChannel().close();
+          } catch (IOException e) {
             e.printStackTrace();
           }
-
-          Log.put("running over peer: " + peer, 120);
-
-          if ((peer.isConnecting && peer.getLastAnswered() > 10000)
-              || (!peer.isConnecting && peer.getLastAnswered() > Settings.pingTimeout)) {
-
-            if (peer.isConnected() || peer.isConnecting) {
-
-              peer.disconnect("timeout");
-              if (peer.getNodeId() == null) {
-                Log.put(
-                    "removed peer from peerList, tried once and peer never connected before: "
-                        + peer.ip
-                        + ":"
-                        + peer.port,
-                    120);
-              }
-
-              // todo: interrupt outbound thread?
-            } else if (peer.getLastAnswered() > Settings.pingTimeout * 2) {
-              peer.writeBuffer = null;
-              peer.writeBufferCrypted = null;
-            }
-
-          } else if (peer.isConnected()) {
-
-            peer.cnt++;
-            if (peer.cnt > Settings.peerListRequestDelay * 1000 / (Settings.pingDelay)) {
-              peer.sendPing();
-              peer.cnt = 0;
-            } else {
-              if (peer.isConnected() && peer.getLastAnswered() > Settings.pingDelay) {
-                peer.sendPing();
-              }
-            }
-          }
+          toRemove.add(peerInHandshake);
         }
-      } finally {
-        lock.unlock();
       }
+      ConnectionHandler.peerInHandshakes.removeAll(toRemove);
+    } finally {
+      serverContext.getConnectionHandler().getPeerInHandshakesLock().unlock();
     }
   }
 }

--- a/src/main/java/im/redpanda/jobs/KademliaSearchJob.java
+++ b/src/main/java/im/redpanda/jobs/KademliaSearchJob.java
@@ -61,9 +61,9 @@ public class KademliaSearchJob extends Job {
 
     /**
      * Lets check if this KademliaId was already searched in the last seconds such that no search
-     * loops occur. Each Key is blacklisted for 5 seconds after a search and only direct searches
-     * will be returned for that key. TODO: Maybe we should create a list of "requesters" for each
-     * search such that we can send an answers to all "requesters".
+     * loops occur. Each key is blacklisted for {@link #BLACKLIST_KEY_FOR} (30 seconds) after a
+     * search and only direct searches will be returned for that key. TODO: Maybe we should create a
+     * list of "requesters" for each search such that we can send an answers to all "requesters".
      */
     long currentTimeMillis = System.currentTimeMillis();
 

--- a/src/main/java/im/redpanda/jobs/KademliaSearchJob.java
+++ b/src/main/java/im/redpanda/jobs/KademliaSearchJob.java
@@ -59,11 +59,11 @@ public class KademliaSearchJob extends Job {
   @Override
   public void init() {
 
-    /**
-     * Lets check if this KademliaId was already searched in the last seconds such that no search
-     * loops occur. Each key is blacklisted for {@link #BLACKLIST_KEY_FOR} (30 seconds) after a
-     * search and only direct searches will be returned for that key. TODO: Maybe we should create a
-     * list of "requesters" for each search such that we can send an answers to all "requesters".
+    /*
+     * Check whether this KademliaId was searched recently, so that no search loops occur. After a
+     * search the key stays blacklisted for BLACKLIST_KEY_FOR; while it is, only direct searches are
+     * answered for that key. TODO: maybe we should keep a list of "requesters" per search so that
+     * we can send an answer to all of them.
      */
     long currentTimeMillis = System.currentTimeMillis();
 

--- a/src/main/java/im/redpanda/kademlia/KadStoreManager.java
+++ b/src/main/java/im/redpanda/kademlia/KadStoreManager.java
@@ -32,7 +32,9 @@ public class KadStoreManager {
    */
   private static final int MIN_SIZE = 1024 * 1024 * 10;
 
-  private static final long MAX_KEEP_TIME = 1000L * 60L * 60L * 24L * 14L; // 7 days
+  /** How long a stored entry is kept before the eviction sweep may drop it: 14 days. */
+  private static final long MAX_KEEP_TIME = 1000L * 60L * 60L * 24L * 14L;
+
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
   private static final Map<KademliaId, KadContent> entries = new HashMap<>();

--- a/src/test/java/im/redpanda/core/PeerInHandshakeTest.java
+++ b/src/test/java/im/redpanda/core/PeerInHandshakeTest.java
@@ -192,4 +192,37 @@ public class PeerInHandshakeTest {
       channel.close();
     }
   }
+
+  /**
+   * Regression for T68 (a): {@code addConnection} used to return void, so {@code
+   * OutboundHandler.connectTo} reported success even when the registration had failed and the peer
+   * had already been disconnected again — {@code run()}'s {@code newConnections += 5} backoff
+   * pacing therefore never fired for those attempts.
+   */
+  @Test
+  public void addConnection_returnsFalseWhenRegistrationFails() throws Exception {
+    SocketChannel channel = SocketChannel.open();
+    channel.close(); // configureBlocking() on a closed channel throws ClosedChannelException
+
+    Peer peer = new Peer("127.0.0.1", 1234);
+    PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", peer, channel);
+
+    assertFalse(peerInHandshake.addConnection(false));
+  }
+
+  @Test
+  public void addConnection_returnsTrueWhenRegistrationSucceeds() throws Exception {
+    SocketChannel channel = SocketChannel.open();
+    Peer peer = new Peer("127.0.0.1", 1234);
+    PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", peer, channel);
+
+    try {
+      assertTrue(peerInHandshake.addConnection(false));
+    } finally {
+      if (peerInHandshake.getKey() != null) {
+        peerInHandshake.getKey().cancel();
+      }
+      channel.close();
+    }
+  }
 }

--- a/src/test/java/im/redpanda/core/PeerJobsHandshakeReapTest.java
+++ b/src/test/java/im/redpanda/core/PeerJobsHandshakeReapTest.java
@@ -1,0 +1,71 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.nio.channels.SocketChannel;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Regression test for T68 (b): {@code PeerJobs} skipped the stale-{@link PeerInHandshake} cleanup
+ * with {@code if (peerList.size() == 0) continue;} before it ran, so handshake channels were never
+ * reaped while the peer list was empty — a fresh node or one that just lost every connection is
+ * exactly the situation in which half-open handshakes pile up.
+ */
+public class PeerJobsHandshakeReapTest {
+
+  @After
+  public void tearDown() {
+    ConnectionHandler.peerInHandshakes.clear();
+  }
+
+  @Test
+  public void runOnce_reapsStaleHandshakesWhilePeerListIsEmpty() throws Exception {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    serverContext.setConnectionHandler(new ConnectionHandler(serverContext, false));
+    ConnectionHandler.peerInHandshakes.clear();
+
+    assertThat(serverContext.getPeerList().size()).isZero();
+
+    try (SocketChannel channel = SocketChannel.open()) {
+      PeerInHandshake stale =
+          new PeerInHandshake("127.0.0.1", new Peer("127.0.0.1", 1234), channel);
+      ageOut(stale);
+      serverContext.getConnectionHandler().addPeerInHandshake(stale);
+
+      new PeerJobs(serverContext).runOnce();
+
+      assertThat(channel.isOpen())
+          .as("the stale handshake channel must be closed even with an empty peer list")
+          .isFalse();
+      assertThat(ConnectionHandler.peerInHandshakes).doesNotContain(stale);
+    }
+  }
+
+  @Test
+  public void runOnce_keepsFreshHandshakes() throws Exception {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    serverContext.setConnectionHandler(new ConnectionHandler(serverContext, false));
+    ConnectionHandler.peerInHandshakes.clear();
+
+    try (SocketChannel channel = SocketChannel.open()) {
+      PeerInHandshake fresh =
+          new PeerInHandshake("127.0.0.1", new Peer("127.0.0.1", 1234), channel);
+      serverContext.getConnectionHandler().addPeerInHandshake(fresh);
+
+      new PeerJobs(serverContext).runOnce();
+
+      assertThat(channel.isOpen()).isTrue();
+      assertThat(ConnectionHandler.peerInHandshakes).contains(fresh);
+    }
+  }
+
+  /** Backdates the handshake past {@link PeerJobs#HANDSHAKE_TIMEOUT_MS}. */
+  private static void ageOut(PeerInHandshake peerInHandshake) throws Exception {
+    Field createdAt = PeerInHandshake.class.getDeclaredField("createdAt");
+    createdAt.setAccessible(true);
+    createdAt.setLong(
+        peerInHandshake, System.currentTimeMillis() - PeerJobs.HANDSHAKE_TIMEOUT_MS - 1000L);
+  }
+}


### PR DESCRIPTION
Backlog **T68** — four small pre-existing findings from the wave-1 sweep. All four re-verified against current `main` (post #277–#281); all still present.

### (a) `OutboundHandler.connectTo` reported success on a failed registration
`PeerInHandshake.addConnection` returned `void`. When `socketChannel.register(...)` throws `IOException`, the method closes its channel and disconnects the peer (M4 fix, #278) — but `connectTo` still returned `true`. `run()`'s `newConnections += 5` backoff pacing (`OutboundHandler.java:309-313`) therefore never fired for those attempts, so a node whose selector registrations fail keeps hammering the peer list at full speed.

`addConnection` now returns the `registered` flag and `connectTo` returns it.

### (b) Stale handshakes were never reaped while the peer list was empty
`PeerJobs.run()` did `if (peerList.size() == 0) continue;` **before** the stale-`PeerInHandshake` cleanup. A handshake that never completes is not in the peer list, so the cleanup was gated on a condition unrelated to it — and skipped entirely exactly when handshakes pile up (fresh start, total connection loss, reseed storm).

The cleanup now runs first. The loop body is extracted into a package-private `runOnce()` so the ordering is testable without waiting out the thread's 3 s + 1–5 s sleeps; the reaper itself moved into `reapStaleHandshakes()` with the 10 s timeout as a named constant.

### (c)/(d) Doc drift
- `KadStoreManager.MAX_KEEP_TIME`: comment said `// 7 days`, the value is 14 days.
- `KademliaSearchJob.init()` javadoc said "blacklisted for 5 seconds", `BLACKLIST_KEY_FOR` is 30 s.

## Tests

- `PeerJobsHandshakeReapTest` — a backdated handshake is closed and dropped with an empty peer list; a fresh one is kept.
- `PeerInHandshakeTest.addConnection_returnsFalseWhenRegistrationFails` / `…ReturnsTrueWhenRegistrationSucceeds` — the failure case closes the channel first so `configureBlocking()` throws `ClosedChannelException`, i.e. the real `IOException` branch.

**Negative control:** with the reap moved back behind the `size() == 0` guard, `runOnce_reapsStaleHandshakesWhilePeerListIsEmpty` fails (`the stale handshake channel must be closed even with an empty peer list`). For (a) the pre-fix source cannot even compile the assertion (`addConnection` was `void`).

`mvn test`: 429 tests, 0 failures, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm