### PR TITLE
test: make the read-queue-full leak test deterministic

### DIFF
--- a/src/test/java/im/redpanda/core/ConnectionHandlerSocketLeakTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerSocketLeakTest.java
@@ -3,6 +3,7 @@ package im.redpanda.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import java.io.Serial;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.nio.channels.SelectionKey;
@@ -11,6 +12,7 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -135,13 +137,7 @@ public class ConnectionHandlerSocketLeakTest {
     // disconnected. A queue that always rejects is the same condition for handleKeyReadable
     // (offer() == false / add() throwing IllegalStateException) but nothing can undo it.
     BlockingQueue<Peer> originalQueue = ConnectionHandler.peersToReadAndParse;
-    ConnectionHandler.peersToReadAndParse =
-        new LinkedBlockingQueue<>() {
-          @Override
-          public boolean offer(Peer peerToQueue) {
-            return false;
-          }
-        };
+    ConnectionHandler.peersToReadAndParse = new AlwaysFullQueue(originalQueue);
 
     try {
       Method handleKeyReadable =
@@ -156,5 +152,65 @@ public class ConnectionHandlerSocketLeakTest {
     assertThat(ConnectionHandler.workingRead).doesNotContain(peer);
     assertThat(peer.isConnected()).isFalse();
     assertThat(channel.isOpen()).isFalse();
+  }
+
+  /**
+   * A queue that rejects every offer, i.e. behaves like a permanently full read queue.
+   *
+   * <p>Only the producer side is overridden. Every consumer operation delegates to the real queue,
+   * because a {@code ConnectionReaderThread} can read {@code ConnectionHandler.peersToReadAndParse}
+   * while this stub is installed: with a self-contained stub such a thread would block in {@code
+   * take()} on a queue that nobody ever fills and would never see the restored original — the test
+   * would strand the very reader threads whose leftovers made it flaky in the first place.
+   */
+  private static final class AlwaysFullQueue extends LinkedBlockingQueue<Peer> {
+
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final transient BlockingQueue<Peer> delegate;
+
+    private AlwaysFullQueue(BlockingQueue<Peer> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public boolean offer(Peer peer) {
+      return false;
+    }
+
+    @Override
+    public boolean offer(Peer peer, long timeout, TimeUnit unit) {
+      return false;
+    }
+
+    @Override
+    public int remainingCapacity() {
+      return 0;
+    }
+
+    @Override
+    public Peer take() throws InterruptedException {
+      return delegate.take();
+    }
+
+    @Override
+    public Peer poll(long timeout, TimeUnit unit) throws InterruptedException {
+      return delegate.poll(timeout, unit);
+    }
+
+    @Override
+    public Peer poll() {
+      return delegate.poll();
+    }
+
+    @Override
+    public Peer peek() {
+      return delegate.peek();
+    }
+
+    @Override
+    public int size() {
+      return delegate.size();
+    }
   }
 }

--- a/src/test/java/im/redpanda/core/ConnectionHandlerSocketLeakTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerSocketLeakTest.java
@@ -9,6 +9,8 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -127,17 +129,29 @@ public class ConnectionHandlerSocketLeakTest {
     peer.setConnected(true);
     key.attach(peer);
 
-    // fill the bounded queue up to its capacity
-    while (ConnectionHandler.peersToReadAndParse.offer(new Peer("127.0.0.2", 1))) {
-      // intentionally empty
+    // Filling the real queue up to its capacity made this test flaky: peersToReadAndParse is
+    // static and any ConnectionReaderThread left behind by an earlier test class keeps polling it,
+    // so the queue could have room again by the time handleKeyReadable ran and the peer was never
+    // disconnected. A queue that always rejects is the same condition for handleKeyReadable
+    // (offer() == false / add() throwing IllegalStateException) but nothing can undo it.
+    BlockingQueue<Peer> originalQueue = ConnectionHandler.peersToReadAndParse;
+    ConnectionHandler.peersToReadAndParse =
+        new LinkedBlockingQueue<>() {
+          @Override
+          public boolean offer(Peer peerToQueue) {
+            return false;
+          }
+        };
+
+    try {
+      Method handleKeyReadable =
+          ConnectionHandler.class.getDeclaredMethod("handleKeyReadable", SelectionKey.class);
+      handleKeyReadable.setAccessible(true);
+
+      handleKeyReadable.invoke(handler, key);
+    } finally {
+      ConnectionHandler.peersToReadAndParse = originalQueue;
     }
-    assertThat(ConnectionHandler.peersToReadAndParse.remainingCapacity()).isZero();
-
-    Method handleKeyReadable =
-        ConnectionHandler.class.getDeclaredMethod("handleKeyReadable", SelectionKey.class);
-    handleKeyReadable.setAccessible(true);
-
-    handleKeyReadable.invoke(handler, key);
 
     assertThat(ConnectionHandler.workingRead).doesNotContain(peer);
     assertThat(peer.isConnected()).isFalse();


### PR DESCRIPTION
`ConnectionHandlerSocketLeakTest.handleKeyReadable_disconnectsPeerWhenReadQueueIsFull` (added in #278) is genuinely flaky and **fails on main itself** — CI run 30261026965 on main @ 221466e, plus two local failures followed by a pass.

## Root cause

The test filled the real `ConnectionHandler.peersToReadAndParse` up to its capacity (600) and then asserted that `handleKeyReadable` disconnects the peer. That queue is `public static` and `ConnectionReaderThread`s poll it in a loop (`ConnectionReaderThread#run`). A reader thread left behind by an earlier test class in the same fork keeps draining that same static queue, so between the fill loop and the reflective invocation a slot could free up — `offer()` then succeeded, the peer was never disconnected and the three assertions failed.

## Fix

Swap in a queue that always rejects for the duration of the call, instead of trying to keep the real one full:

```java
ConnectionHandler.peersToReadAndParse =
    new LinkedBlockingQueue<>() {
      @Override
      public boolean offer(Peer peerToQueue) {
        return false;
      }
    };
```

That is exactly the condition `handleKeyReadable` reacts to and nothing can undo it, so the test is now deterministic. The original queue is restored in a `finally`.

## Still tests H6

Verified against the pre-#278 production code (`peersToReadAndParse.add(peer)` without the disconnect branch): the test still fails there, with `IllegalStateException: Queue full` — `AbstractQueue.add` delegates to the overridden `offer`. So the H6 coverage is unchanged.

Test-only change. Full local suite green (430 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm