### PR TITLE
fix(oh): tie-break the forwarding candidates on the full node id (T74)

### DIFF
--- a/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
+++ b/src/main/java/im/redpanda/flaschenpost/OhForwarder.java
@@ -12,6 +12,7 @@ import im.redpanda.outbound.OutboundService;
 import im.redpanda.store.NodeEdge;
 import im.redpanda.store.NodeStore;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
@@ -311,11 +312,20 @@ public final class OhForwarder {
       return direct;
     }
 
-    // tie-break equal XOR distances by KademliaId so the TreeSet never collapses distinct peers
+    // Tie-break equal XOR distances by KademliaId so the TreeSet never collapses distinct peers.
+    // The tie-break compares the FULL 160-bit id. It used to compare KademliaId.toString(), which
+    // is a debug label of the first 10 Base58 characters only — so the comparator chain did not
+    // actually guarantee the property this comment claims: two distinct peers sharing that prefix
+    // would compare 0 and the second would be dropped from the candidate set. Today the primary
+    // comparator saves it (XOR against a fixed key is injective, so distinct ids can never tie),
+    // which is why no deposit was ever misrouted by this — but the safety net was resting on the
+    // very thing it exists to back up. Same class of defect as H1 in KademliaId.equals (#281):
+    // a shortened id is a label, not an identity. Raw bytes are exact and avoid a full Base58
+    // encoding on the forwarding path.
     TreeSet<Peer> candidates =
         new TreeSet<>(
             new PeerComparator(targetNodeId)
-                .thenComparing(peer -> peer.getKademliaId().toString()));
+                .thenComparing(peer -> peer.getKademliaId().getBytes(), Arrays::compareUnsigned));
     Lock lock = peerList.getReadWriteLock().readLock();
     lock.lock();
     try {


### PR DESCRIPTION
`OhForwarder.selectNextPeer` builds its candidate `TreeSet` with

```java
new PeerComparator(targetNodeId)
    .thenComparing(peer -> peer.getKademliaId().toString())
```

and the comment above it promises the tie-break exists "so the TreeSet never collapses distinct peers". `KademliaId.toString()` returns `Base58.encode(keyBytes).substring(0, 10)` — a debug label, not an identity. Two distinct peers sharing that 10-character prefix compare 0, and the `TreeSet` drops the second one.

**Impact today: none, and the PR says so deliberately.** `PeerComparator` compares `id.getInt().xor(key)`, and XOR against a fixed key is injective, so two distinct ids can never produce an equal primary result — the tie-break is unreachable. The defect is that the safety net was resting on the very property it exists to back up, so any future change to the primary comparator (a coarser bucket metric, a distance cache, a graph-hop score) would silently start dropping candidates. Same class as H1 in `KademliaId.equals` (#281): a shortened id is a label, not an identity.

Fix: compare the full 160 bits via `Arrays.compareUnsigned` on the id bytes. Exact, and it avoids a full Base58 encoding on the forwarding path.

No regression test: a real prefix collision would need grinding 58^10 ≈ 4.3e17 candidates, and any test that reaches the tie-break through the public path is impossible while the primary comparator remains injective — a test asserting otherwise would only be testing itself. `OhForwarderTest` (14 tests) stays green.