### PR TITLE
fix(handshake): parse every plaintext handshake command in a read, not just the first

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -524,7 +524,15 @@ public class ConnectionHandler extends Thread {
           Log.put("read: " + read + " " + key.interestOps(), 150);
           if (peerInHandshake.getStatus() == 0) {
             /** The status indicates that no handshake was parsed before for this PeerInHandshake */
-            ConnectionReaderThread.parseHandshake(serverContext, peerInHandshake, allocate);
+            if (ConnectionReaderThread.parseHandshake(serverContext, peerInHandshake, allocate)) {
+              // parseHandshake() consumed the 30-byte handshake and compacted the buffer, so
+              // whatever the peer coalesced behind it is now at the front, ready to be flipped
+              // for reading. Dropping it here is the same defect as REDPANDAJ-2FA below.
+              allocate.flip();
+              if (!parsePlaintextHandshakeCommands(peerInHandshake, allocate)) {
+                return;
+              }
+            }
           } else {
 
             /**
@@ -532,58 +540,8 @@ public class ConnectionHandler extends Thread {
              * PeerInHandshake. Here we are providing more data for the other Peer like the public
              * key.
              */
-            byte command = allocate.get();
-            if (command == Command.REQUEST_PUBLIC_KEY) {
-              /** The other Peer requested our public key, lets send our public key! */
-              ConnectionReaderThread.sendPublicKeyToPeer(serverContext, peerInHandshake);
-            } else if (command == Command.SEND_PUBLIC_KEY && peerInHandshake.getStatus() == 1) {
-              /**
-               * We got the public key of the Peer, lets store it and check that this public key
-               * indeed corresponds to the KademliaId (v23: 64-byte Ed25519/X25519 export).
-               */
-              byte[] bytesPublicKey = new byte[NodeId.PUBLIC_KEYLEN];
-              allocate.get(bytesPublicKey);
-
-              NodeId nodeId = NodeId.importPublic(bytesPublicKey);
-
-              Log.put("new nodeid from peer: " + nodeId.getKademliaId(), 20);
-
-              if (!peerInHandshake.getIdentity().equals(nodeId.getKademliaId())) {
-                /**
-                 * We obtained a public key which does not match the KademliaId of this Peer and
-                 * should cancel that connection here.
-                 */
-                Log.put("Wrong KademliaId/Public Key for that peer...", 20);
-                peerInHandshake.setStatus(2);
-                peerInHandshake.getSocketChannel().close();
-              } else {
-                /**
-                 * We obtained the correct public key and can add it to the Peer and lets set that
-                 * peerInHandshake status to waiting for encryption
-                 */
-                peerInHandshake.getPeer().setNodeId(nodeId);
-                peerInHandshake.setNodeId(nodeId);
-                peerInHandshake.setStatus(-1);
-              }
-
-            } else if (command == Command.ACTIVATE_ENCRYPTION) {
-
-              /**
-               * We received the byte to activate the encryption; the payload is the 32-byte
-               * ephemeral X25519 public key of the peer (v23).
-               */
-              if (allocate.remaining() < 32) {
-                System.out.println("not enough bytes for encryption... " + allocate.remaining());
-                peerInHandshake.getSocketChannel().close();
-                return;
-              }
-              byte[] ephemeralFromThem = new byte[32];
-              allocate.get(ephemeralFromThem);
-              peerInHandshake.setEphemeralPublicFromThem(ephemeralFromThem);
-
-              peerInHandshake.setAwaitingEncryption(true);
-
-              System.out.println("parsed ACTIVATE_ENCRYPTION");
+            if (!parsePlaintextHandshakeCommands(peerInHandshake, allocate)) {
+              return;
             }
           }
 
@@ -681,6 +639,104 @@ public class ConnectionHandler extends Thread {
       Log.sentry(e);
       key.cancel();
     }
+  }
+
+  /**
+   * Consumes the plaintext handshake commands (REQUEST_PUBLIC_KEY / SEND_PUBLIC_KEY /
+   * ACTIVATE_ENCRYPTION) that are available in {@code buffer}.
+   *
+   * <p>REDPANDAJ-2FA: this used to parse exactly ONE command per {@code read()} and silently
+   * discard the rest of the buffer. TCP is a byte stream, so a peer that answers our
+   * REQUEST_PUBLIC_KEY in the same event-loop turn in which it sends its own REQUEST_PUBLIC_KEY
+   * puts both commands into a single segment. We then answered the first one and dropped its
+   * 65-byte SEND_PUBLIC_KEY, so the handshake stayed in status 1 forever: neither of the {@code
+   * status == -1} blocks in the caller runs, we never send our own ACTIVATE_ENCRYPTION and never
+   * activate encryption — while the peer treats the connection as usable and writes requests into
+   * it until its own watchdog redials. In the emulator duo E2E this cost ~60 s of dead connection
+   * plus the client's 90 s ack timeout and re-send backoff, i.e. a ~130 s first delivery.
+   *
+   * <p>Stops at the first command it cannot fully parse instead of resyncing mid-stream, and stops
+   * right after ACTIVATE_ENCRYPTION so the caller's REDPANDAJ-2DS block still sees a coalesced
+   * first GCM frame as leftover ciphertext.
+   *
+   * @return {@code false} if the connection was torn down and the caller must stop processing this
+   *     read event, {@code true} otherwise.
+   */
+  private boolean parsePlaintextHandshakeCommands(
+      PeerInHandshake peerInHandshake, ByteBuffer buffer) throws IOException {
+
+    while (buffer.hasRemaining()) {
+      byte command = buffer.get();
+
+      if (command == Command.REQUEST_PUBLIC_KEY) {
+        /** The other Peer requested our public key, lets send our public key! */
+        ConnectionReaderThread.sendPublicKeyToPeer(serverContext, peerInHandshake);
+      } else if (command == Command.SEND_PUBLIC_KEY && peerInHandshake.getStatus() == 1) {
+        /**
+         * We got the public key of the Peer, lets store it and check that this public key indeed
+         * corresponds to the KademliaId (v23: 64-byte Ed25519/X25519 export).
+         */
+        if (buffer.remaining() < NodeId.PUBLIC_KEYLEN) {
+          // Split across two reads. There is no cross-read buffer for the plaintext handshake
+          // phase, so this command can never be completed — and leaving it unparsed is exactly
+          // the wedge described above. Drop the connection instead; the peer redials and the
+          // retry gets a clean stream. (Before this method existed the same input threw
+          // BufferUnderflowException into the generic catch, which reported a Sentry error.)
+          System.out.println("not enough bytes for public key... " + buffer.remaining());
+          peerInHandshake.getSocketChannel().close();
+          return false;
+        }
+        byte[] bytesPublicKey = new byte[NodeId.PUBLIC_KEYLEN];
+        buffer.get(bytesPublicKey);
+
+        NodeId nodeId = NodeId.importPublic(bytesPublicKey);
+
+        Log.put("new nodeid from peer: " + nodeId.getKademliaId(), 20);
+
+        if (!peerInHandshake.getIdentity().equals(nodeId.getKademliaId())) {
+          /**
+           * We obtained a public key which does not match the KademliaId of this Peer and should
+           * cancel that connection here.
+           */
+          Log.put("Wrong KademliaId/Public Key for that peer...", 20);
+          peerInHandshake.setStatus(2);
+          peerInHandshake.getSocketChannel().close();
+          return false;
+        }
+        /**
+         * We obtained the correct public key and can add it to the Peer and lets set that
+         * peerInHandshake status to waiting for encryption
+         */
+        peerInHandshake.getPeer().setNodeId(nodeId);
+        peerInHandshake.setNodeId(nodeId);
+        peerInHandshake.setStatus(-1);
+      } else if (command == Command.ACTIVATE_ENCRYPTION) {
+
+        /**
+         * We received the byte to activate the encryption; the payload is the 32-byte ephemeral
+         * X25519 public key of the peer (v23).
+         */
+        if (buffer.remaining() < 32) {
+          System.out.println("not enough bytes for encryption... " + buffer.remaining());
+          peerInHandshake.getSocketChannel().close();
+          return false;
+        }
+        byte[] ephemeralFromThem = new byte[32];
+        buffer.get(ephemeralFromThem);
+        peerInHandshake.setEphemeralPublicFromThem(ephemeralFromThem);
+
+        peerInHandshake.setAwaitingEncryption(true);
+
+        System.out.println("parsed ACTIVATE_ENCRYPTION");
+        // Anything left belongs to the encrypted stream (REDPANDAJ-2DS), not to this loop.
+        return true;
+      } else {
+        // Not a plaintext handshake command we can act on in this state. Do not try to resync on
+        // the following bytes — that is how a desynced stream turns into random command dispatch.
+        break;
+      }
+    }
+    return true;
   }
 
   /**

--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -38,6 +38,12 @@ public class ConnectionHandler extends Thread {
   public static Selector selector;
   public static final ReentrantLock selectorLock = new ReentrantLock();
 
+  /**
+   * Upper bound for {@link #parsePlaintextHandshakeCommands}: the plaintext phase only ever carries
+   * REQUEST_PUBLIC_KEY, SEND_PUBLIC_KEY and ACTIVATE_ENCRYPTION.
+   */
+  static final int MAX_PLAINTEXT_HANDSHAKE_COMMANDS_PER_READ = 3;
+
   public static ArrayList<PeerInHandshake> peerInHandshakes = new ArrayList<>();
   @Getter private ReentrantLock peerInHandshakesLock = new ReentrantLock(false);
   public static BlockingQueue<Peer> peersToReadAndParse = new LinkedBlockingQueue<>(600);
@@ -665,7 +671,12 @@ public class ConnectionHandler extends Thread {
   private boolean parsePlaintextHandshakeCommands(
       PeerInHandshake peerInHandshake, ByteBuffer buffer) throws IOException {
 
-    while (buffer.hasRemaining()) {
+    // The plaintext phase knows exactly three commands, so a well-behaved peer never sends more
+    // than that in one read. The cap keeps a hostile peer from turning a single 117-byte read of
+    // REQUEST_PUBLIC_KEY bytes into 117 public-key writes (65 bytes each) back at it.
+    int commandsLeft = MAX_PLAINTEXT_HANDSHAKE_COMMANDS_PER_READ;
+
+    while (buffer.hasRemaining() && commandsLeft-- > 0) {
       byte command = buffer.get();
 
       if (command == Command.REQUEST_PUBLIC_KEY) {

--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -44,6 +44,9 @@ public class ConnectionHandler extends Thread {
    */
   static final int MAX_PLAINTEXT_HANDSHAKE_COMMANDS_PER_READ = 3;
 
+  /** Longest plaintext handshake command: SEND_PUBLIC_KEY plus its 64-byte key export. */
+  static final int MAX_PLAINTEXT_HANDSHAKE_COMMAND_LEN = 1 + NodeId.PUBLIC_KEYLEN;
+
   public static ArrayList<PeerInHandshake> peerInHandshakes = new ArrayList<>();
   @Getter private ReentrantLock peerInHandshakesLock = new ReentrantLock(false);
   public static BlockingQueue<Peer> peersToReadAndParse = new LinkedBlockingQueue<>(600);
@@ -528,25 +531,35 @@ public class ConnectionHandler extends Thread {
         if (!peerInHandshake.isEncryptionActive()) {
 
           Log.put("read: " + read + " " + key.interestOps(), 150);
+
+          /**
+           * The buffer the plaintext handshake commands are decoded from. Usually the read buffer
+           * itself; a previous read that ended mid-command hands its tail over here
+           * (REDPANDAJ-2FA), and then it is the concatenation of both.
+           */
+          ByteBuffer plaintext = allocate;
+
+          boolean handshakeParsed = true;
           if (peerInHandshake.getStatus() == 0) {
             /** The status indicates that no handshake was parsed before for this PeerInHandshake */
-            if (ConnectionReaderThread.parseHandshake(serverContext, peerInHandshake, allocate)) {
+            handshakeParsed =
+                ConnectionReaderThread.parseHandshake(serverContext, peerInHandshake, allocate);
+            if (handshakeParsed) {
               // parseHandshake() consumed the 30-byte handshake and compacted the buffer, so
               // whatever the peer coalesced behind it is now at the front, ready to be flipped
-              // for reading. Dropping it here is the same defect as REDPANDAJ-2FA below.
+              // for reading. Dropping it here is the same defect as REDPANDAJ-2FA.
               allocate.flip();
-              if (!parsePlaintextHandshakeCommands(peerInHandshake, allocate)) {
-                return;
-              }
             }
-          } else {
+          }
 
-            /**
-             * The status indicates that the first handshake was already parsed before for this
-             * PeerInHandshake. Here we are providing more data for the other Peer like the public
-             * key.
-             */
-            if (!parsePlaintextHandshakeCommands(peerInHandshake, allocate)) {
+          /**
+           * For a status other than 0 the first handshake was already parsed before for this
+           * PeerInHandshake. Here we are providing more data for the other Peer like the public
+           * key.
+           */
+          if (handshakeParsed) {
+            plaintext = peerInHandshake.prependPlaintextHandshakeCarry(allocate);
+            if (!parsePlaintextHandshakeCommands(peerInHandshake, plaintext)) {
               return;
             }
           }
@@ -605,15 +618,15 @@ public class ConnectionHandler extends Thread {
 
             /**
              * REDPANDAJ-2DS: if the peer's ACTIVATE_ENCRYPTION and its first GCM frame (counter 0)
-             * were coalesced by the kernel into this single read(), 'allocate' still holds the
-             * ciphertext of that first frame after the plaintext branch above consumed only the
+             * were coalesced by the kernel into this single read(), 'plaintext' still holds the
+             * ciphertext of that first frame after the plaintext branch above stopped at the
              * ACTIVATE_ENCRYPTION command. Encryption is active now (activateEncryption() just
              * ran), so feed the leftover bytes into decrypt() right away instead of silently
              * dropping them - dropping them would desync the receive counter and the next frame
              * would fail with "unexpected GCM frame nonce".
              */
-            if (allocate.hasRemaining()) {
-              handleFirstEncryptedCommand(peerInHandshake, allocate);
+            if (plaintext.hasRemaining()) {
+              handleFirstEncryptedCommand(peerInHandshake, plaintext);
             }
           }
 
@@ -688,14 +701,7 @@ public class ConnectionHandler extends Thread {
          * corresponds to the KademliaId (v23: 64-byte Ed25519/X25519 export).
          */
         if (buffer.remaining() < NodeId.PUBLIC_KEYLEN) {
-          // Split across two reads. There is no cross-read buffer for the plaintext handshake
-          // phase, so this command can never be completed — and leaving it unparsed is exactly
-          // the wedge described above. Drop the connection instead; the peer redials and the
-          // retry gets a clean stream. (Before this method existed the same input threw
-          // BufferUnderflowException into the generic catch, which reported a Sentry error.)
-          System.out.println("not enough bytes for public key... " + buffer.remaining());
-          peerInHandshake.getSocketChannel().close();
-          return false;
+          return carryOverIncompleteCommand(peerInHandshake, buffer);
         }
         byte[] bytesPublicKey = new byte[NodeId.PUBLIC_KEYLEN];
         buffer.get(bytesPublicKey);
@@ -728,9 +734,7 @@ public class ConnectionHandler extends Thread {
          * X25519 public key of the peer (v23).
          */
         if (buffer.remaining() < 32) {
-          System.out.println("not enough bytes for encryption... " + buffer.remaining());
-          peerInHandshake.getSocketChannel().close();
-          return false;
+          return carryOverIncompleteCommand(peerInHandshake, buffer);
         }
         byte[] ephemeralFromThem = new byte[32];
         buffer.get(ephemeralFromThem);
@@ -747,6 +751,38 @@ public class ConnectionHandler extends Thread {
         break;
       }
     }
+    return true;
+  }
+
+  /**
+   * Stashes a plaintext handshake command whose payload has not fully arrived yet, so the next read
+   * can decode it (REDPANDAJ-2FA). {@code buffer} is positioned right after the command byte, which
+   * is rewound back into the stash.
+   *
+   * <p>Before this, an incomplete SEND_PUBLIC_KEY threw {@code BufferUnderflowException} into the
+   * generic catch and an incomplete ACTIVATE_ENCRYPTION closed the connection ("not enough bytes
+   * for encryption..."). Both cost the peer a full redial, and the light client that hit the latter
+   * during an S4 reconnect did not come back at all.
+   *
+   * @return always {@code true} for the "wait for more bytes" case; {@code false} only when the
+   *     stash would exceed the longest plaintext command, which no conforming peer can produce.
+   */
+  private boolean carryOverIncompleteCommand(PeerInHandshake peerInHandshake, ByteBuffer buffer)
+      throws IOException {
+    buffer.position(buffer.position() - 1); // put the command byte back
+    byte[] carry = new byte[buffer.remaining()];
+    buffer.get(carry);
+    if (carry.length > MAX_PLAINTEXT_HANDSHAKE_COMMAND_LEN) {
+      // Cannot happen for a conforming peer: we only get here when the command is INcomplete, so
+      // the tail is shorter than the command. Belt and braces against an unbounded stash.
+      System.out.println("oversized plaintext handshake remainder... " + carry.length);
+      peerInHandshake.getSocketChannel().close();
+      return false;
+    }
+    peerInHandshake.setPlaintextHandshakeCarry(carry);
+    Log.put(
+        "plaintext handshake command split across reads, carrying " + carry.length + " byte(s)",
+        20);
     return true;
   }
 

--- a/src/main/java/im/redpanda/core/PeerInHandshake.java
+++ b/src/main/java/im/redpanda/core/PeerInHandshake.java
@@ -3,6 +3,7 @@ package im.redpanda.core;
 import im.redpanda.core.exceptions.PeerProtocolException;
 import im.redpanda.crypt.CryptoUtils;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.security.InvalidKeyException;
@@ -51,6 +52,16 @@ public class PeerInHandshake {
   private byte[] receiveKey;
 
   private PeerChiperStreams peerChiperStreams;
+
+  /**
+   * Bytes of a plaintext handshake command that did not fit into the read that started it
+   * (REDPANDAJ-2FA). The plaintext phase is framed by fixed command lengths, not by a length
+   * prefix, so a command split across two reads used to be undecodable: SEND_PUBLIC_KEY threw
+   * BufferUnderflowException and ACTIVATE_ENCRYPTION closed the connection ("not enough bytes for
+   * encryption..."), which cost the peer a full redial. They are carried over to the next read
+   * instead. Never larger than the longest command (1 + 64 bytes).
+   */
+  private byte[] plaintextHandshakeCarry;
 
   private final long createdAt;
 
@@ -150,6 +161,33 @@ public class PeerInHandshake {
     } catch (IOException closeEx) {
       closeEx.printStackTrace();
     }
+  }
+
+  /**
+   * Prepends the bytes stashed by the previous read (REDPANDAJ-2FA) to {@code justRead} and clears
+   * the stash. Returns {@code justRead} unchanged when there is nothing to carry over, which is the
+   * normal case.
+   */
+  ByteBuffer prependPlaintextHandshakeCarry(ByteBuffer justRead) {
+    if (plaintextHandshakeCarry == null) {
+      return justRead;
+    }
+    ByteBuffer merged =
+        ByteBuffer.allocate(plaintextHandshakeCarry.length + justRead.remaining())
+            .put(plaintextHandshakeCarry)
+            .put(justRead);
+    plaintextHandshakeCarry = null;
+    merged.flip();
+    return merged;
+  }
+
+  /** Stashes the not-yet-decodable tail of a plaintext handshake read for the next read. */
+  void setPlaintextHandshakeCarry(byte[] carry) {
+    plaintextHandshakeCarry = carry;
+  }
+
+  int plaintextHandshakeCarryLength() {
+    return plaintextHandshakeCarry == null ? 0 : plaintextHandshakeCarry.length;
   }
 
   public int getPort() {

--- a/src/test/java/im/redpanda/core/ConnectionHandlerCoalescedPublicKeyTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerCoalescedPublicKeyTest.java
@@ -99,7 +99,11 @@ public class ConnectionHandlerCoalescedPublicKeyTest {
           ByteBuffer inbound = ByteBuffer.allocate(256);
           int expected = 1 + NodeId.PUBLIC_KEYLEN + 1 + 32;
           long deadline = System.currentTimeMillis() + 5_000;
-          // non-blocking + deadline: a regression must fail the assertions below, never hang CI
+          // SocketChannel.open() hands back a BLOCKING channel, in which read() parks until bytes
+          // arrive - a regression that writes fewer bytes than expected would hang the build
+          // instead of failing it. Switch to non-blocking so the deadline below actually bounds
+          // this loop (Copilot review, PR #288).
+          client.configureBlocking(false);
           while (inbound.position() < expected && System.currentTimeMillis() < deadline) {
             if (client.read(inbound) == 0) {
               Thread.sleep(10);

--- a/src/test/java/im/redpanda/core/ConnectionHandlerCoalescedPublicKeyTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerCoalescedPublicKeyTest.java
@@ -30,6 +30,90 @@ public class ConnectionHandlerCoalescedPublicKeyTest {
     java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
   }
 
+  /**
+   * The other half of REDPANDAJ-2FA: a command whose payload has not fully arrived yet must be
+   * carried over to the next read. SEND_PUBLIC_KEY used to throw BufferUnderflowException here and
+   * ACTIVATE_ENCRYPTION closed the connection outright.
+   */
+  @Test
+  public void sendPublicKeySplitAcrossTwoReadsIsCarriedOver() throws Exception {
+    ByteBufferPool.init();
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    ConnectionHandler connectionHandler = new ConnectionHandler(serverContext, false);
+
+    try (ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+        Selector selector = Selector.open()) {
+      serverSocketChannel.configureBlocking(false);
+      serverSocketChannel.bind(new InetSocketAddress("127.0.0.1", 0));
+      int port = serverSocketChannel.socket().getLocalPort();
+
+      try (SocketChannel client = SocketChannel.open(new InetSocketAddress("127.0.0.1", port))) {
+        SocketChannel accepted;
+        do {
+          accepted = serverSocketChannel.accept();
+        } while (accepted == null);
+        accepted.configureBlocking(false);
+
+        NodeId peerIdentity = NodeId.generateWithSimpleKey();
+        PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", accepted);
+        peerInHandshake.setPeer(new Peer("127.0.0.1", 0));
+        peerInHandshake.setProtocolVersion(23);
+        peerInHandshake.setLightClient(true);
+        peerInHandshake.setIdentity(peerIdentity.getKademliaId());
+        peerInHandshake.setStatus(1);
+
+        SelectionKey key = accepted.register(selector, SelectionKey.OP_READ);
+        key.attach(peerInHandshake);
+        peerInHandshake.setKey(key);
+        connectionHandler.addPeerInHandshake(peerInHandshake);
+
+        Method handlePeerInHandshake =
+            ConnectionHandler.class.getDeclaredMethod("handlePeerInHandshake", SelectionKey.class);
+        handlePeerInHandshake.setAccessible(true);
+
+        try {
+          byte[] peerPublicExport = peerIdentity.exportPublic();
+          int firstChunk = 30; // command byte + 29 of the 64 key bytes
+
+          ByteBuffer head = ByteBuffer.allocate(1 + firstChunk);
+          head.put(Command.SEND_PUBLIC_KEY);
+          head.put(peerPublicExport, 0, firstChunk);
+          head.flip();
+          client.write(head);
+
+          assertTrue("expected a first readable event", selector.select(10_000) > 0);
+          selector.selectedKeys().clear();
+          handlePeerInHandshake.invoke(connectionHandler, key);
+
+          assertEquals(
+              "the incomplete command must be stashed, not consumed or dropped",
+              1 + firstChunk,
+              peerInHandshake.plaintextHandshakeCarryLength());
+          assertEquals("still waiting for the key", 1, peerInHandshake.getStatus());
+          assertTrue("the connection must stay open", accepted.isOpen());
+
+          ByteBuffer tail = ByteBuffer.allocate(peerPublicExport.length - firstChunk);
+          tail.put(peerPublicExport, firstChunk, peerPublicExport.length - firstChunk);
+          tail.flip();
+          client.write(tail);
+
+          assertTrue("expected a second readable event", selector.select(10_000) > 0);
+          selector.selectedKeys().clear();
+          handlePeerInHandshake.invoke(connectionHandler, key);
+
+          assertEquals(
+              "the split SEND_PUBLIC_KEY must be decoded once the tail arrived",
+              -1,
+              peerInHandshake.getStatus());
+          assertEquals(0, peerInHandshake.plaintextHandshakeCarryLength());
+          assertNotNull(peerInHandshake.getNodeId());
+        } finally {
+          connectionHandler.removePeerInHandshake(peerInHandshake);
+        }
+      }
+    }
+  }
+
   @Test
   public void coalescedRequestAndSendPublicKeyArePromotedInOneEvent() throws Exception {
     ByteBufferPool.init();

--- a/src/test/java/im/redpanda/core/ConnectionHandlerCoalescedPublicKeyTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerCoalescedPublicKeyTest.java
@@ -1,0 +1,122 @@
+package im.redpanda.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import org.junit.Test;
+
+/**
+ * REDPANDAJ-2FA regression: {@code ConnectionHandler.handlePeerInHandshake} must not drop the
+ * peer's SEND_PUBLIC_KEY when it arrives coalesced with the peer's own REQUEST_PUBLIC_KEY in a
+ * single read().
+ *
+ * <p>Both commands are written by the light client within one event-loop turn (it answers our
+ * REQUEST_PUBLIC_KEY right after asking for ours), so the kernel regularly delivers them as one
+ * segment. Parsing only the first command left the handshake in status 1 forever — we never sent
+ * our ACTIVATE_ENCRYPTION, encryption never activated, and the client kept writing requests into a
+ * connection the node would never answer.
+ */
+public class ConnectionHandlerCoalescedPublicKeyTest {
+
+  static {
+    java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+  }
+
+  @Test
+  public void coalescedRequestAndSendPublicKeyArePromotedInOneEvent() throws Exception {
+    ByteBufferPool.init();
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    ConnectionHandler connectionHandler = new ConnectionHandler(serverContext, false);
+
+    try (ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+        Selector selector = Selector.open()) {
+      serverSocketChannel.configureBlocking(false);
+      serverSocketChannel.bind(new InetSocketAddress("127.0.0.1", 0));
+      int port = serverSocketChannel.socket().getLocalPort();
+
+      try (SocketChannel client = SocketChannel.open(new InetSocketAddress("127.0.0.1", port))) {
+        SocketChannel accepted;
+        do {
+          accepted = serverSocketChannel.accept();
+        } while (accepted == null);
+        accepted.configureBlocking(false);
+
+        // State right after parseHandshake(): the peer's identity (KademliaId) is known from the
+        // 30-byte handshake, we asked for its public key (status 1) and are waiting for it.
+        NodeId peerIdentity = NodeId.generateWithSimpleKey();
+        PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", accepted);
+        peerInHandshake.setPeer(new Peer("127.0.0.1", 0));
+        peerInHandshake.setProtocolVersion(23);
+        peerInHandshake.setLightClient(true);
+        peerInHandshake.setIdentity(peerIdentity.getKademliaId());
+        peerInHandshake.setStatus(1);
+
+        SelectionKey key = accepted.register(selector, SelectionKey.OP_READ);
+        key.attach(peerInHandshake);
+        peerInHandshake.setKey(key);
+        connectionHandler.addPeerInHandshake(peerInHandshake);
+
+        try {
+          // One write() => one segment => one read() server-side: the client asks for our public
+          // key and answers ours in the same turn.
+          byte[] peerPublicExport = peerIdentity.exportPublic();
+          ByteBuffer combined = ByteBuffer.allocate(1 + 1 + peerPublicExport.length);
+          combined.put(Command.REQUEST_PUBLIC_KEY);
+          combined.put(Command.SEND_PUBLIC_KEY);
+          combined.put(peerPublicExport);
+          combined.flip();
+          client.write(combined);
+
+          assertTrue(
+              "expected the accepted channel to become readable", selector.select(10_000) > 0);
+          SelectionKey readyKey = selector.selectedKeys().iterator().next();
+
+          Method handlePeerInHandshake =
+              ConnectionHandler.class.getDeclaredMethod(
+                  "handlePeerInHandshake", SelectionKey.class);
+          handlePeerInHandshake.setAccessible(true);
+          handlePeerInHandshake.invoke(connectionHandler, readyKey);
+
+          // Without the fix only REQUEST_PUBLIC_KEY was consumed and the status stayed 1, so the
+          // handshake could never reach the encryption step.
+          assertEquals(
+              "the coalesced SEND_PUBLIC_KEY must have been parsed in the same read event",
+              -1,
+              peerInHandshake.getStatus());
+          assertNotNull("the peer's NodeId must be known now", peerInHandshake.getNodeId());
+          assertNotNull(peerInHandshake.getPeer().getNodeId());
+
+          // Both replies must be on the wire: our public key (answer to REQUEST_PUBLIC_KEY) and
+          // our ACTIVATE_ENCRYPTION, which the caller only sends once the status is -1.
+          ByteBuffer inbound = ByteBuffer.allocate(256);
+          int expected = 1 + NodeId.PUBLIC_KEYLEN + 1 + 32;
+          long deadline = System.currentTimeMillis() + 5_000;
+          // non-blocking + deadline: a regression must fail the assertions below, never hang CI
+          while (inbound.position() < expected && System.currentTimeMillis() < deadline) {
+            if (client.read(inbound) == 0) {
+              Thread.sleep(10);
+            }
+          }
+          inbound.flip();
+          assertEquals(
+              "expected SEND_PUBLIC_KEY followed by ACTIVATE_ENCRYPTION",
+              expected,
+              inbound.remaining());
+          assertEquals(Command.SEND_PUBLIC_KEY, inbound.get());
+          inbound.position(inbound.position() + NodeId.PUBLIC_KEYLEN);
+          assertEquals(Command.ACTIVATE_ENCRYPTION, inbound.get());
+        } finally {
+          connectionHandler.removePeerInHandshake(peerInHandshake);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

`ConnectionHandler.handlePeerInHandshake` consumed exactly **one** plaintext handshake command per `read()` and silently discarded the rest of the buffer (unchanged since 2019). TCP is a byte stream: the light client asks for our public key and answers our `REQUEST_PUBLIC_KEY` within the same event-loop turn, so the kernel regularly delivers `[REQUEST_PUBLIC_KEY][SEND_PUBLIC_KEY + 64 bytes]` as a single segment.

We answered the first command and dropped the peer's key, so the handshake stayed in `status == 1` forever: neither `status == -1` block runs, we never send our `ACTIVATE_ENCRYPTION` and never activate encryption — while the peer treats the connection as established and writes requests into it that we can never answer. The peer only recovers via its own watchdog.

## How it was found

A deploy-gate run reported **S1 (pairing + first delivery) = 130 442 ms** where every other run today was 0.8–2.4 s. Re-running the gate 3× on unchanged main reproduced it: **127 604 ms / 990 ms / 2 401 ms** — bimodal, not a slow trend. In every slow run the node log shows Alice's handshake reaching `parsed ACTIVATE_ENCRYPTION` and never `received first encrypted command`, followed by 4–5 redials over ~60 s; in the fast runs it connects on the first attempt.

The 130 s is the deterministic cost of the client's recovery path after the first deposit is written into that dead connection:

| t | event |
|---|---|
| +0 s | `sendMessage` — deposit lost in the wedged connection |
| +50 s | client watchdog: 2 consecutive fetch timeouts → redial |
| +61 s | OH re-registered (it had never landed) |
| +91 s | no R-ACK within 90 s (`RedPandaLightClient.ackTimeout`) → re-queue |
| +130 s | re-send after the 30 s backoff → delivered |

## Change

- Plaintext handshake commands are consumed in a loop, including whatever the peer coalesced behind the 30-byte handshake itself (the same defect one state earlier).
- The loop stops at the first command it cannot fully parse instead of resyncing mid-stream, and stops right after `ACTIVATE_ENCRYPTION` so the REDPANDAJ-2DS block still sees a coalesced first GCM frame as leftover ciphertext.
- A `SEND_PUBLIC_KEY` split across two reads now closes the socket instead of throwing `BufferUnderflowException` into the generic catch. There is no cross-read buffer for this phase, so the command can never be completed; the peer redials and the retry gets a clean stream.

## Tests

New `ConnectionHandlerCoalescedPublicKeyTest` drives the real `handlePeerInHandshake` over a real socket pair with both commands in one `write()`. Negative control: with the production change reverted it fails with `expected:<-1> but was:<1>`. Full suite green (457 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm