### PR TITLE
feat(rendezvous): grow the channel record bucket to 1024 bytes for k=3 OHs

### DIFF
--- a/src/main/java/im/redpanda/outbound/ChannelDht.java
+++ b/src/main/java/im/redpanda/outbound/ChannelDht.java
@@ -59,8 +59,18 @@ public final class ChannelDht {
    * to nodes: the client's {@code [nonce][AEAD ciphertext of a fixed-size plaintext]} blob, sized
    * to exactly this many bytes. All length/padding metadata lives <em>inside</em> the encrypted
    * plaintext, so no cleartext field ever reveals the real payload size.
+   *
+   * <p>Sized 1024 since the OH redundancy went to k=3: the usable plaintext is {@code
+   * RECORD_SIZE_BYTES - 12 nonce - 16 GCM tag}, and two participants with three OH descriptors each
+   * (~74 bytes per descriptor) need 530..574 bytes, which no longer fit the previous 512-byte
+   * bucket. 1024 leaves headroom for IPv6 endpoints and a third participant.
+   *
+   * <p>Changing this value is a <em>breaking</em> protocol change: {@link #isValidRecord} rejects
+   * every record of a different size, so nodes on the old bucket drop records published by upgraded
+   * clients and vice versa. Roll the network out before the clients; channels whose record is
+   * dropped in the meantime keep healing over the in-band {@code oh_update} announce.
    */
-  public static final int RECORD_SIZE_BYTES = 512;
+  public static final int RECORD_SIZE_BYTES = 1024;
 
   /**
    * Maximum age of a rendezvous record before it is considered stale. The spec sets a 48 h TTL;

--- a/src/test/java/im/redpanda/outbound/ChannelDhtTest.java
+++ b/src/test/java/im/redpanda/outbound/ChannelDhtTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import im.redpanda.core.KademliaId;
 import im.redpanda.core.NodeId;
+import im.redpanda.crypt.Utils;
 import im.redpanda.kademlia.KadContent;
 import java.security.SecureRandom;
 import java.util.List;
@@ -109,6 +110,28 @@ public class ChannelDhtTest {
     assertThat(content.verify()).isTrue();
     assertThat(content.getId()).isEqualTo(ChannelDht.rendezvousKademliaId(secret, now));
     assertThat(content.getPubkey()).isEqualTo(ChannelDht.deriveRecordNodeId(secret).exportPublic());
+  }
+
+  @Test
+  public void buildRecordContent_matchesTheClientCrossCheckVector() {
+    // Pins the bucket size and the exact signature the dart light client asserts against
+    // (channel_rendezvous_test.dart). Both sides sign the same bytes, so a one-sided change to
+    // RECORD_SIZE_BYTES — the kind that silently makes every published record undeliverable —
+    // fails here instead of in the field.
+    byte[] secret = new byte[32];
+    for (int i = 0; i < secret.length; i++) {
+      secret[i] = (byte) i;
+    }
+    byte[] content = new byte[ChannelDht.RECORD_SIZE_BYTES];
+    java.util.Arrays.fill(content, (byte) 0xAB);
+
+    KadContent record = ChannelDht.buildRecordContent(secret, content, 1000000000000L);
+
+    assertThat(ChannelDht.RECORD_SIZE_BYTES).isEqualTo(1024);
+    assertThat(Utils.bytesToHexString(record.getSignature()))
+        .isEqualTo(
+            "e649ea68beaedc8e66a11765ec5d4b3fbac2bf58e54815105741fd6007276893"
+                + "4838668388001641eac6c21223ec4e195fc590b1c91571ae9c0699932b411600");
   }
 
   // --- Validation ---


### PR DESCRIPTION
## Why

OH redundancy is going from k=2 to k=3 (`ohRedundancy` in the mobile light client). The rendezvous record that carries each participant's OH list does not fit at k=3:

| case (2 participants, IPv4 endpoints) | encoded plaintext | budget |
|---|---|---|
| k=2, name 13 B | 408 B | 484 B ✅ |
| k=3, name 0 B | 530 B | 484 B ❌ |
| k=3, name 13 B | 556 B | 484 B ❌ |
| k=3, name 22 B | 574 B | 484 B ❌ |

Budget is `RECORD_SIZE_BYTES - 12 nonce - 16 GCM tag`. Per OH descriptor: `1 + len(endpoint) + 20 handleId + 32 authPub` ≈ 74 B for IPv4.

On overflow the client's `encodeEntries` throws, and `_publishRendezvous` swallows it into a log line — the record would silently never be published again and T44 recovery (finding a peer's OHs over the DHT) would go dead.

## What

- `ChannelDht.RECORD_SIZE_BYTES` 512 → 1024. At 1024 the usable plaintext is 996 B: k=3 needs 556 B, with headroom for IPv6 endpoints and a third participant.
- New test pinning the bucket size *and* the signature vector the dart light client cross-checks against, so a one-sided size change fails in CI rather than in the field.

Capacity re-checked, no further limit is hit:

- garlic `CMD_RECORD_STORE`: innermost plaintext ≤ 1789 B at 3 hops, store proto at 1024 B content ≈ 1167 B
- lookup answer over reverse garlic: ≤ 1663 B at 4 return hops, needs ≈ 1168 B
- mailbox item cap 64 KB, `KadStoreManager` budget 10 MB
- `OhDht.RECORD_SIZE_BYTES` stays 256 — separate bucket, already a different size

## Breaking

`isValidRecord` rejects every record of a different size, so this must be deployed to the whole testnet **before** clients publish the larger record. Old records vanish from the DHT at rollout; channels heal over the in-band `oh_update` announce, which has no such size limit.

## Tests

`ChannelDhtTest` 16/16, `RecordDhtRouterTest` 4/4, `OhDhtTest` 13/13 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm