### PR TITLE
fix(L2,L1): reject degenerate X25519 keys and rate-limit reverse-garlic reflection

### DIFF
--- a/src/main/java/im/redpanda/core/PeerInHandshake.java
+++ b/src/main/java/im/redpanda/core/PeerInHandshake.java
@@ -1,9 +1,11 @@
 package im.redpanda.core;
 
+import im.redpanda.core.exceptions.PeerProtocolException;
 import im.redpanda.crypt.CryptoUtils;
 import java.io.IOException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
+import java.security.InvalidKeyException;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import org.bouncycastle.crypto.params.X25519PrivateKeyParameters;
@@ -221,8 +223,14 @@ public class PeerInHandshake {
   /**
    * Derives the session keys for this connection: X25519(ephemeralA, ephemeralB) + HKDF-SHA256 with
    * the sorted verify keys as salt (v23).
+   *
+   * @throws PeerProtocolException if the peer's ephemeral key is a degenerate X25519 point (RFC
+   *     7748 contributory-behaviour check, see {@link CryptoUtils#x25519}). A conforming client
+   *     derives its ephemeral public key from a random scalar and can never produce one, so this
+   *     only ever fires for a broken or hostile peer: drop the handshake quietly, like every other
+   *     protocol violation on this path.
    */
-  public void calculateSharedSecret(ServerContext serverContext) {
+  public void calculateSharedSecret(ServerContext serverContext) throws PeerProtocolException {
     if (nodeId == null || !nodeId.hasKey()) {
       throw new RuntimeException("calculateSharedSecret: missing the peers public NodeId keys");
     }
@@ -230,9 +238,15 @@ public class PeerInHandshake {
       throw new RuntimeException("calculateSharedSecret: ephemeral keys not exchanged yet");
     }
 
-    byte[] shared =
-        CryptoUtils.x25519(
-            ephemeralKeyFromUs, new X25519PublicKeyParameters(ephemeralPublicFromThem, 0));
+    byte[] shared;
+    try {
+      shared =
+          CryptoUtils.x25519(
+              ephemeralKeyFromUs, new X25519PublicKeyParameters(ephemeralPublicFromThem, 0));
+    } catch (InvalidKeyException e) {
+      throw new PeerProtocolException(
+          "degenerate ephemeral X25519 key from peer: " + e.getMessage());
+    }
 
     byte[] ourVerifyKey = serverContext.getNodeId().getVerifyKeyBytes();
     byte[] theirVerifyKey = nodeId.getVerifyKeyBytes();

--- a/src/main/java/im/redpanda/crypt/CryptoUtils.java
+++ b/src/main/java/im/redpanda/crypt/CryptoUtils.java
@@ -1,6 +1,8 @@
 package im.redpanda.crypt;
 
 import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
+import java.util.Arrays;
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
@@ -33,14 +35,49 @@ public final class CryptoUtils {
 
   private CryptoUtils() {}
 
-  /** Computes the raw X25519 shared secret (32 bytes). */
+  /**
+   * Computes the raw X25519 shared secret (32 bytes), rejecting degenerate peer public keys.
+   *
+   * <p>X25519 has small-order points: for those (and for a few other degenerate inputs such as
+   * {@code u = 0}, {@code u = 1} or {@code u = p}) the agreement output is all zeroes regardless of
+   * our private key, so a peer that sends one can force a shared secret it knows in advance. RFC
+   * 7748 §6.1 calls checking for this "contributory behaviour" and requires it wherever the output
+   * feeds a KDF — which is every call site here (HKDF-SHA256 → AES-GCM key).
+   *
+   * <p>Bouncy Castle already fails the agreement for those inputs, but it signals that with an
+   * unchecked {@link IllegalStateException}. That would escape the packet-parsing paths, which
+   * catch only {@link GeneralSecurityException} — a remotely triggerable unchecked throw on a
+   * reader thread. Translating it (and re-checking the output ourselves, so the guarantee does not
+   * depend on the provider) turns it into the ordinary "drop this packet" path.
+   *
+   * @throws InvalidKeyException if the peer's public key is degenerate — the caller must drop the
+   *     packet / connection
+   */
   public static byte[] x25519(
-      X25519PrivateKeyParameters privateKey, X25519PublicKeyParameters publicKey) {
+      X25519PrivateKeyParameters privateKey, X25519PublicKeyParameters publicKey)
+      throws InvalidKeyException {
     X25519Agreement agreement = new X25519Agreement();
     agreement.init(privateKey);
     byte[] shared = new byte[agreement.getAgreementSize()];
-    agreement.calculateAgreement(publicKey, shared, 0);
+    try {
+      agreement.calculateAgreement(publicKey, shared, 0);
+    } catch (IllegalStateException e) {
+      throw new InvalidKeyException("X25519 agreement failed: degenerate peer public key", e);
+    }
+    if (isAllZero(shared)) {
+      Arrays.fill(shared, (byte) 0);
+      throw new InvalidKeyException("X25519 agreement produced an all-zero shared secret");
+    }
     return shared;
+  }
+
+  /** Branch-free all-zero check (no early exit, so it leaks nothing about the secret). */
+  private static boolean isAllZero(byte[] bytes) {
+    int accumulator = 0;
+    for (byte b : bytes) {
+      accumulator |= b;
+    }
+    return accumulator == 0;
   }
 
   /** HKDF-SHA256: derives {@code outLen} bytes from the input key material. */

--- a/src/main/java/im/redpanda/flaschenpost/GarlicMessage.java
+++ b/src/main/java/im/redpanda/flaschenpost/GarlicMessage.java
@@ -4,6 +4,7 @@ import im.redpanda.core.*;
 import im.redpanda.crypt.CryptoUtils;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -234,6 +235,11 @@ public class GarlicMessage extends Flaschenpost {
         }
       }
 
+    } catch (InvalidKeyException e) {
+      // degenerate ephemeral X25519 key (RFC 7748 contributory-behaviour check in
+      // CryptoUtils.x25519): remotely triggerable, so drop it as quietly as a bad GCM tag rather
+      // than reporting one Sentry event per packet
+      Log.put("garlic message with a degenerate ephemeral key, dropping packet...", 50);
     } catch (AEADBadTagException e) {
       // authentication failed: tampered ciphertext, wrong recipient binding (AAD) or wrong key —
       // drop the packet without parsing anything

--- a/src/main/java/im/redpanda/flaschenpost/ReverseGarlic.java
+++ b/src/main/java/im/redpanda/flaschenpost/ReverseGarlic.java
@@ -7,6 +7,7 @@ import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.util.List;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.crypto.params.X25519PublicKeyParameters;
 
@@ -27,7 +28,41 @@ public final class ReverseGarlic {
 
   private static final SecureRandom RANDOM = new SecureRandom();
 
+  /**
+   * Global rate limiter for hop-carrying reverse-garlic emission (L1, bug hunt 2026-07-26).
+   *
+   * <p>The return-path hop descriptors are chosen entirely by the sender and never validated
+   * against the relays' real keys, so a deposit with a crafted return path makes this node emit an
+   * onion packet at an address of the attacker's choosing — bounded reflection. Amplification is
+   * already low (at most {@link ReturnPath#MAX_HOPS} hops, one ack-sized packet per deposit,
+   * fire-and-forget), but nothing capped the *rate* of attacker-driven emission. A single global
+   * bucket bounds it, following the same pattern as the record-store and record-lookup limiters in
+   * {@link GarlicRouter}: an unattributable garlic-wrapped path gets a global cap, not a per-source
+   * one.
+   *
+   * <p>Only the hop-carrying path is limited. With {@code hop_count = 0} this node is the final
+   * station itself — a local mailbox deposit or a normal MS02b forward toward the ack OH host, no
+   * sender-chosen destination and therefore no reflection — so the common direct-deposit R-ACK is
+   * never dropped by this.
+   */
+  private static volatile RecordStoreRateLimiter reflectionRateLimiter =
+      new RecordStoreRateLimiter(
+          RecordStoreRateLimiter.DEFAULT_CAPACITY,
+          RecordStoreRateLimiter.DEFAULT_REFILL_INTERVAL_MS,
+          System.currentTimeMillis());
+
   private ReverseGarlic() {}
+
+  /**
+   * Test-only hook: swaps the reflection rate limiter for a small, deterministic bucket so tests
+   * can exercise exhaustion without wall-clock timing. Returns the previous instance so the caller
+   * can restore it.
+   */
+  static RecordStoreRateLimiter swapReflectionRateLimiterForTest(RecordStoreRateLimiter limiter) {
+    RecordStoreRateLimiter previous = reflectionRateLimiter;
+    reflectionRateLimiter = Objects.requireNonNull(limiter);
+    return previous;
+  }
 
   /**
    * Sends {@code payload} back along {@code returnPath}. The payload is deposited into the ack OH
@@ -39,6 +74,10 @@ public final class ReverseGarlic {
     List<ReturnPath.Hop> hops = returnPath.hops();
     if (hops.isEmpty()) {
       deliverLocally(serverContext, returnPath, payload);
+      return;
+    }
+    if (!reflectionRateLimiter.tryAcquire(System.currentTimeMillis())) {
+      log.debug("reverse-garlic emission rate limit reached, dropping payload");
       return;
     }
     byte[] packet;

--- a/src/test/java/im/redpanda/core/PeerInHandshakeDegenerateKeyTest.java
+++ b/src/test/java/im/redpanda/core/PeerInHandshakeDegenerateKeyTest.java
@@ -1,0 +1,55 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import im.redpanda.core.exceptions.PeerProtocolException;
+import im.redpanda.crypt.CryptoUtils;
+import java.security.Security;
+import org.junit.Test;
+
+/**
+ * Regression test for L2 (bug hunt 2026-07-26) on the handshake path: an ephemeral X25519 key that
+ * is a small-order point makes the agreement all-zero, so it must not reach the HKDF that derives
+ * the session keys. {@code PeerProtocolException} is the existing "hostile-network noise" channel —
+ * {@code ConnectionHandler.handlePeerInHandshake} drops such a handshake quietly and closes the
+ * channel instead of reporting a Sentry error per occurrence.
+ */
+public class PeerInHandshakeDegenerateKeyTest {
+
+  static {
+    Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+  }
+
+  @Test
+  public void calculateSharedSecret_rejectsADegenerateEphemeralKey() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    PeerInHandshake handshake =
+        newHandshakeWith(serverContext, new byte[CryptoUtils.X25519_KEY_LEN]);
+
+    assertThatThrownBy(() -> handshake.calculateSharedSecret(serverContext))
+        .isInstanceOf(PeerProtocolException.class)
+        .hasMessageContaining("degenerate");
+  }
+
+  /** Interop guard: an ephemeral key from a conforming client still completes the key schedule. */
+  @Test
+  public void calculateSharedSecret_acceptsAnHonestEphemeralKey() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    PeerInHandshake theirSide = new PeerInHandshake("127.0.0.1", new Peer("127.0.0.1", 1234), null);
+    PeerInHandshake handshake =
+        newHandshakeWith(serverContext, theirSide.getEphemeralPublicFromUs());
+
+    assertThatCode(() -> handshake.calculateSharedSecret(serverContext)).doesNotThrowAnyException();
+  }
+
+  private static PeerInHandshake newHandshakeWith(
+      ServerContext serverContext, byte[] ephemeralFromThem) {
+    Peer peer = new Peer("127.0.0.1", 1234);
+    PeerInHandshake handshake = new PeerInHandshake("127.0.0.1", peer, null);
+    handshake.setNodeId(NodeId.importPublic(new NodeId().exportPublic()));
+    handshake.getEphemeralPublicFromUs(); // generate our own ephemeral keypair
+    handshake.setEphemeralPublicFromThem(ephemeralFromThem);
+    return handshake;
+  }
+}

--- a/src/test/java/im/redpanda/crypt/CryptoUtilsX25519ValidationTest.java
+++ b/src/test/java/im/redpanda/crypt/CryptoUtilsX25519ValidationTest.java
@@ -1,0 +1,125 @@
+package im.redpanda.crypt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.security.InvalidKeyException;
+import java.security.SecureRandom;
+import org.bouncycastle.crypto.params.X25519PrivateKeyParameters;
+import org.bouncycastle.crypto.params.X25519PublicKeyParameters;
+import org.junit.Test;
+
+/**
+ * Regression tests for L2 (bug hunt 2026-07-26): X25519 outputs feed HKDF at every call site, so
+ * degenerate peer public keys — the small-order points and the other inputs that make the agreement
+ * all-zero regardless of our private key — must be rejected before the KDF ever sees them (RFC 7748
+ * §6.1 contributory behaviour).
+ */
+public class CryptoUtilsX25519ValidationTest {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  /** {@code u = 0} — the canonical degenerate input. */
+  private static final byte[] ALL_ZERO = new byte[32];
+
+  /** {@code u = 1}, order 4. */
+  private static final byte[] U_ONE = withFirstByte(1);
+
+  /** An order-8 point (RFC 7748 §6.1 / the classic small-order test vector). */
+  private static final byte[] ORDER_EIGHT =
+      new byte[] {
+        (byte) 0xe0,
+        (byte) 0xeb,
+        0x7a,
+        0x7c,
+        0x3b,
+        0x41,
+        (byte) 0xb8,
+        (byte) 0xae,
+        0x16,
+        0x56,
+        (byte) 0xe3,
+        (byte) 0xfa,
+        (byte) 0xf1,
+        (byte) 0x9f,
+        (byte) 0xc4,
+        0x6a,
+        (byte) 0xda,
+        0x09,
+        (byte) 0x8d,
+        (byte) 0xeb,
+        (byte) 0x9c,
+        0x32,
+        (byte) 0xb1,
+        (byte) 0xfd,
+        (byte) 0x86,
+        0x62,
+        0x05,
+        0x16,
+        0x5f,
+        0x49,
+        (byte) 0xb8,
+        0x00
+      };
+
+  /** {@code u = p = 2^255 - 19}, i.e. 0 in disguise. */
+  private static final byte[] U_P = fieldPrime();
+
+  @Test
+  public void x25519_rejectsDegeneratePeerKeys() {
+    for (byte[] degenerate : new byte[][] {ALL_ZERO, U_ONE, ORDER_EIGHT, U_P}) {
+      assertThatThrownBy(
+              () ->
+                  CryptoUtils.x25519(
+                      new X25519PrivateKeyParameters(RANDOM),
+                      new X25519PublicKeyParameters(degenerate, 0)))
+          .as("degenerate peer key must never reach the KDF")
+          .isInstanceOf(InvalidKeyException.class);
+    }
+  }
+
+  /**
+   * Interop guard: a conforming peer derives its public key from a random scalar, which is never a
+   * degenerate point (probability ~2^-125). This is the evidence that the backend-side check cannot
+   * reject a well-behaved current client — the mobile side derives its keys the same way.
+   */
+  @Test
+  public void x25519_acceptsEveryHonestlyGeneratedKeypair() throws Exception {
+    for (int i = 0; i < 500; i++) {
+      X25519PrivateKeyParameters ours = new X25519PrivateKeyParameters(RANDOM);
+      X25519PrivateKeyParameters theirs = new X25519PrivateKeyParameters(RANDOM);
+
+      byte[] a = CryptoUtils.x25519(ours, theirs.generatePublicKey());
+      byte[] b = CryptoUtils.x25519(theirs, ours.generatePublicKey());
+
+      assertThat(a).isEqualTo(b);
+      assertThat(a).hasSize(CryptoUtils.X25519_KEY_LEN);
+    }
+  }
+
+  @Test
+  public void x25519_isStillAPlainAgreementForNormalKeys() {
+    X25519PrivateKeyParameters ours = new X25519PrivateKeyParameters(RANDOM);
+    X25519PrivateKeyParameters theirs = new X25519PrivateKeyParameters(RANDOM);
+
+    assertThatCode(() -> CryptoUtils.x25519(ours, theirs.generatePublicKey()))
+        .doesNotThrowAnyException();
+  }
+
+  private static byte[] withFirstByte(int value) {
+    byte[] bytes = new byte[32];
+    bytes[0] = (byte) value;
+    return bytes;
+  }
+
+  private static byte[] fieldPrime() {
+    byte[] bytes = new byte[32];
+    bytes[0] = (byte) 0xed;
+    for (int i = 1; i < 31; i++) {
+      bytes[i] = (byte) 0xff;
+    }
+    bytes[31] = (byte) 0x7f;
+    return bytes;
+  }
+}

--- a/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
+++ b/src/test/java/im/redpanda/e2e/HandshakeVersionsE2EIT.java
@@ -20,6 +20,7 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
+import java.security.InvalidKeyException;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Arrays;
@@ -340,8 +341,13 @@ public class HandshakeVersionsE2EIT {
       byte[] nodeEphemeral = readFully(32);
 
       X25519PrivateKeyParameters ephemeral = new X25519PrivateKeyParameters(RANDOM);
-      byte[] shared =
-          CryptoUtils.x25519(ephemeral, new X25519PublicKeyParameters(nodeEphemeral, 0));
+      byte[] shared;
+      try {
+        shared = CryptoUtils.x25519(ephemeral, new X25519PublicKeyParameters(nodeEphemeral, 0));
+      } catch (InvalidKeyException e) {
+        // the node under test always sends an honestly generated ephemeral key
+        throw new IOException("node sent a degenerate ephemeral X25519 key", e);
+      }
       byte[] ourVerify = identity.getVerifyKeyBytes();
       byte[] nodeVerify = Arrays.copyOfRange(nodePublicKey, 0, 32);
       byte[] minKey = Arrays.compareUnsigned(ourVerify, nodeVerify) <= 0 ? ourVerify : nodeVerify;
@@ -392,8 +398,13 @@ public class HandshakeVersionsE2EIT {
       byte[] nodeEphemeral = readFully(32);
 
       // key schedule (we initiated the connection -> client role)
-      byte[] shared =
-          CryptoUtils.x25519(ephemeral, new X25519PublicKeyParameters(nodeEphemeral, 0));
+      byte[] shared;
+      try {
+        shared = CryptoUtils.x25519(ephemeral, new X25519PublicKeyParameters(nodeEphemeral, 0));
+      } catch (InvalidKeyException e) {
+        // the node under test always sends an honestly generated ephemeral key
+        throw new IOException("node sent a degenerate ephemeral X25519 key", e);
+      }
       byte[] ourVerify = identity.getVerifyKeyBytes();
       byte[] nodeVerify = Arrays.copyOfRange(nodePublicKey, 0, 32);
       byte[] minKey = Arrays.compareUnsigned(ourVerify, nodeVerify) <= 0 ? ourVerify : nodeVerify;

--- a/src/test/java/im/redpanda/flaschenpost/GarlicMessageDegenerateKeyTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/GarlicMessageDegenerateKeyTest.java
@@ -1,0 +1,113 @@
+package im.redpanda.flaschenpost;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.ServerContext;
+import im.redpanda.crypt.CryptoUtils;
+import java.nio.ByteBuffer;
+import java.security.InvalidKeyException;
+import java.security.SecureRandom;
+import org.bouncycastle.crypto.params.X25519PublicKeyParameters;
+import org.junit.Test;
+
+/**
+ * Regression tests for L2 (bug hunt 2026-07-26) on the packet-parsing paths: a garlic message or
+ * flaschenpost layer whose ephemeral X25519 key is a small-order point must be dropped like any
+ * other bad packet. Before the check in {@code CryptoUtils.x25519}, BouncyCastle's own
+ * contributory-behaviour failure surfaced as an unchecked {@link IllegalStateException} — these
+ * paths catch only {@code GeneralSecurityException}, so a remote peer could throw an unchecked
+ * exception onto a reader thread with a 32-byte payload.
+ */
+public class GarlicMessageDegenerateKeyTest {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  @Test
+  public void garlicMessageWithDegenerateEphemeralKey_isDroppedWithoutThrowing() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+
+    GarlicMessage message =
+        new GarlicMessage(serverContext, buildPacketWithZeroEphemeralKey(serverContext.getNonce()));
+
+    assertThat(message.isTargetedToUs()).isTrue();
+    assertThatCode(message::parseContent).doesNotThrowAnyException();
+    assertThat(message.getGMContent()).isEmpty();
+  }
+
+  @Test
+  public void decryptPayload_reportsTheDegenerateKeyAsAnInvalidKey() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+
+    GarlicMessage message =
+        new GarlicMessage(serverContext, buildPacketWithZeroEphemeralKey(serverContext.getNonce()));
+
+    assertThatThrownBy(message::decryptPayload).isInstanceOf(InvalidKeyException.class);
+  }
+
+  @Test
+  public void flaschenpostLayerWithDegenerateEphemeralKey_isDroppedWithoutThrowing() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+
+    // a well-formed MS04 layer body whose ephemeral_pub is an all-zero (degenerate) point
+    byte[] ciphertext = new byte[64];
+    RANDOM.nextBytes(ciphertext);
+    ByteBuffer body = ByteBuffer.allocate(FlaschenpostV2.BODY_HEADER_LEN + ciphertext.length);
+    byte[] nonce = new byte[CryptoUtils.GCM_NONCE_LEN];
+    RANDOM.nextBytes(nonce);
+    body.put(nonce);
+    body.put(new byte[CryptoUtils.X25519_KEY_LEN]);
+    body.putInt(ciphertext.length);
+    body.put(ciphertext);
+
+    byte[] packet =
+        FlaschenpostV2.buildPacket(RANDOM.nextInt(), serverContext.getNonce(), body.array());
+
+    assertThatCode(() -> GarlicRouter.handle(serverContext, packet)).doesNotThrowAnyException();
+  }
+
+  /**
+   * Builds a syntactically valid garlic-message v2 packet addressed to {@code destination} whose
+   * ephemeral public key is the all-zero point. The ciphertext is random — the key agreement fails
+   * long before the GCM tag is ever checked.
+   */
+  private static byte[] buildPacketWithZeroEphemeralKey(KademliaId destination) {
+    byte[] nonce = new byte[GarlicMessage.NONCE_LEN];
+    RANDOM.nextBytes(nonce);
+    byte[] ciphertext = new byte[CryptoUtils.GCM_TAG_LEN + 16];
+    RANDOM.nextBytes(ciphertext);
+
+    int overallLength =
+        1
+            + 4
+            + KademliaId.ID_LENGTH_BYTES
+            + GarlicMessage.NONCE_LEN
+            + GarlicMessage.EPHEMERAL_KEY_LEN
+            + 4
+            + ciphertext.length;
+
+    ByteBuffer packet = ByteBuffer.allocate(overallLength);
+    packet.put(GarlicMessage.VERSION);
+    packet.putInt(overallLength - 1 - 4);
+    packet.put(destination.getBytes());
+    packet.put(nonce);
+    packet.put(new byte[GarlicMessage.EPHEMERAL_KEY_LEN]); // degenerate ephemeral key
+    packet.putInt(ciphertext.length);
+    packet.put(ciphertext);
+    return packet.array();
+  }
+
+  /** Sanity: the all-zero point really is rejected by the primitive this test relies on. */
+  @Test
+  public void allZeroPointIsRejectedByTheAgreement() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    assertThatThrownBy(
+            () ->
+                CryptoUtils.x25519(
+                    serverContext.getNodeId().getEncryptionKey(),
+                    new X25519PublicKeyParameters(new byte[CryptoUtils.X25519_KEY_LEN], 0)))
+        .isInstanceOf(InvalidKeyException.class);
+  }
+}

--- a/src/test/java/im/redpanda/flaschenpost/ReverseGarlicReflectionLimitTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/ReverseGarlicReflectionLimitTest.java
@@ -1,0 +1,139 @@
+package im.redpanda.flaschenpost;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import im.redpanda.core.Command;
+import im.redpanda.core.KademliaId;
+import im.redpanda.core.Peer;
+import im.redpanda.core.ServerContext;
+import im.redpanda.outbound.OutboundHandleStore;
+import im.redpanda.outbound.OutboundMailboxStore;
+import im.redpanda.outbound.OutboundService;
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression tests for L1 (bug hunt 2026-07-26): the return-path hop descriptors are chosen
+ * entirely by the sender and never validated, so a deposit with a crafted return path makes this
+ * node emit an onion packet at an address of the attacker's choosing. Amplification was already
+ * bounded (≤ {@link ReturnPath#MAX_HOPS} hops, one ack-sized packet, fire-and-forget), but nothing
+ * capped the rate of attacker-driven emission.
+ */
+public class ReverseGarlicReflectionLimitTest {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private ServerContext relay;
+  private ServerContext target;
+  private OutboundHandleStore handleStore;
+  private OutboundMailboxStore mailboxStore;
+  private Peer relayToTarget;
+  private RecordStoreRateLimiter previousLimiter;
+
+  @Before
+  public void setUp() {
+    relay = ServerContext.buildDefaultServerContext();
+    handleStore = new OutboundHandleStore();
+    mailboxStore = new OutboundMailboxStore();
+    relay.setOutboundService(new OutboundService(handleStore, mailboxStore));
+
+    target = ServerContext.buildDefaultServerContext();
+
+    relayToTarget = new Peer("127.0.0.1", 9601, target.getNodeId());
+    relayToTarget.setConnected(true);
+    relayToTarget.writeBuffer = ByteBuffer.allocate(65536);
+    relay.getPeerList().add(relayToTarget);
+  }
+
+  @After
+  public void tearDown() {
+    if (previousLimiter != null) {
+      ReverseGarlic.swapReflectionRateLimiterForTest(previousLimiter);
+    }
+  }
+
+  @Test
+  public void hopCarryingEmissionIsRateLimited() {
+    // one token, refilled once a minute → the second emission is deterministically over budget
+    previousLimiter =
+        ReverseGarlic.swapReflectionRateLimiterForTest(
+            new RecordStoreRateLimiter(1, 60_000L, System.currentTimeMillis()));
+
+    ReturnPath attackerChosenPath = pathVia(target);
+
+    ReverseGarlic.sendTaggedPayload(relay, attackerChosenPath, payload());
+    assertThat(emittedFrames()).as("the first hop-carrying emission is admitted").isEqualTo(1);
+
+    ReverseGarlic.sendTaggedPayload(relay, attackerChosenPath, payload());
+    ReverseGarlic.sendTaggedPayload(relay, attackerChosenPath, payload());
+    assertThat(emittedFrames())
+        .as("further emissions must be dropped while the bucket is empty")
+        .isZero();
+  }
+
+  /**
+   * hop_count = 0 is not a reflection vector — this node is the final station itself — so it must
+   * keep working even with an exhausted bucket.
+   */
+  @Test
+  public void zeroHopDeliveryIsNotRateLimited() {
+    previousLimiter =
+        ReverseGarlic.swapReflectionRateLimiterForTest(
+            new RecordStoreRateLimiter(1, 60_000L, System.currentTimeMillis()));
+
+    byte[] ohId = new byte[KademliaId.ID_LENGTH_BYTES];
+    RANDOM.nextBytes(ohId);
+    long now = System.currentTimeMillis();
+    handleStore.put(ohId, new OutboundHandleStore.HandleRecord(new byte[65], now, now + 60_000));
+
+    ReturnPath direct = new ReturnPath(ohId, sessionTag(), List.of());
+    for (int i = 0; i < 5; i++) {
+      ReverseGarlic.sendTaggedPayload(relay, direct, payload());
+    }
+
+    assertThat(mailboxStore.fetchMessages(ohId, 10, 0))
+        .as("direct deposits must never be dropped by the reflection limiter")
+        .hasSize(5);
+  }
+
+  /** A return path whose only hop is {@code hop} — the "reflect at this node" shape. */
+  private ReturnPath pathVia(ServerContext hop) {
+    byte[] ohId = new byte[KademliaId.ID_LENGTH_BYTES];
+    RANDOM.nextBytes(ohId);
+    return new ReturnPath(
+        ohId,
+        sessionTag(),
+        List.of(
+            new ReturnPath.Hop(
+                hop.getNonce(), hop.getNodeId().getEncryptionPubKey().getEncoded())));
+  }
+
+  private static byte[] sessionTag() {
+    byte[] tag = new byte[FlaschenpostV2.SESSION_TAG_LEN];
+    RANDOM.nextBytes(tag);
+    return tag;
+  }
+
+  private static byte[] payload() {
+    return "r-ack".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+  }
+
+  /** Counts (and drains) the FLASCHENPOST_V2 frames this relay wrote toward the target. */
+  private int emittedFrames() {
+    ByteBuffer out = relayToTarget.writeBuffer;
+    out.flip();
+    int frames = 0;
+    while (out.hasRemaining()) {
+      assertThat(out.get()).isEqualTo(Command.FLASCHENPOST_V2);
+      byte[] packet = new byte[out.getInt()];
+      out.get(packet);
+      frames++;
+    }
+    out.clear();
+    return frames;
+  }
+}


### PR DESCRIPTION
Backlog **T64**, findings L2 and L1 from `plans/bug-hunt-2026-07-26.md`. Both re-verified against current `main` (post #277–#283).

## L2 — no contributory-behaviour check on incoming X25519 keys

**Re-verification changed the shape of this finding.** Every X25519 output in this codebase feeds HKDF — garlic v2 (`GarlicMessage`), the MS04 layer crypto (`FlaschenpostV2`) and the v23 TCP key schedule (`PeerInHandshake`) — so a degenerate peer public key (small-order point, `u = 0`, `u = 1`, `u = p`) must be rejected before the KDF sees it (RFC 7748 §6.1). BouncyCastle 1.84 **already** fails the agreement for all of those (verified empirically for all four classes), so the "attacker forces a known shared secret" half of the finding is **already covered by the library**.

What is *not* covered: BC signals it with an unchecked `IllegalStateException("X25519 agreement failed")`, and the packet-parsing paths catch only `GeneralSecurityException` / `AEADBadTagException`. A remote peer could therefore throw an unchecked exception onto a reader thread with a 32-byte ephemeral key — the negative control below shows it escaping `GarlicRouter.handle` verbatim.

Fix: `CryptoUtils.x25519` translates it to `InvalidKeyException` and additionally re-checks the output itself (branch-free all-zero test), so the guarantee no longer depends on the provider's behaviour. Call sites:

| site | behaviour |
| --- | --- |
| `GarlicMessage.parseContent` | new explicit `InvalidKeyException` catch — dropped as quietly as a bad GCM tag, **no** Sentry event per hostile packet |
| `GarlicRouter.handle` → `FlaschenpostV2.decryptLayer` | already dropped on `GeneralSecurityException`, now actually reaches that branch |
| `PeerInHandshake.calculateSharedSecret` | throws `PeerProtocolException` — the existing "hostile-network noise" channel that `ConnectionHandler.handlePeerInHandshake` drops quietly and closes the channel for (REDPANDAJ-2DX pattern). **No change to `ConnectionHandler` was needed**: the call site already sits inside that try block. |
| `GarlicMessage.computeContent` / `FlaschenpostV2.encryptLayer` | send paths, already inside `throws`/`catch (GeneralSecurityException)` |

### Interop with current mobile clients — verified, no break

A conforming client derives its ephemeral (and identity) X25519 public key as `generatePublicKey()` of a random scalar; such a point is degenerate with probability ~2^-125. The mobile side derives its keys the same way, so **no well-behaved current client can produce a key this check rejects** — the change is backend-local and needs no coordinated rollout. `CryptoUtilsX25519ValidationTest.x25519_acceptsEveryHonestlyGeneratedKeypair` asserts exactly that over 500 fresh keypairs (both directions agree, nothing thrown), and `PeerInHandshakeDegenerateKeyTest.calculateSharedSecret_acceptsAnHonestEphemeralKey` does it for the handshake key schedule. This also does not touch H2 (the memo'd handshake-authentication decision) in any way.

## L1 — bounded reflection via the reverse-garlic return path

The return-path hop descriptors are chosen entirely by the sender and never validated against the relays' real keys, so a deposit carrying a crafted return path makes this node emit an onion packet at an address of the attacker's choosing. Amplification was already bounded — at most `MAX_HOPS = 4` hops, one ack-sized packet per deposit, fire-and-forget — but nothing capped the *rate* of attacker-driven emission.

A global token bucket now gates it, following the established `RecordStoreRateLimiter` pattern (record stores, and the record-lookup bucket from #269): a garlic-wrapped path has no attributable source, so it gets a global cap rather than a per-source one. Defaults are the shared ones (burst 60, refill 1/s).

**Only the hop-carrying path is limited.** With `hop_count = 0` this node is the final station itself — a local mailbox deposit or a normal MS02b forward toward the ack OH host — which has no sender-chosen destination and therefore no reflection, so the common direct-deposit R-ACK is never dropped by this. I did not treat this as needing a design decision: it is a drive-by limiter on an existing pattern, it does not change the wire format, and the un-limited path covers the normal case.

## Tests

- `CryptoUtilsX25519ValidationTest` — all four degenerate classes rejected; 500 honest keypairs accepted and agreeing.
- `GarlicMessageDegenerateKeyTest` — a garlic v2 packet and an MS04 layer with an all-zero ephemeral key are dropped without throwing; `decryptPayload` surfaces `InvalidKeyException`.
- `PeerInHandshakeDegenerateKeyTest` — degenerate ephemeral ⇒ `PeerProtocolException`; honest ephemeral ⇒ key schedule completes.
- `ReverseGarlicReflectionLimitTest` — with a 1-token bucket the first hop-carrying emission is admitted and the next two are dropped; `hop_count = 0` deposits are unaffected by an exhausted bucket.

**Negative controls (run):** with the `IllegalStateException` translation and the output re-check removed, 6 of the 8 L2 tests fail — and they fail *with* `java.lang.IllegalStateException: X25519 agreement failed` propagating out of `GarlicRouter.handle` / `GarlicMessage.parseContent`, i.e. the negative control reproduces the reader-thread throw the fix removes. With the limiter gate removed, `hopCarryingEmissionIsRateLimited` fails while `zeroHopDeliveryIsNotRateLimited` still passes.

`mvn test`: 438 tests, 0 failures, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm