### PR TITLE
fix(M5,L3,L4): bound connection points, the ByteBufferPool debug map and update-task failures

### DIFF
--- a/src/main/java/im/redpanda/core/ByteBufferPool.java
+++ b/src/main/java/im/redpanda/core/ByteBufferPool.java
@@ -6,6 +6,7 @@ import io.sentry.Sentry;
 import io.sentry.SentryLevel;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,10 +21,48 @@ public class ByteBufferPool {
   private static final org.slf4j.Logger log =
       org.slf4j.LoggerFactory.getLogger(ByteBufferPool.class);
   private static GenericKeyedObjectPool<Integer, ByteBuffer> pool;
-  private static final Map<ByteBuffer, String> byteBufferToStacktrace = new IdentityHashMap<>();
+
+  /**
+   * System property enabling the return-stack tracing below (L3, bug hunt 2026-07-26).
+   *
+   * <p>The map is a pure debug aid: its only consumer is the Sentry message in {@link
+   * #borrowObject(Integer)}, which names the caller that last returned a buffer that came back out
+   * of the pool in an invalid state. Capturing and formatting a full stack trace on <em>every</em>
+   * successful {@code returnObject()} is a hot-path cost for a diagnostic that is almost never
+   * read, so it is opt-in and off by default. The invalid-return path itself keeps reporting
+   * unconditionally — that branch already captures its own stack trace and does not depend on this
+   * map.
+   */
+  static final String TRACE_RETURNS_PROPERTY = "redpanda.bytebufferpool.traceReturns";
+
+  private static volatile boolean traceReturns = Boolean.getBoolean(TRACE_RETURNS_PROPERTY);
+
+  /**
+   * Identity map (buffer equality is content-based and the content mutates, so {@link
+   * IdentityHashMap} is required) from a pooled buffer to the stack trace of its last return.
+   *
+   * <p>Entries are dropped again when the pool destroys the buffer — commons-pool's evictor
+   * destroys idle buffers after 30 s, and the entries used to stay strongly reachable for the whole
+   * process lifetime, so the map (and every multi-kilobyte trace string in it) grew without bound
+   * under bursty load. Accessed from every reader/writer thread, hence synchronized.
+   */
+  private static final Map<ByteBuffer, String> byteBufferToStacktrace =
+      Collections.synchronizedMap(new IdentityHashMap<>());
 
   private ByteBufferPool() {
     // Hide implicit public constructor
+  }
+
+  /** Test hook: toggles the return-stack tracing and returns the previous setting. */
+  static boolean setTraceReturnsForTest(boolean enabled) {
+    boolean previous = traceReturns;
+    traceReturns = enabled;
+    return previous;
+  }
+
+  /** Test hook: whether a return stack trace is currently held for this exact buffer instance. */
+  static boolean isTraced(ByteBuffer byteBuffer) {
+    return byteBufferToStacktrace.containsKey(byteBuffer);
   }
 
   public static void init() {
@@ -88,6 +127,15 @@ public class ByteBufferPool {
           }
 
           @Override
+          public void destroyObject(Integer key, PooledObject<ByteBuffer> p) throws Exception {
+            // The recorded stack trace must not outlive the buffer it describes: the evictor
+            // destroys idle buffers after 30 s, and without this the entry (and its multi-kilobyte
+            // trace string) stayed strongly reachable forever.
+            byteBufferToStacktrace.remove(p.getObject());
+            super.destroyObject(key, p);
+          }
+
+          @Override
           public PooledObject<ByteBuffer> wrap(ByteBuffer byteBuffer) {
             return new DefaultPooledObject<>(byteBuffer);
           }
@@ -119,7 +167,10 @@ public class ByteBufferPool {
     }
 
     while (byteBuffer.position() != 0 || byteBuffer.limit() != byteBuffer.capacity()) {
-      String stack = byteBufferToStacktrace.get(byteBuffer);
+      String stack =
+          traceReturns
+              ? byteBufferToStacktrace.get(byteBuffer)
+              : "not recorded (-D" + TRACE_RETURNS_PROPERTY + "=true to enable)";
       Log.sentry("borrowObject found an invalid ByteBuffer: " + byteBuffer + " stack: " + stack);
       try {
         pool.invalidateObject(key, byteBuffer);
@@ -164,11 +215,13 @@ public class ByteBufferPool {
         Log.sentry("had to invalidate ByteBuffer: \n" + out);
       }
     } else {
-      StringBuilder out = new StringBuilder();
-      for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
-        out.append(e.toString()).append("\n");
+      if (traceReturns) {
+        StringBuilder out = new StringBuilder();
+        for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
+          out.append(e.toString()).append("\n");
+        }
+        byteBufferToStacktrace.put(byteBuffer, out.toString());
       }
-      byteBufferToStacktrace.put(byteBuffer, out.toString());
       pool.returnObject(key, byteBuffer);
     }
   }

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -61,6 +61,96 @@ public class InboundCommandProcessor {
    */
   static java.util.function.Consumer<Thread> installThreadHookForTests = t -> {};
 
+  /**
+   * Wraps an update-distribution task so unchecked failures are reported instead of vanishing.
+   *
+   * <p>These tasks go to {@code ExecutorService.submit()} and nobody ever looks at the returned
+   * {@code Future}, so any {@code RuntimeException} was swallowed without a log line or a Sentry
+   * event. The upload runnables dereference {@code peer.writeBuffer} / {@code
+   * peer.writeBufferCrypted} after sleeping up to 60 s, and {@link Peer#disconnect(String)} nulls
+   * exactly those fields — a peer disconnecting inside that window produced a silent NPE. Locks and
+   * semaphores are released via {@code finally} either way, so this was a diagnostic blind spot on
+   * the update-distribution path rather than a leak, but it hid the one failure mode that path is
+   * most likely to hit.
+   *
+   * <p>{@link Error}s are reported and rethrown; only unchecked exceptions are absorbed.
+   */
+  static Runnable reporting(String taskName, Runnable task) {
+    return () -> {
+      try {
+        task.run();
+      } catch (RuntimeException e) {
+        logger.warn("update task '{}' failed", taskName, e);
+        Log.sentry(e);
+      } catch (Error e) {
+        logger.error("update task '{}' failed fatally", taskName, e);
+        Log.sentry(e);
+        throw e;
+      }
+    };
+  }
+
+  /**
+   * Writes a single update-request command byte into the peer's write buffer.
+   *
+   * <p>{@link Peer#disconnect(String)} nulls {@code writeBuffer} while holding {@code
+   * writeBufferLock}, so the field is re-read and checked under that lock (the TD008 pattern from
+   * {@link Peer#sendPing()}). The previous code did {@code lock(); peer.writeBuffer.put(...);
+   * unlock();} with no {@code finally} — a disconnect in that window did not only NPE, it left
+   * {@code writeBufferLock} permanently locked.
+   *
+   * @return {@code true} if the command was queued, {@code false} if the peer is gone
+   */
+  static boolean requestUpdateContent(Peer peer, byte command) {
+    peer.writeBufferLock.lock();
+    try {
+      ByteBuffer writeBuffer = peer.writeBuffer;
+      if (writeBuffer == null) {
+        logger.info("peer disconnected before the update could be requested, aborting");
+        return false;
+      }
+      writeBuffer.put(command);
+    } finally {
+      peer.writeBufferLock.unlock();
+    }
+    peer.setWriteBufferFilled();
+    return true;
+  }
+
+  /**
+   * Appends a fully built update frame to the peer's write buffer, growing the buffer if needed.
+   *
+   * <p>Same re-read-under-the-lock contract as {@link #requestUpdateContent(Peer, byte)}: the frame
+   * is built after a {@code Thread.sleep} and a multi-megabyte disk read, so the peer may well be
+   * gone by the time we get here. Dereferencing the nulled {@code writeBuffer} raised an NPE inside
+   * a {@code Runnable} whose {@code Future} nobody observes — no log, no Sentry.
+   *
+   * @return {@code true} if the frame was queued, {@code false} if the peer is gone
+   */
+  static boolean appendToWriteBuffer(Peer peer, ByteBuffer frame) {
+    peer.writeBufferLock.lock();
+    try {
+      ByteBuffer writeBuffer = peer.writeBuffer;
+      if (writeBuffer == null) {
+        logger.info("peer disconnected before the update could be uploaded, aborting");
+        return false;
+      }
+      if (writeBuffer.remaining() < frame.remaining()) {
+        ByteBuffer allocate =
+            ByteBuffer.allocate(writeBuffer.capacity() + frame.remaining() + 1024 * 1024 * 10);
+        writeBuffer.flip();
+        allocate.put(writeBuffer);
+        peer.writeBuffer = allocate;
+        writeBuffer = allocate;
+      }
+      writeBuffer.put(frame.array());
+    } finally {
+      peer.writeBufferLock.unlock();
+    }
+    peer.setWriteBufferFilled();
+    return true;
+  }
+
   /** System property overriding {@link #updateJarPath()}; used by tests to avoid CWD sharing. */
   private static final String JAR_PATH_PROPERTY = "redpanda.update.jar.path";
 
@@ -509,10 +599,9 @@ public class InboundCommandProcessor {
             ConnectionReaderThread.updateDownloadLock.lock();
             try {
               System.out.println("our version is outdated, we try to download it from this peer!");
-              peer.writeBufferLock.lock();
-              peer.getWriteBuffer().put(Command.UPDATE_REQUEST_CONTENT);
-              peer.writeBufferLock.unlock();
-              peer.setWriteBufferFilled();
+              if (!requestUpdateContent(peer, Command.UPDATE_REQUEST_CONTENT)) {
+                return;
+              }
               try {
                 Thread.sleep(60000);
               } catch (InterruptedException ignored) {
@@ -522,7 +611,7 @@ public class InboundCommandProcessor {
               ConnectionReaderThread.updateDownloadLock.unlock();
             }
           };
-      Server.threadPool.submit(runnable);
+      Server.threadPool.submit(reporting("update-request-content-download", runnable));
     }
     return 1 + 8;
   }
@@ -561,20 +650,8 @@ public class InboundCommandProcessor {
               a.put(serverContext.getLocalSettings().getUpdateSignature());
               a.put(data);
               a.flip();
-              peer.writeBufferLock.lock();
-              try {
-                if (peer.writeBuffer.remaining() < a.remaining()) {
-                  ByteBuffer allocate =
-                      ByteBuffer.allocate(
-                          peer.writeBuffer.capacity() + a.remaining() + 1024 * 1024 * 10);
-                  peer.writeBuffer.flip();
-                  allocate.put(peer.writeBuffer);
-                  peer.writeBuffer = allocate;
-                }
-                peer.writeBuffer.put(a.array());
-                peer.setWriteBufferFilled();
-              } finally {
-                peer.writeBufferLock.unlock();
+              if (!appendToWriteBuffer(peer, a)) {
+                return;
               }
             } catch (FileNotFoundException e) {
               Log.sentry(e);
@@ -587,7 +664,7 @@ public class InboundCommandProcessor {
             ConnectionReaderThread.updateUploadLock.release();
           }
         };
-    ConnectionReaderThread.threadPool.submit(runnable);
+    ConnectionReaderThread.threadPool.submit(reporting("update-answer-content-upload", runnable));
     return 1;
   }
 
@@ -645,7 +722,8 @@ public class InboundCommandProcessor {
       // read from the connection buffer has already been captured above (othersTimestamp,
       // signatureBytes, data), so nothing here races the reader moving on to the next command.
       ConnectionReaderThread.threadPool.submit(
-          () -> installJarUpdate(othersTimestamp, signatureBytes, data));
+          reporting(
+              "install-jar-update", () -> installJarUpdate(othersTimestamp, signatureBytes, data)));
     }
     return consumedBytes;
   }
@@ -746,10 +824,9 @@ public class InboundCommandProcessor {
               }
               System.out.println(
                   "our android.apk version is outdated, we try to download it from this peer!");
-              peer.writeBufferLock.lock();
-              peer.writeBuffer.put(Command.ANDROID_UPDATE_REQUEST_CONTENT);
-              peer.writeBufferLock.unlock();
-              peer.setWriteBufferFilled();
+              if (!requestUpdateContent(peer, Command.ANDROID_UPDATE_REQUEST_CONTENT)) {
+                return;
+              }
               try {
                 Thread.sleep(60000);
               } catch (InterruptedException ignored) {
@@ -760,7 +837,8 @@ public class InboundCommandProcessor {
             }
           };
       InboundCommandProcessor.this.serverContext.getNodeStore();
-      ConnectionReaderThread.threadPool.submit(runnable);
+      ConnectionReaderThread.threadPool.submit(
+          reporting("android-update-request-content-download", runnable));
     }
     return 1 + 8;
   }
@@ -810,20 +888,8 @@ public class InboundCommandProcessor {
               a.put(androidSignature);
               a.put(data);
               a.flip();
-              peer.writeBufferLock.lock();
-              try {
-                if (peer.writeBuffer.remaining() < a.remaining()) {
-                  ByteBuffer allocate =
-                      ByteBuffer.allocate(
-                          peer.writeBuffer.capacity() + a.remaining() + 1024 * 1024 * 10);
-                  peer.writeBuffer.flip();
-                  allocate.put(peer.writeBuffer);
-                  peer.writeBuffer = allocate;
-                }
-                peer.writeBuffer.put(a.array());
-                peer.setWriteBufferFilled();
-              } finally {
-                peer.writeBufferLock.unlock();
+              if (!appendToWriteBuffer(peer, a)) {
+                return;
               }
               int cnt = 0;
               while (cnt < 6) {
@@ -834,9 +900,13 @@ public class InboundCommandProcessor {
                 }
                 peer.writeBufferLock.lock();
                 try {
-                  if (!peer.isConnected()
-                      || (peer.writeBuffer.position() == 0
-                          && peer.writeBufferCrypted.position() == 0)) {
+                  // re-read under the lock: disconnect() nulls both buffers while holding it
+                  ByteBuffer writeBuffer = peer.writeBuffer;
+                  ByteBuffer writeBufferCrypted = peer.writeBufferCrypted;
+                  if (!peer.isConnected() || writeBuffer == null || writeBufferCrypted == null) {
+                    break;
+                  }
+                  if (writeBuffer.position() == 0 && writeBufferCrypted.position() == 0) {
                     break;
                   }
                 } finally {
@@ -851,7 +921,8 @@ public class InboundCommandProcessor {
             ConnectionReaderThread.updateUploadLock.release();
           }
         };
-    ConnectionReaderThread.threadPool.submit(runnable);
+    ConnectionReaderThread.threadPool.submit(
+        reporting("android-update-answer-content-upload", runnable));
     return 1;
   }
 
@@ -909,7 +980,8 @@ public class InboundCommandProcessor {
       // matching the request-side handlers. othersTimestamp/signature/data are already captured
       // above so nothing here races the reader moving on to the next command.
       ConnectionReaderThread.threadPool.submit(
-          () -> installApkUpdate(othersTimestamp, signature, data));
+          reporting(
+              "install-apk-update", () -> installApkUpdate(othersTimestamp, signature, data)));
     }
     return consumedBytes;
   }

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -68,10 +68,15 @@ public class InboundCommandProcessor {
    * {@code Future}, so any {@code RuntimeException} was swallowed without a log line or a Sentry
    * event. The upload runnables dereference {@code peer.writeBuffer} / {@code
    * peer.writeBufferCrypted} after sleeping up to 60 s, and {@link Peer#disconnect(String)} nulls
-   * exactly those fields — a peer disconnecting inside that window produced a silent NPE. Locks and
-   * semaphores are released via {@code finally} either way, so this was a diagnostic blind spot on
-   * the update-distribution path rather than a leak, but it hid the one failure mode that path is
-   * most likely to hit.
+   * exactly those fields — a peer disconnecting inside that window produced a silent NPE.
+   *
+   * <p>This wrapper only makes such a failure visible; it does not make the task bodies safe. Each
+   * body is responsible for its own cleanup, and two of them were not: {@code
+   * handleUpdateAnswerTimestamp} and {@code handleAndroidUpdateAnswerTimestamp} did {@code lock();
+   * put(); unlock();} with no {@code finally}, so the NPE left {@code writeBufferLock} held
+   * forever. That is fixed at the source — see {@link #requestUpdateContent(Peer, byte)} and {@link
+   * #appendToWriteBuffer(Peer, ByteBuffer)}, which hold the lock in a {@code try/finally} and abort
+   * cleanly when the peer is gone.
    *
    * <p>{@link Error}s are reported and rethrown; only unchecked exceptions are absorbed.
    */
@@ -143,7 +148,10 @@ public class InboundCommandProcessor {
         peer.writeBuffer = allocate;
         writeBuffer = allocate;
       }
-      writeBuffer.put(frame.array());
+      // put(ByteBuffer), not put(frame.array()): the bulk-array form writes the whole backing
+      // array regardless of position/limit and fails outright on a non-array-backed buffer, so it
+      // does not match the remaining() capacity check above (Copilot review).
+      writeBuffer.put(frame);
     } finally {
       peer.writeBufferLock.unlock();
     }

--- a/src/main/java/im/redpanda/core/Node.java
+++ b/src/main/java/im/redpanda/core/Node.java
@@ -7,12 +7,16 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class Node implements Serializable {
 
   static final int MAX_SCORE_VALUE = 50;
+
+  /** A connection point not seen for two weeks is dropped from the persisted node. */
+  static final long CONNECTION_POINT_MAX_AGE_MS = 1000L * 60L * 60L * 24L * 14L;
 
   private static final Logger logger = LogManager.getLogger();
 
@@ -61,6 +65,11 @@ public class Node implements Serializable {
     this.lastSeen = System.currentTimeMillis();
   }
 
+  /** The connection points currently known for this node (live list, not a copy). */
+  List<ConnectionPoint> getConnectionPoints() {
+    return connectionPoints;
+  }
+
   public ConnectionPoint latestSeenConnectionPoint() {
     if (connectionPoints.isEmpty()) {
       return null;
@@ -69,22 +78,35 @@ public class Node implements Serializable {
     return connectionPoints.getFirst();
   }
 
+  /**
+   * Records that this node was seen at {@code ip:port} and evicts every connection point that has
+   * not been seen for {@link #CONNECTION_POINT_MAX_AGE_MS}.
+   *
+   * <p>The loop used to {@code break} on the first match, so the staleness scan only ever covered
+   * the entries before the match — and never ran at all for a long-lived stable connection, whose
+   * point sits at the front of the list and is re-confirmed by {@code NodeConnectionPointsSeenJob}
+   * every two minutes. The entries are persisted, so a node seen from many addresses over time
+   * (mobile/NAT churn, replayed handshakes from many source IPs) accumulated connection points
+   * without the intended 14-day bound.
+   */
   public void seen(String ip, int port) {
     seen();
     ConnectionPoint connectionPoint = new ConnectionPoint(ip, port);
 
     ArrayList<ConnectionPoint> toRemove = new ArrayList<>();
+    long staleBefore = this.lastSeen - CONNECTION_POINT_MAX_AGE_MS;
 
     boolean found = false;
     for (ConnectionPoint point : connectionPoints) {
-      if (point.equals(connectionPoint)) {
+      if (!found && point.equals(connectionPoint)) {
         point.setLastSeen(this.lastSeen);
         point.resetRetries();
         found = true;
-        break;
+        // just refreshed, so it can never be stale — and the scan must continue over the rest
+        continue;
       }
 
-      if (point.lastSeen < this.lastSeen - 1000L * 60L * 60L * 24L * 14L) {
+      if (point.getLastSeen() < staleBefore) {
         logger.info("removed connection point since not seen since two weeks: " + point.getIp());
         toRemove.add(point);
       }

--- a/src/test/java/im/redpanda/core/ByteBufferPoolStacktraceTrackingTest.java
+++ b/src/test/java/im/redpanda/core/ByteBufferPoolStacktraceTrackingTest.java
@@ -1,0 +1,61 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression tests for L3 (bug hunt 2026-07-26): {@code byteBufferToStacktrace} recorded a full
+ * stack-trace string on every successful {@code returnObject()} and was never pruned.
+ * commons-pool's evictor destroys idle buffers after 30 s, but the map entries — and their
+ * multi-kilobyte strings — stayed strongly reachable for the whole process lifetime.
+ */
+public class ByteBufferPoolStacktraceTrackingTest {
+
+  private boolean previousTraceReturns;
+
+  @Before
+  public void setUp() {
+    ByteBufferPool.init();
+    previousTraceReturns = ByteBufferPool.setTraceReturnsForTest(false);
+  }
+
+  @After
+  public void tearDown() {
+    ByteBufferPool.setTraceReturnsForTest(previousTraceReturns);
+  }
+
+  /** The debug facility is opt-in: nothing is captured or retained on the hot return path. */
+  @Test
+  public void returnObject_recordsNothingWhenTracingIsDisabled() {
+    ByteBufferPool.setTraceReturnsForTest(false);
+
+    ByteBuffer buffer = ByteBufferPool.borrowObject(512);
+    ByteBufferPool.returnObject(buffer);
+
+    assertThat(ByteBufferPool.isTraced(buffer)).isFalse();
+  }
+
+  /** With tracing on the entry must not outlive the buffer it describes. */
+  @Test
+  public void tracedStacktraceIsDroppedWhenThePoolDestroysTheBuffer() {
+    ByteBufferPool.setTraceReturnsForTest(true);
+
+    ByteBuffer buffer = ByteBufferPool.borrowObject(512);
+    ByteBufferPool.returnObject(buffer);
+
+    assertThat(ByteBufferPool.isTraced(buffer))
+        .as("tracing is on, so the return stack must be recorded")
+        .isTrue();
+
+    // clear() destroys every idle object exactly like the evictor does after 30 s of idleness
+    ByteBufferPool.getPool().clear();
+
+    assertThat(ByteBufferPool.isTraced(buffer))
+        .as("the recorded stack must be dropped together with the destroyed buffer")
+        .isFalse();
+  }
+}

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorUpdateDisconnectTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorUpdateDisconnectTest.java
@@ -1,0 +1,97 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.nio.ByteBuffer;
+import org.junit.Test;
+
+/**
+ * Regression tests for L4 (bug hunt 2026-07-26): the update-distribution runnables dereferenced
+ * {@code peer.writeBuffer} after a {@code Thread.sleep} of up to 60 s and a multi-megabyte disk
+ * read. {@link Peer#disconnect(String)} nulls that field, so a peer disconnecting in that window
+ * raised an unchecked NPE inside a {@code Runnable} whose {@code Future} nobody observes — no log,
+ * no Sentry. Two of the sites additionally did {@code lock(); put(); unlock();} without a {@code
+ * finally}, so the NPE left {@code writeBufferLock} locked forever.
+ */
+public class InboundCommandProcessorUpdateDisconnectTest {
+
+  @Test
+  public void requestUpdateContent_abortsCleanlyWhenThePeerDisconnected() {
+    Peer peer = new Peer("127.0.0.1", 1234);
+    peer.writeBuffer = null; // what disconnect() leaves behind
+
+    assertThat(InboundCommandProcessor.requestUpdateContent(peer, Command.UPDATE_REQUEST_CONTENT))
+        .isFalse();
+    assertThat(peer.writeBufferLock.isLocked())
+        .as("the write buffer lock must not be left held")
+        .isFalse();
+  }
+
+  @Test
+  public void requestUpdateContent_writesTheCommandWhenConnected() {
+    Peer peer = new Peer("127.0.0.1", 1234);
+    peer.writeBuffer = ByteBuffer.allocate(64);
+
+    assertThat(InboundCommandProcessor.requestUpdateContent(peer, Command.UPDATE_REQUEST_CONTENT))
+        .isTrue();
+
+    peer.writeBuffer.flip();
+    assertThat(peer.writeBuffer.get()).isEqualTo(Command.UPDATE_REQUEST_CONTENT);
+    assertThat(peer.writeBufferLock.isLocked()).isFalse();
+  }
+
+  @Test
+  public void appendToWriteBuffer_abortsCleanlyWhenThePeerDisconnected() {
+    Peer peer = new Peer("127.0.0.1", 1234);
+    peer.writeBuffer = null;
+
+    ByteBuffer frame = ByteBuffer.allocate(8);
+    frame.putLong(42L);
+    frame.flip();
+
+    assertThat(InboundCommandProcessor.appendToWriteBuffer(peer, frame)).isFalse();
+    assertThat(peer.writeBufferLock.isLocked()).isFalse();
+  }
+
+  @Test
+  public void appendToWriteBuffer_growsTheBufferWhenTheFrameDoesNotFit() {
+    Peer peer = new Peer("127.0.0.1", 1234);
+    peer.writeBuffer = ByteBuffer.allocate(4);
+
+    byte[] payload = new byte[64];
+    payload[0] = 7;
+    ByteBuffer frame = ByteBuffer.wrap(payload);
+
+    assertThat(InboundCommandProcessor.appendToWriteBuffer(peer, frame)).isTrue();
+    assertThat(peer.writeBuffer.capacity()).isGreaterThan(payload.length);
+    assertThat(peer.writeBuffer.position()).isEqualTo(payload.length);
+    assertThat(peer.writeBuffer.get(0)).isEqualTo((byte) 7);
+  }
+
+  /** An unchecked failure in a submitted update task must be reported, not swallowed. */
+  @Test
+  public void reporting_absorbsAndReportsUncheckedExceptions() {
+    Runnable wrapped =
+        InboundCommandProcessor.reporting(
+            "unit-test",
+            () -> {
+              throw new NullPointerException("peer disconnected mid-upload");
+            });
+
+    assertThatCode(wrapped::run).doesNotThrowAnyException();
+  }
+
+  /** Errors stay fatal — they are reported and rethrown. */
+  @Test
+  public void reporting_rethrowsErrors() {
+    Runnable wrapped =
+        InboundCommandProcessor.reporting(
+            "unit-test",
+            () -> {
+              throw new StackOverflowError("boom");
+            });
+
+    assertThatCode(wrapped::run).isInstanceOf(StackOverflowError.class);
+  }
+}

--- a/src/test/java/im/redpanda/core/NodeSeenEvictionTest.java
+++ b/src/test/java/im/redpanda/core/NodeSeenEvictionTest.java
@@ -1,0 +1,86 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.Security;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Regression test for M5 (bug hunt 2026-07-26): {@code Node.seen(ip, port)} used to {@code break}
+ * out of its loop on the first matching connection point, so the two-week staleness scan only ever
+ * covered the entries before the match — and never ran at all for a long-lived stable connection,
+ * whose point sits at the front of the list and is re-confirmed every two minutes by {@code
+ * NodeConnectionPointsSeenJob}. The connection points are persisted with the node, so they
+ * accumulated without the intended 14-day bound.
+ */
+public class NodeSeenEvictionTest {
+
+  static {
+    Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+  }
+
+  @Test
+  public void seen_evictsStalePointsBehindTheMatchedOne() {
+    Node node = newNode();
+
+    node.addConnectionPoint("10.0.0.1", 1000); // the stable, always-matching point
+    node.addConnectionPoint("10.0.0.2", 2000); // stale
+    node.addConnectionPoint("10.0.0.3", 3000); // stale
+    node.addConnectionPoint("10.0.0.4", 4000); // recent
+
+    backdate(node, "10.0.0.2", Node.CONNECTION_POINT_MAX_AGE_MS + 60_000L);
+    backdate(node, "10.0.0.3", Node.CONNECTION_POINT_MAX_AGE_MS + 60_000L);
+    backdate(node, "10.0.0.4", Node.CONNECTION_POINT_MAX_AGE_MS - 60_000L);
+
+    node.seen("10.0.0.1", 1000);
+
+    assertThat(ips(node))
+        .as("the two-week scan must run past the matched point")
+        .containsExactly("10.0.0.1", "10.0.0.4");
+  }
+
+  @Test
+  public void seen_keepsTheMatchedPointEvenIfItWasStale() {
+    Node node = newNode();
+
+    node.addConnectionPoint("10.0.0.1", 1000);
+    backdate(node, "10.0.0.1", Node.CONNECTION_POINT_MAX_AGE_MS + 60_000L);
+
+    node.seen("10.0.0.1", 1000);
+
+    // the match is refreshed to "now", so it must never be collected by the same pass
+    assertThat(ips(node)).containsExactly("10.0.0.1");
+    assertThat(node.getConnectionPoints().getFirst().getRetries()).isZero();
+  }
+
+  @Test
+  public void seen_addsAnUnknownPointAndStillEvicts() {
+    Node node = newNode();
+
+    node.addConnectionPoint("10.0.0.2", 2000);
+    backdate(node, "10.0.0.2", Node.CONNECTION_POINT_MAX_AGE_MS + 60_000L);
+
+    node.seen("10.0.0.9", 9000);
+
+    assertThat(ips(node)).containsExactly("10.0.0.9");
+  }
+
+  private static Node newNode() {
+    return new Node(ServerContext.buildDefaultServerContext(), new NodeId());
+  }
+
+  private static List<String> ips(Node node) {
+    return node.getConnectionPoints().stream().map(Node.ConnectionPoint::getIp).toList();
+  }
+
+  private static void backdate(Node node, String ip, long ageMs) {
+    for (Node.ConnectionPoint point : node.getConnectionPoints()) {
+      if (point.getIp().equals(ip)) {
+        point.setLastSeen(System.currentTimeMillis() - ageMs);
+        return;
+      }
+    }
+    throw new IllegalStateException("no connection point for " + ip);
+  }
+}


### PR DESCRIPTION
Backlog **T64**, findings M5, L3 and L4 from `plans/bug-hunt-2026-07-26.md`. All three re-verified against current `main` (post #277–#282); all still present.

## M5 — `Node.seen(ip, port)` never ran the stale-ConnectionPoint scan

The loop both matched a known `ConnectionPoint` and collected two-week-stale ones, but `break`ed on the match — so the staleness scan only ever covered the entries *before* it. `NodeConnectionPointsSeenJob` calls `seen(ip, port)` every two minutes for every connected peer with an unchanged ip:port, which always takes the early-match path, so for a long-lived stable connection the eviction never ran at all. The points are persisted with the `Node`, so a node seen from many addresses over time (mobile/NAT churn, replayed handshakes from many source IPs) accumulated them without the intended 14-day bound.

The loop now `continue`s past the match instead of breaking. The matched point was just refreshed to `lastSeen = now`, so it can never be collected by the same pass. The magic constant became `Node.CONNECTION_POINT_MAX_AGE_MS`.

## L3 — `ByteBufferPool.byteBufferToStacktrace` grew unbounded

An `IdentityHashMap<ByteBuffer, String>` recorded a full formatted stack trace on every successful `returnObject()` and was never pruned. commons-pool's evictor destroys idle buffers after 30 s, but the entries — and every multi-kilobyte trace string — stayed strongly reachable for the whole process lifetime.

The map has exactly one consumer: the Sentry message in `borrowObject()` naming who last returned a buffer that came back in an invalid state. Two changes:

1. **Opt-in.** Capture happens only with `-Dredpanda.bytebufferpool.traceReturns=true`. Formatting a stack trace on *every* buffer return is a hot-path cost for a diagnostic that is almost never read; the invalid-return branch of `returnObject()` keeps reporting unconditionally with its own stack trace and does not use this map at all. With tracing off the Sentry message says so explicitly instead of printing `stack: null`.
2. **Pruned when enabled.** A new `destroyObject` override drops the entry when the pool destroys the buffer, so a recorded trace can no longer outlive the buffer it describes. The map is also `synchronizedMap` now — it was a plain `IdentityHashMap` written from every reader/writer thread. (`IdentityHashMap` itself is required: `ByteBuffer` equality is content-based and the content mutates.)

## L4 — update tasks swallowed NPEs after a disconnect

The six update-distribution runnables go to `ExecutorService.submit()` and nobody ever looks at the returned `Future`. The upload paths dereference `peer.writeBuffer` / `peer.writeBufferCrypted` after a `Thread.sleep` (200 ms, up to 60 s in the Android variant) and a multi-megabyte disk read, and `Peer.disconnect()` nulls exactly those fields — so a peer disconnecting in that window produced an NPE with no log and no Sentry event.

- All six tasks are wrapped in `reporting(name, task)`, which logs and reports unchecked exceptions; `Error`s are reported and rethrown.
- The buffer accesses moved into `requestUpdateContent(peer, command)` and `appendToWriteBuffer(peer, frame)`, which re-read and null-check the field *under* `writeBufferLock` — the same pattern `Peer.sendPing()` already uses (TD008) — and abort cleanly with a log line instead of throwing.
- **Additional finding while fixing:** two of the sites (`handleUpdateAnswerTimestamp`, `handleAndroidUpdateAnswerTimestamp`) did `writeBufferLock.lock(); peer.writeBuffer.put(...); writeBufferLock.unlock();` with **no** `finally`. The NPE there did not just vanish — it left `writeBufferLock` permanently held for that peer. That is fixed with them, so the "no leak, only a blind spot" assessment in the bug-hunt writeup was too optimistic for those two.
- The Android download-progress poll also re-reads both buffers under the lock instead of dereferencing the fields directly.

## Tests

- `NodeSeenEvictionTest` — stale points *behind* the matched one are evicted; a stale point that is itself the match survives (it was just refreshed); the unknown-point path still evicts.
- `ByteBufferPoolStacktraceTrackingTest` — nothing is recorded with tracing off; with tracing on the entry is dropped when the pool destroys the buffer.
- `InboundCommandProcessorUpdateDisconnectTest` — both buffer helpers return `false` and leave `writeBufferLock` unlocked when the peer disconnected, write/grow correctly when it did not, and `reporting(...)` absorbs unchecked exceptions while rethrowing `Error`s.

**Negative controls:** each of the three assertions fails against the pre-fix code by construction — the M5 test's `containsExactly("10.0.0.1", "10.0.0.4")` sees all four points when the loop `break`s (verified by running the test against the unmodified loop), the L3 test's `isTraced` is `true` after `clear()` without the `destroyObject` override, and the L4 helpers did not exist as separate methods, with the pre-fix inline code throwing NPE instead of returning `false`.

`mvn test`: 438 tests, 0 failures, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm