### PR TITLE
fix(TD026): stop pinning the peer list read lock across PeerJobs' 20 ms-per-peer loop

### DIFF
--- a/src/main/java/im/redpanda/core/PeerJobs.java
+++ b/src/main/java/im/redpanda/core/PeerJobs.java
@@ -58,17 +58,19 @@ public class PeerJobs extends Thread {
 
     // TD026: snapshot the list under the read lock, then iterate WITHOUT holding it. The loop
     // below sleeps 20 ms per peer, so holding the read lock across it pinned the peer list for
-    // size() * 20 ms — with the ~280 peers a seed node accumulates that is over five seconds of
-    // continuously held read lock, measured at 5644 ms mean / 5653 ms max on the testnet.
+    // size() * 20 ms — with the couple of hundred peers a seed node accumulates that is several
+    // seconds of continuously held read lock. Note the cost is linear in the list size, so this
+    // was harmless while lists were small and only became visible as they grew.
     //
     // A ReentrantReadWriteLock queues writers behind that, and since #280 made PeerList.add()
     // always take the write lock, ConnectionHandler.setupConnection() — which runs on the SELECTOR
     // thread — blocked there for seconds. That stalls the entire NIO event loop: no reads, no
     // writes, for every peer at once. Waiting readers are blocked too (a queued writer makes new
-    // readers block), which is why InboundCommandProcessor.handlePing()'s peerList.contains() on
-    // the reader threads was measured waiting 394 ms mean / 3401 ms max before it could even
+    // readers block), so InboundCommandProcessor.handlePing()'s peerList.contains() on the reader
+    // threads waited hundreds of milliseconds, with multi-second outliers, before it could even
     // queue the PONG reply. Net effect: peer ping went from the true ~20 ms network RTT to
-    // hundreds of ms with multi-second outliers.
+    // hundreds of ms. The measured figures behind this are in the PR description and in TD026
+    // rather than here, so they cannot drift out of sync with the code.
     //
     // The copy keeps the iteration CME-safe exactly as the held lock did; nothing in the loop
     // touches the peer list itself, only the Peer objects, which the peer list lock never guarded.

--- a/src/main/java/im/redpanda/core/PeerJobs.java
+++ b/src/main/java/im/redpanda/core/PeerJobs.java
@@ -56,55 +56,74 @@ public class PeerJobs extends Thread {
       return;
     }
 
+    // TD026: snapshot the list under the read lock, then iterate WITHOUT holding it. The loop
+    // below sleeps 20 ms per peer, so holding the read lock across it pinned the peer list for
+    // size() * 20 ms — with the ~280 peers a seed node accumulates that is over five seconds of
+    // continuously held read lock, measured at 5644 ms mean / 5653 ms max on the testnet.
+    //
+    // A ReentrantReadWriteLock queues writers behind that, and since #280 made PeerList.add()
+    // always take the write lock, ConnectionHandler.setupConnection() — which runs on the SELECTOR
+    // thread — blocked there for seconds. That stalls the entire NIO event loop: no reads, no
+    // writes, for every peer at once. Waiting readers are blocked too (a queued writer makes new
+    // readers block), which is why InboundCommandProcessor.handlePing()'s peerList.contains() on
+    // the reader threads was measured waiting 394 ms mean / 3401 ms max before it could even
+    // queue the PONG reply. Net effect: peer ping went from the true ~20 ms network RTT to
+    // hundreds of ms with multi-second outliers.
+    //
+    // The copy keeps the iteration CME-safe exactly as the held lock did; nothing in the loop
+    // touches the peer list itself, only the Peer objects, which the peer list lock never guarded.
+    ArrayList<Peer> peers;
     Lock lock = peerList.getReadWriteLock().readLock();
     lock.lock();
     try {
-      for (Peer peer : peerList.getPeerArrayList()) {
+      peers = new ArrayList<>(peerList.getPeerArrayList());
+    } finally {
+      lock.unlock();
+    }
 
-        try {
-          Thread.sleep(20);
-        } catch (InterruptedException e) {
-          e.printStackTrace();
-        }
+    for (Peer peer : peers) {
 
-        Log.put("running over peer: " + peer, 120);
+      try {
+        Thread.sleep(20);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
 
-        if ((peer.isConnecting && peer.getLastAnswered() > 10000)
-            || (!peer.isConnecting && peer.getLastAnswered() > Settings.pingTimeout)) {
+      Log.put("running over peer: " + peer, 120);
 
-          if (peer.isConnected() || peer.isConnecting) {
+      if ((peer.isConnecting && peer.getLastAnswered() > 10000)
+          || (!peer.isConnecting && peer.getLastAnswered() > Settings.pingTimeout)) {
 
-            peer.disconnect("timeout");
-            if (peer.getNodeId() == null) {
-              Log.put(
-                  "removed peer from peerList, tried once and peer never connected before: "
-                      + peer.ip
-                      + ":"
-                      + peer.port,
-                  120);
-            }
+        if (peer.isConnected() || peer.isConnecting) {
 
-            // todo: interrupt outbound thread?
-          } else if (peer.getLastAnswered() > Settings.pingTimeout * 2) {
-            peer.writeBuffer = null;
-            peer.writeBufferCrypted = null;
+          peer.disconnect("timeout");
+          if (peer.getNodeId() == null) {
+            Log.put(
+                "removed peer from peerList, tried once and peer never connected before: "
+                    + peer.ip
+                    + ":"
+                    + peer.port,
+                120);
           }
 
-        } else if (peer.isConnected()) {
+          // todo: interrupt outbound thread?
+        } else if (peer.getLastAnswered() > Settings.pingTimeout * 2) {
+          peer.writeBuffer = null;
+          peer.writeBufferCrypted = null;
+        }
 
-          peer.cnt++;
-          if (peer.cnt > Settings.peerListRequestDelay * 1000 / (Settings.pingDelay)) {
+      } else if (peer.isConnected()) {
+
+        peer.cnt++;
+        if (peer.cnt > Settings.peerListRequestDelay * 1000 / (Settings.pingDelay)) {
+          peer.sendPing();
+          peer.cnt = 0;
+        } else {
+          if (peer.isConnected() && peer.getLastAnswered() > Settings.pingDelay) {
             peer.sendPing();
-            peer.cnt = 0;
-          } else {
-            if (peer.isConnected() && peer.getLastAnswered() > Settings.pingDelay) {
-              peer.sendPing();
-            }
           }
         }
       }
-    } finally {
-      lock.unlock();
     }
   }
 

--- a/src/test/java/im/redpanda/core/PeerJobsPeerListLockTest.java
+++ b/src/test/java/im/redpanda/core/PeerJobsPeerListLockTest.java
@@ -40,8 +40,10 @@ public class PeerJobsPeerListLockTest {
     CountDownLatch insideLoop = new CountDownLatch(1);
     CountDownLatch writerDone = new CountDownLatch(1);
 
-    // isConnected() is the first thing runOnce() asks each peer, so this parks the loop at a point
-    // where the read lock would still be held by the defective version.
+    // runOnce() sleeps, logs and evaluates the timeout condition before it reaches isConnected(),
+    // so this is not the first call it makes on a peer — but it is inside the per-peer body, which
+    // is all this test needs: parking here holds the loop at a point where the defective version
+    // would still be holding the read lock.
     Peer probe =
         new Peer("127.0.0.1", 45001) {
           @Override

--- a/src/test/java/im/redpanda/core/PeerJobsPeerListLockTest.java
+++ b/src/test/java/im/redpanda/core/PeerJobsPeerListLockTest.java
@@ -1,0 +1,81 @@
+package im.redpanda.core;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import org.junit.Test;
+
+/**
+ * Regression test for TD026: {@code PeerJobs.runOnce()} used to hold the {@link PeerList} read lock
+ * across its whole per-peer loop — a loop that sleeps 20 ms per peer. With a few hundred known
+ * peers that is several seconds of continuously held read lock, which starves every writer.
+ *
+ * <p>That became a user-visible latency regression once {@code PeerList.add()} started taking the
+ * write lock unconditionally (#280): {@code ConnectionHandler.setupConnection()} calls {@code
+ * add()} on the selector thread, so the entire NIO event loop — every read, every write, for every
+ * peer — stalled for as long as this loop held the read lock. Measured peer ping went from ~20 ms
+ * (the true network RTT) to hundreds of milliseconds and multi-second outliers.
+ *
+ * <p>The assertion is one-sided and not timing-flaky: the probe peer parks inside the loop until
+ * the test thread has had its chance at the write lock, so a slow machine only gives the writer
+ * more time to succeed, never less.
+ */
+public class PeerJobsPeerListLockTest {
+
+  /**
+   * Generous upper bound for acquiring the write lock while {@code runOnce()} is mid-loop. With the
+   * defect the lock is held for the entire loop, so this always times out; without it the lock is
+   * free the instant the snapshot is taken.
+   */
+  private static final long WRITE_LOCK_TIMEOUT_MS = 2000;
+
+  @Test
+  public void runOnce_doesNotHoldThePeerListReadLockWhileIteratingPeers() throws Exception {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    serverContext.setConnectionHandler(new ConnectionHandler(serverContext, false));
+    ConnectionHandler.peerInHandshakes.clear();
+
+    CountDownLatch insideLoop = new CountDownLatch(1);
+    CountDownLatch writerDone = new CountDownLatch(1);
+
+    // isConnected() is the first thing runOnce() asks each peer, so this parks the loop at a point
+    // where the read lock would still be held by the defective version.
+    Peer probe =
+        new Peer("127.0.0.1", 45001) {
+          @Override
+          public boolean isConnected() {
+            insideLoop.countDown();
+            try {
+              writerDone.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+            return false;
+          }
+        };
+    serverContext.getPeerList().add(probe);
+
+    PeerJobs peerJobs = new PeerJobs(serverContext);
+    Thread jobThread = new Thread(peerJobs::runOnce, "peerjobs-under-test");
+    jobThread.setDaemon(true);
+    jobThread.start();
+
+    assertTrue("runOnce() never reached the per-peer loop", insideLoop.await(30, TimeUnit.SECONDS));
+
+    Lock writeLock = serverContext.getPeerList().getReadWriteLock().writeLock();
+    boolean acquired = writeLock.tryLock(WRITE_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    if (acquired) {
+      writeLock.unlock();
+    }
+
+    writerDone.countDown();
+    jobThread.join(TimeUnit.SECONDS.toMillis(30));
+
+    assertTrue(
+        "PeerJobs.runOnce() must not hold the peer list read lock while it iterates and sleeps —"
+            + " it starves peerList.add() on the selector thread and stalls all peer I/O",
+        acquired);
+  }
+}


### PR DESCRIPTION
## What was reported

Mean peer ping of 300-700 ms against the testnet nodes, expected well under 50 ms; suspicion on a lock from the 2026-07-27 batch.

## It is real, not a measurement artifact

Measured against `5.75.137.166` / `46.224.156.238` with temporary instrumentation (not committed) separating buffer-write, socket-flush and PONG-arrival times:

| | value |
|---|---|
| ICMP RTT | 16.2 / 23.2 ms min/avg (node 1), 16.9 / 18.7 ms (node 2) |
| raw TCP connect RTT | 18.0 ms min |
| `peer.ping`, good samples | **19-21 ms** — matches the wire RTT |
| `peer.ping`, mean over 70 samples | **1604.7 ms** (median 224, p90 5605, max 5629) |
| PING buffer -> socket write | **0.6 ms** mean, max 2 ms |

Three candidate explanations were checked and **refuted**:

1. *`lastPinged` stamped before `tryLock()`, so a skipped PING corrupts the sample* — confirmed as written (`Peer.java:276` stamps, `:278` locks), but over the whole run: `skipLock=0`, `skipFull=0`, `skipNull=0`, `throttled=0`, attempts == writes, and `pongNoPending=0`. PING and PONG stayed 1:1; `reported` tracked the true buffer-to-PONG time to within 1 ms.
2. *The stamp is taken at buffer-write, so it hides local queuing* — true in principle, but buffer -> socket is 0.6 ms mean / 2 ms max. Not the cause.
3. *The EWMA inflates the mean* — confirmed as an amplifier (a single 5.6 s outlier stays above 300 ms for ~4 samples, ~20 s), but it amplifies a real delay rather than inventing one. Deliberately left alone: smoothing it harder would only hide latency.

The time is genuinely spent waiting.

## Root cause

`PeerJobs.runOnce()` held the `PeerList` **read lock** across a loop that does `Thread.sleep(20)` per peer. A seed node accumulates ~280 peers, so the lock was held continuously for **5.6 s** (measured 5643 ms mean / 5653 ms max, n=17).

That was survivable while `PeerList.add()` still had its lock-free duplicate fast path. **#280 (2026-07-27)** made `add()` always take the **write lock** — and `ConnectionHandler.setupConnection()` calls `add()` **on the selector thread**. The whole NIO event loop now parks behind this read lock for seconds, stalling every read and write for every peer at once. A queued writer also blocks new readers, so `handlePing()`'s `peerList.contains()` on the reader threads was measured waiting **727.8 ms mean / 4753 ms max** before it could even queue a PONG reply.

#280 is not itself wrong — it closed a genuine data race. It exposed a latent defect in `PeerJobs`.

## The fix

Snapshot the list under the read lock, iterate the copy without it. The copy preserves exactly the CME-safety the held lock provided; nothing in the loop touches the peer list itself, only `Peer` objects, which this lock never guarded.

## Measured, same node, same seeds

| metric | before | after |
|---|---|---|
| PeerJobs holds peerlist readlock | 5643 ms mean / 5653 max | **0 ms / 0 ms** |
| `peerList.contains` wait (reader thread) | 727.8 ms mean / 4753 max | **0 ms / 0 ms** |
| selector-ready -> socket read | 529.0 ms mean / 4630 max | **0.2 ms / 2 ms** |
| socket read -> PONG parsed | 62.5 ms mean / 4354 max | **1.0 ms / 10 ms** |
| `peer.ping` sample | 1604.7 ms mean / 224 median | 814.3 / 127 |
| displayed EWMA `peer.ping` | 1478.8 ms mean / 937 median | 651.5 / 280 |

Every local wait goes to zero. End-to-end ping improves but stays elevated **because the remote testnet nodes still run the unfixed code** and stall their own PONG replies the same way. That half only clears once this ships to them — nothing was deployed from here.

## Test

`PeerJobsPeerListLockTest` parks a probe peer inside the loop and asserts a writer can still acquire the write lock. Negative control: fails against current `main` (*"must not hold the peer list read lock while it iterates"*), passes with this change. The assertion is one-sided, so a slow machine only gives the writer more time, never less.

Full suite: **460 tests, 0 failures, 0 errors, 1 skipped** (no flakes, `InboundCommandProcessorUpdateHardeningTest` included).

Wire format unchanged; no coordinated mobile release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm