### PR TITLE
fix(core): take the graph and peer-list locks in the save paths

### DIFF
--- a/src/main/java/im/redpanda/core/LocalSettings.java
+++ b/src/main/java/im/redpanda/core/LocalSettings.java
@@ -115,15 +115,9 @@ public class LocalSettings implements Serializable {
     File file = new File(Settings.SAVE_DIR + "/localSettings" + port + ".dat");
     File tmpFile = new File(Settings.SAVE_DIR + "/localSettings" + port + ".dat.tmp");
 
-    byte[] serialized;
     try {
-      serialized = serializeUnderGraphLock();
-    } catch (IOException ex) {
-      log.info("error serializing local settings", ex);
-      return;
-    }
+      byte[] serialized = serializeUnderGraphLock();
 
-    try {
       try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile)) {
         fileOutputStream.write(serialized);
         fileOutputStream.flush();

--- a/src/main/java/im/redpanda/core/LocalSettings.java
+++ b/src/main/java/im/redpanda/core/LocalSettings.java
@@ -1,6 +1,8 @@
 package im.redpanda.core;
 
 import im.redpanda.store.NodeEdge;
+import im.redpanda.store.NodeStore;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -11,6 +13,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.concurrent.locks.Lock;
 import lombok.extern.slf4j.Slf4j;
 import org.jgrapht.graph.DefaultDirectedWeightedGraph;
 
@@ -38,6 +41,19 @@ public class LocalSettings implements Serializable {
 
   private SystemUpTimeData systemUpTimeData;
 
+  /**
+   * Read lock of the {@link NodeStore} that owns {@link #nodeGraph}, or {@code null} while no
+   * NodeStore has adopted the graph (standalone uses such as {@code Updater}, and the window
+   * between {@link #load(int)} and {@code NodeStore.build...}).
+   *
+   * <p>{@code transient} because a {@link Lock} is not serializable and the lock is a property of
+   * the running process, not of the persisted settings. Set by {@link
+   * NodeStore#buildWithDiskCache(ServerContext)} / {@link
+   * NodeStore#buildWithMemoryCacheOnly(ServerContext)} rather than passed to {@link #save(int)}, so
+   * that every caller of {@code save()} is protected without having to know about the NodeStore.
+   */
+  private transient Lock nodeGraphLock;
+
   public LocalSettings() {
     myIdentity = new NodeId();
     updateTimestamp = -1;
@@ -62,12 +78,32 @@ public class LocalSettings implements Serializable {
   }
 
   /**
-   * Writes the settings to disk atomically: the object graph is serialized into a temporary file
-   * which only replaces the live file once it is complete. Serializing straight into the live file
-   * truncates it first, so any failure half way through (a {@link
-   * java.util.ConcurrentModificationException} from a collection mutated by another thread —
-   * REDPANDAJ-2E6 —, a full disk, ...) left behind a truncated file that {@link #load(int)} cannot
-   * read, and the node silently generated a new identity on the next start.
+   * Sets the lock that guards {@link #nodeGraph} against concurrent mutation. See {@link
+   * #nodeGraphLock}.
+   *
+   * @param nodeGraphLock the owning NodeStore's read lock, or {@code null} to detach
+   */
+  public synchronized void setNodeGraphLock(Lock nodeGraphLock) {
+    this.nodeGraphLock = nodeGraphLock;
+  }
+
+  /**
+   * Writes the settings to disk atomically: the object graph is serialized into memory first and
+   * the resulting bytes go through a temporary file which only replaces the live file once it is
+   * complete. Serializing straight into the live file truncates it first, so any failure half way
+   * through (a {@link java.util.ConcurrentModificationException} from a collection mutated by
+   * another thread — REDPANDAJ-2E6 —, a full disk, ...) left behind a truncated file that {@link
+   * #load(int)} cannot read, and the node silently generated a new identity on the next start.
+   *
+   * <p>Serialization runs under the NodeStore read lock ({@link #nodeGraphLock}) because {@link
+   * #nodeGraph} is the very graph {@code NodeStore#maintainNodes} mutates under the matching write
+   * lock (REDPANDAJ-2DW). Without it the save itself still fails with a {@code
+   * ConcurrentModificationException} — harmlessly since #282, but the graph never reaches the disk.
+   * Only the in-memory serialization is covered; the file I/O and the fsync run outside the lock so
+   * that a slow disk cannot stall the node's graph maintenance.
+   *
+   * <p>Lock order is {@code LocalSettings monitor -> NodeStore read lock}. Nothing may therefore
+   * call {@code save()} while holding the NodeStore write lock; today no caller does.
    *
    * <p>Synchronized because both the {@code SaveJobs} job and the update handling in {@code
    * InboundCommandProcessor} call this, and two saves running at once would write the same file.
@@ -79,14 +115,20 @@ public class LocalSettings implements Serializable {
     File file = new File(Settings.SAVE_DIR + "/localSettings" + port + ".dat");
     File tmpFile = new File(Settings.SAVE_DIR + "/localSettings" + port + ".dat.tmp");
 
+    byte[] serialized;
     try {
-      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
-          ObjectOutputStream objectOutputStream = new ObjectOutputStream(fileOutputStream)) {
-        objectOutputStream.writeObject(this);
-        objectOutputStream.flush();
+      serialized = serializeUnderGraphLock();
+    } catch (IOException ex) {
+      log.info("error serializing local settings", ex);
+      return;
+    }
+
+    try {
+      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile)) {
+        fileOutputStream.write(serialized);
+        fileOutputStream.flush();
         // force the bytes to disk before the rename, otherwise a crash right after the rename
-        // could leave an empty file where a complete old one used to be. Both streams are still
-        // open here, try-with-resources closes them at the end of the block.
+        // could leave an empty file where a complete old one used to be.
         fileOutputStream.getFD().sync();
       }
 
@@ -102,6 +144,24 @@ public class LocalSettings implements Serializable {
       // on success the temporary file has been renamed away, on failure it is incomplete
       if (tmpFile.exists() && !tmpFile.delete()) {
         log.info("could not delete temporary settings file {}", tmpFile);
+      }
+    }
+  }
+
+  private byte[] serializeUnderGraphLock() throws IOException {
+    Lock lock = nodeGraphLock;
+    if (lock != null) {
+      lock.lock();
+    }
+    try {
+      ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+      try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(buffer)) {
+        objectOutputStream.writeObject(this);
+      }
+      return buffer.toByteArray();
+    } finally {
+      if (lock != null) {
+        lock.unlock();
       }
     }
   }

--- a/src/main/java/im/redpanda/core/Saver.java
+++ b/src/main/java/im/redpanda/core/Saver.java
@@ -1,10 +1,13 @@
 package im.redpanda.core;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -14,6 +17,38 @@ public class Saver {
 
   public static final String SAVE_DIR = "data";
 
+  /**
+   * Snapshots the peer list under its read lock and persists the snapshot.
+   *
+   * <p>The callers used to hand {@link PeerList#getPeerArrayList()} — the live list — straight to
+   * {@link #savePeers(List)}, which iterates it. Network threads add and remove peers concurrently,
+   * so the iteration could throw a {@code ConcurrentModificationException} and the save was lost
+   * (the same class of bug as redpandaj#260 and REDPANDAJ-2DZ; every other iteration site takes the
+   * lock). Only the snapshot is taken under the lock, the serialization and the file I/O run
+   * without it.
+   */
+  public static void savePeers(PeerList peerList) {
+    ArrayList<Peer> snapshot;
+    Lock readLock = peerList.getReadWriteLock().readLock();
+    readLock.lock();
+    try {
+      snapshot = new ArrayList<>(peerList.getPeerArrayList());
+    } finally {
+      readLock.unlock();
+    }
+    savePeers(snapshot);
+  }
+
+  /**
+   * Persists the given peers. Callers holding a {@link PeerList} must use {@link
+   * #savePeers(PeerList)} instead — this overload assumes the list is not mutated concurrently.
+   *
+   * <p>Written via a temporary file plus fsync and an atomic rename, for the same reason as {@code
+   * LocalSettings.save()}: writing in place truncates {@code peers.dat} first, so a failure half
+   * way through leaves a corrupt file behind. That is less severe here (an unreadable {@code
+   * peers.dat} only costs the known peers, {@link #loadPeers()} falls back to an empty map) but the
+   * pattern is three lines, so there is no reason to keep the truncating write.
+   */
   public static void savePeers(List<Peer> peers) {
     ArrayList<PeerSaveable> arrayList = new ArrayList<>();
 
@@ -29,19 +64,28 @@ public class Saver {
     mkdirs.mkdir();
 
     File file = new File(SAVE_DIR + "/peers.dat");
+    File tmpFile = new File(SAVE_DIR + "/peers.dat.tmp");
 
     try {
-      if (file.createNewFile()) {
-        log.info("Created new peers.dat file");
+      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
+          ObjectOutputStream objectOutputStream = new ObjectOutputStream(fileOutputStream)) {
+        objectOutputStream.writeObject(arrayList);
+        objectOutputStream.flush();
+        fileOutputStream.getFD().sync();
       }
-      try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
-        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(fileOutputStream)) {
-          objectOutputStream.writeObject(arrayList);
-        }
-      }
+
+      Files.move(
+          tmpFile.toPath(),
+          file.toPath(),
+          StandardCopyOption.REPLACE_EXISTING,
+          StandardCopyOption.ATOMIC_MOVE);
 
     } catch (IOException ex) {
       log.error("Could not save peers", ex);
+    } finally {
+      if (tmpFile.exists() && !tmpFile.delete()) {
+        log.info("could not delete temporary peers file {}", tmpFile);
+      }
     }
   }
 

--- a/src/main/java/im/redpanda/core/Saver.java
+++ b/src/main/java/im/redpanda/core/Saver.java
@@ -18,6 +18,14 @@ public class Saver {
   public static final String SAVE_DIR = "data";
 
   /**
+   * Guards the write to {@code peers.dat}. The recurring {@code SaveJobs} and {@code
+   * Server.shutdown} can both be in {@link #savePeers(List)} at the same time, and they would race
+   * on the shared temporary file and its rename. Mirrors the {@code synchronized} on {@code
+   * LocalSettings.save(int)}.
+   */
+  private static final Object SAVE_LOCK = new Object();
+
+  /**
    * Snapshots the peer list under its read lock and persists the snapshot.
    *
    * <p>The callers used to hand {@link PeerList#getPeerArrayList()} — the live list — straight to
@@ -47,7 +55,8 @@ public class Saver {
    * LocalSettings.save()}: writing in place truncates {@code peers.dat} first, so a failure half
    * way through leaves a corrupt file behind. That is less severe here (an unreadable {@code
    * peers.dat} only costs the known peers, {@link #loadPeers()} falls back to an empty map) but the
-   * pattern is three lines, so there is no reason to keep the truncating write.
+   * pattern is three lines, so there is no reason to keep the truncating write. The write is
+   * serialized on {@link #SAVE_LOCK} so that two savers cannot race on the shared temporary file.
    */
   public static void savePeers(List<Peer> peers) {
     ArrayList<PeerSaveable> arrayList = new ArrayList<>();
@@ -66,25 +75,27 @@ public class Saver {
     File file = new File(SAVE_DIR + "/peers.dat");
     File tmpFile = new File(SAVE_DIR + "/peers.dat.tmp");
 
-    try {
-      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
-          ObjectOutputStream objectOutputStream = new ObjectOutputStream(fileOutputStream)) {
-        objectOutputStream.writeObject(arrayList);
-        objectOutputStream.flush();
-        fileOutputStream.getFD().sync();
-      }
+    synchronized (SAVE_LOCK) {
+      try {
+        try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
+            ObjectOutputStream objectOutputStream = new ObjectOutputStream(fileOutputStream)) {
+          objectOutputStream.writeObject(arrayList);
+          objectOutputStream.flush();
+          fileOutputStream.getFD().sync();
+        }
 
-      Files.move(
-          tmpFile.toPath(),
-          file.toPath(),
-          StandardCopyOption.REPLACE_EXISTING,
-          StandardCopyOption.ATOMIC_MOVE);
+        Files.move(
+            tmpFile.toPath(),
+            file.toPath(),
+            StandardCopyOption.REPLACE_EXISTING,
+            StandardCopyOption.ATOMIC_MOVE);
 
-    } catch (IOException ex) {
-      log.error("Could not save peers", ex);
-    } finally {
-      if (tmpFile.exists() && !tmpFile.delete()) {
-        log.info("could not delete temporary peers file {}", tmpFile);
+      } catch (IOException ex) {
+        log.error("Could not save peers", ex);
+      } finally {
+        if (tmpFile.exists() && !tmpFile.delete()) {
+          log.info("could not delete temporary peers file {}", tmpFile);
+        }
       }
     }
   }

--- a/src/main/java/im/redpanda/core/Server.java
+++ b/src/main/java/im/redpanda/core/Server.java
@@ -76,7 +76,7 @@ public class Server {
       Thread.currentThread().interrupt();
     }
 
-    Saver.savePeers(serverContext.getPeerList().getPeerArrayList());
+    Saver.savePeers(serverContext.getPeerList());
     serverContext.getNodeStore().close();
     serverContext.getLocalSettings().save(serverContext.getPort());
   }

--- a/src/main/java/im/redpanda/jobs/SaveJobs.java
+++ b/src/main/java/im/redpanda/jobs/SaveJobs.java
@@ -18,6 +18,6 @@ public class SaveJobs extends Job {
   public void work() {
     serverContext.getLocalSettings().save(serverContext.getPort());
     serverContext.getNodeStore().saveToDisk();
-    Saver.savePeers(serverContext.getPeerList().getPeerArrayList());
+    Saver.savePeers(serverContext.getPeerList());
   }
 }

--- a/src/main/java/im/redpanda/store/NodeStore.java
+++ b/src/main/java/im/redpanda/store/NodeStore.java
@@ -1,6 +1,7 @@
 package im.redpanda.store;
 
 import im.redpanda.core.KademliaId;
+import im.redpanda.core.LocalSettings;
 import im.redpanda.core.Log;
 import im.redpanda.core.Node;
 import im.redpanda.core.Peer;
@@ -71,7 +72,7 @@ public class NodeStore {
     if (serverContext.getLocalSettings() == null) {
       System.out.println("warning, could not restore nodeGraph from local settings....");
     } else {
-      nodeStore.nodeGraph = serverContext.getLocalSettings().getNodeGraph();
+      nodeStore.adoptGraphOf(serverContext.getLocalSettings());
     }
 
     nodeStore.dbonHeap =
@@ -137,7 +138,7 @@ public class NodeStore {
     if (serverContext.getLocalSettings() == null) {
       Log.put("warning, could not restore nodeGraph from local settings....", 5);
     } else {
-      nodeStore.nodeGraph = serverContext.getLocalSettings().getNodeGraph();
+      nodeStore.adoptGraphOf(serverContext.getLocalSettings());
     }
 
     nodeStore.dbonHeap = DBMaker.heapDB().make();
@@ -154,6 +155,17 @@ public class NodeStore {
                 .create();
 
     return nodeStore;
+  }
+
+  /**
+   * Takes over the persisted graph of {@code localSettings} as the live graph and hands the
+   * settings the read lock that guards it. From here on both sides agree on how the graph is
+   * protected: this store mutates it under {@link #readWriteLock}'s write lock (REDPANDAJ-2DW) and
+   * {@code LocalSettings.save()} serializes it under the read lock.
+   */
+  private void adoptGraphOf(LocalSettings localSettings) {
+    nodeGraph = localSettings.getNodeGraph();
+    localSettings.setNodeGraphLock(readWriteLock.readLock());
   }
 
   public void put(KademliaId kademliaId, Node node) {

--- a/src/test/java/im/redpanda/core/LocalSettingsPersistenceTest.java
+++ b/src/test/java/im/redpanda/core/LocalSettingsPersistenceTest.java
@@ -137,4 +137,42 @@ public class LocalSettingsPersistenceTest {
     assertThat(LocalSettings.load(port).getUpdateTimestamp()).isEqualTo(4711L);
     assertThat(tmpSettingsFile()).doesNotExist();
   }
+
+  /**
+   * The serialized node graph is the very object NodeStore mutates under its write lock (see the
+   * REDPANDAJ-2DW comment in NodeStore#maintainNodes). Serializing it without the matching read
+   * lock risks a ConcurrentModificationException; since #282 that no longer truncates the file, but
+   * the save fails and the graph never reaches the disk.
+   *
+   * <p>Asserted via the lock itself instead of a racing stress test: a save that takes the read
+   * lock cannot make progress while the write lock is held. That is deterministic and one-sided —
+   * see {@link ConcurrencyTestSupport}.
+   */
+  @Test(timeout = 60_000)
+  public void saveBlocksWhileTheNodeGraphWriteLockIsHeld() throws Exception {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    LocalSettings localSettings = serverContext.getLocalSettings();
+    localSettings.setUpdateTimestamp(4711L);
+
+    // buildDefaultServerContext builds the NodeStore, which is where the graph and its lock are
+    // handed over - so this also covers the wiring, not just LocalSettings itself.
+    ConcurrencyTestSupport.assertBlockedWhileHeld(
+        serverContext.getNodeStore().getReadWriteLock().writeLock(),
+        () -> localSettings.save(port));
+
+    assertThat(LocalSettings.load(port).getUpdateTimestamp()).isEqualTo(4711L);
+    assertThat(tmpSettingsFile()).doesNotExist();
+  }
+
+  /** A LocalSettings that no NodeStore has adopted (e.g. Updater) still has to save. */
+  @Test(timeout = 60_000)
+  public void saveWorksWithoutANodeGraphLock() {
+    LocalSettings localSettings = new LocalSettings();
+    localSettings.setUpdateTimestamp(1234L);
+
+    localSettings.save(port);
+
+    assertThat(LocalSettings.load(port).getUpdateTimestamp()).isEqualTo(1234L);
+    assertThat(tmpSettingsFile()).doesNotExist();
+  }
 }

--- a/src/test/java/im/redpanda/core/SaverTest.java
+++ b/src/test/java/im/redpanda/core/SaverTest.java
@@ -1,6 +1,7 @@
 package im.redpanda.core;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -18,14 +19,13 @@ public class SaverTest {
 
   private static final String TEST_SAVE_DIR = "data";
   private static final String TEST_FILE = TEST_SAVE_DIR + "/peers.dat";
+  private static final String TEST_TMP_FILE = TEST_FILE + ".tmp";
 
   @Before
   @After
   public void cleanUp() throws IOException {
-    File file = new File(TEST_FILE);
-    if (file.exists()) {
-      Files.delete(Path.of(TEST_FILE));
-    }
+    Files.deleteIfExists(Path.of(TEST_FILE));
+    Files.deleteIfExists(Path.of(TEST_TMP_FILE));
   }
 
   @Test
@@ -96,6 +96,29 @@ public class SaverTest {
 
     assertTrue(
         loadedPeers.values().stream().noneMatch(p -> p.getIp().equals(bootstrapPeer.getIp())));
+  }
+
+  /**
+   * savePeers used to be handed PeerList#getPeerArrayList() - the live list - and iterated it
+   * without the peer list read lock, while network threads add and remove peers (redpandaj#260,
+   * REDPANDAJ-2DZ). Asserted via the lock itself rather than a racing stress test: a savePeers that
+   * takes the read lock cannot make progress while the write lock is held. Deterministic and
+   * one-sided, see {@link ConcurrencyTestSupport}.
+   */
+  @Test(timeout = 60_000)
+  public void savePeersBlocksWhileThePeerListWriteLockIsHeld() throws Exception {
+    PeerList peerList = ServerContext.buildDefaultServerContext().getPeerList();
+    Peer peer = new Peer("127.0.0.1", 1234);
+    peer.setNodeId(new NodeId());
+    peerList.add(peer);
+
+    ConcurrencyTestSupport.assertBlockedWhileHeld(
+        peerList.getReadWriteLock().writeLock(), () -> Saver.savePeers(peerList));
+
+    Map<KademliaId, Peer> loadedPeers = Saver.loadPeers();
+    assertEquals(1, loadedPeers.size());
+    assertNotNull(loadedPeers.get(peer.getKademliaId()));
+    assertFalse(new File(TEST_TMP_FILE).exists());
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #282, which fixed the *consequence* (a failed save truncated `localSettings<port>.dat` and the node lost its identity) but explicitly left the two remaining *causes* — save paths that serialize live, concurrently mutated collections — to a separate PR. Since #282 such a save fails harmlessly, but it still fails, and the data never reaches the disk.

## 1. `LocalSettings.save()` and the node graph

`save()` serializes `nodeGraph` — the very object `NodeStore` mutates under its write lock (see the `REDPANDAJ-2DW` comment in `NodeStore#maintainNodes`) — while taking no lock at all.

`NodeStore` now hands `LocalSettings` its read lock in the one place where it adopts the graph (`adoptGraphOf`, called from both `build...` factories), and `save()` serializes into memory under that lock. The lock is wired into the settings object rather than passed to `save()` so that *every* caller is covered — including the two in `InboundCommandProcessor`, which have no `NodeStore` at hand.

Lock scope: only the in-memory serialization runs under the read lock. The tmp-file write, the `fsync` and the `ATOMIC_MOVE` run outside it, so a slow disk cannot stall graph maintenance. As a side effect a failed serialization now writes nothing at all, not even a temporary file.

Lock order is `LocalSettings monitor -> NodeStore read lock`; nothing may call `save()` while holding the NodeStore write lock, and today nothing does (documented on `save()`).

## 2. `Saver.savePeers()` and the peer list

`savePeers` was handed `PeerList#getPeerArrayList()` — the live list — and iterated it without the peer-list read lock, while network threads add and remove peers. It was the last iteration site that did not take that lock; every other one was fixed in redpandaj#260 / REDPANDAJ-2DZ.

The callers (`SaveJobs`, `Server.shutdown`) now pass the `PeerList` itself and `savePeers` snapshots it under the read lock; the serialization and the file I/O run without the lock.

`peers.dat` also gets the tmp-file + fsync + `ATOMIC_MOVE` treatment. The blast radius of a truncated `peers.dat` is much smaller than for the settings — `loadPeers()` degrades to an empty map, so the node only loses its known peers, not its identity — but the pattern is three lines, so there is no reason to keep a write that truncates in place.

## Tests

Both regressions are asserted with `ConcurrencyTestSupport.assertBlockedWhileHeld` (added in #280) rather than a racing stress test: a code path that takes the read lock cannot complete while the write lock is held. That is deterministic and one-sided — a slow machine only makes the "still blocked" observation more likely.

`saveBlocksWhileTheNodeGraphWriteLockIsHeld` goes through `ServerContext.buildDefaultServerContext()`, so it covers the NodeStore wiring and not just `LocalSettings` in isolation. `saveWorksWithoutANodeGraphLock` pins the standalone case (`Updater`, and the window before a NodeStore exists).

**Negative controls** (fix patched out, test re-run):
- graph lock removed from `serializeUnderGraphLock` -> `LocalSettingsPersistenceTest.saveBlocksWhileTheNodeGraphWriteLockIsHeld` fails: *"action completed while the conflicting lock was held — it does not take the lock"*
- `savePeers(PeerList)` reverted to `savePeers(peerList.getPeerArrayList())` -> `SaverTest.savePeersBlocksWhileThePeerListWriteLockIsHeld` fails with the same assertion.

Full local suite green (430 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm