### PR TITLE
T86: evict undialable peers + harden peer-list gossip

### DIFF
--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -4,6 +4,7 @@ import static com.google.protobuf.ByteString.copyFrom;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import im.redpanda.crypt.Utils;
 import im.redpanda.flaschenpost.GMParser;
 import im.redpanda.flaschenpost.GarlicRouter;
 import im.redpanda.flaschenpost.OhForwarder;
@@ -505,6 +506,12 @@ public class InboundCommandProcessor {
         if (peerToCheck.ip == null) {
           continue;
         }
+        // Same predicate as on the ingest path, with the recipient as the "other side": do not
+        // hand a local-only address to a peer outside that network, and do not pass on entries
+        // that carry no dialable port. Without this we amplify exactly what we refuse to accept.
+        if (!Utils.isPlausibleAdvertisedAddress(peerToCheck.ip, peerToCheck.getPort(), peer.ip)) {
+          continue;
+        }
         var peerBuilder =
             PeerInfoProto.newBuilder().setIp(peerToCheck.ip).setPort(peerToCheck.getPort());
         if (peerToCheck.getNodeId() != null && peerToCheck.getNodeId().hasKey()) {
@@ -538,6 +545,10 @@ public class InboundCommandProcessor {
       throws InvalidProtocolBufferException {
     SendPeerList sendPeerList = SendPeerList.parseFrom(bytesForPeerList);
     for (PeerInfoProto peerProto : sendPeerList.getPeersList()) {
+      if (serverContext.getPeerList().size() >= Settings.MAX_PEERLIST_SIZE) {
+        Log.put("peer list is full, ignoring the rest of the gossiped peer list", 40);
+        break;
+      }
       NodeId nodeId = null;
       if (peerProto.hasNodeId()) {
         try {
@@ -549,13 +560,21 @@ public class InboundCommandProcessor {
       }
       String ip = peerProto.getIp();
       int port = peerProto.getPort();
+      // Peer-list gossip is unauthenticated: everything below this point comes from the peer and
+      // nothing above verifies it. Reject entries that the advertising peer cannot plausibly know
+      // about — otherwise any peer can steer us into dialling loopback, the local LAN or a
+      // portless address, and we then spread those entries further.
+      if (!Utils.isPlausibleAdvertisedAddress(ip, port, peer.ip)) {
+        Log.put("ignoring implausible peer list entry " + ip + ":" + port + " from " + peer.ip, 40);
+        continue;
+      }
+      if (port == serverContext.getPort() && Utils.isOwnHostAddress(ip)) {
+        Log.put("ignoring peer list entry that points back at us: " + ip + ":" + port, 40);
+        continue;
+      }
       if (nodeId != null) {
         if (nodeId.getKademliaId().equals(serverContext.getNonce())) {
           Log.put("found ourselves in the peerlist", 80);
-          continue;
-        }
-        if (ip == null) {
-          System.out.println("found a peer with ip null...");
           continue;
         }
         Peer newPeer = new Peer(ip, port, nodeId);

--- a/src/main/java/im/redpanda/core/OutboundHandler.java
+++ b/src/main/java/im/redpanda/core/OutboundHandler.java
@@ -198,7 +198,9 @@ public class OutboundHandler extends Thread {
             break;
           }
 
-          if (peer.port == 0) {
+          if (!peer.isDialable()) {
+            // Nothing to connect to. Note this skip happens before the retry-based removal below,
+            // so such a peer could never be evicted here - PeerJobs does it instead (T86).
             continue;
           }
 

--- a/src/main/java/im/redpanda/core/Peer.java
+++ b/src/main/java/im/redpanda/core/Peer.java
@@ -448,6 +448,19 @@ public class Peer implements Comparable<Peer> {
     return port;
   }
 
+  /**
+   * Whether this peer has connection details we could dial.
+   *
+   * <p>False for every peer we only ever learned from an inbound connection: the handshake carries
+   * the sender's listening port, and a light client has no listening socket, so it announces port 0
+   * ({@code PeerInHandshake.port} also defaults to 0). The resulting {@link Peer} keeps the remote
+   * end of that socket, which is useless the moment the connection is gone. Also false after {@link
+   * #removeIpAndPort()}.
+   */
+  public boolean isDialable() {
+    return ip != null && port > 0 && port <= 65535;
+  }
+
   public boolean isAuthed() {
     return authed;
   }

--- a/src/main/java/im/redpanda/core/PeerJobs.java
+++ b/src/main/java/im/redpanda/core/PeerJobs.java
@@ -83,6 +83,8 @@ public class PeerJobs extends Thread {
       lock.unlock();
     }
 
+    evictUndialableDisconnectedPeers(peers);
+
     for (Peer peer : peers) {
 
       try {
@@ -125,6 +127,35 @@ public class PeerJobs extends Thread {
             peer.sendPing();
           }
         }
+      }
+    }
+  }
+
+  /**
+   * Drops peers that are neither connected nor dialable — the retention leak behind the ~280-entry
+   * peer lists (T86).
+   *
+   * <p>Every inbound connection puts a {@link Peer} into the peer list, built from the remote end
+   * of the socket plus the listening port the handshake announced. A light client has no listening
+   * socket and announces port 0, so its entry is undialable from the moment it is created and dead
+   * weight from the moment it disconnects. Nothing ever removed those again: the only eviction
+   * path, {@code OutboundHandler}, skips undialable peers <em>before</em> it reaches its
+   * retry-based removal, so their {@code retries} counter never moves. They then get written to
+   * {@code peers.dat}, restored on the next start and gossiped on to every other node. Measured on
+   * a node bootstrapped from the testnet seeds: 273 of 278 entries had port 0, each with a distinct
+   * identity — one per mobile app instance, per re-install and per e2e run.
+   *
+   * <p>A still-connected peer is kept regardless: that is the live inbound connection, and it is
+   * the one thing such an entry is good for. The entry is recreated by the next handshake, which is
+   * how it came about in the first place.
+   */
+  private void evictUndialableDisconnectedPeers(ArrayList<Peer> peers) {
+    for (Peer peer : peers) {
+      if (peer.isDialable() || peer.isConnected() || peer.isConnecting) {
+        continue;
+      }
+      if (peerList.remove(peer)) {
+        Log.put("removed undialable disconnected peer from peerList: " + peer, 40);
       }
     }
   }

--- a/src/main/java/im/redpanda/core/Saver.java
+++ b/src/main/java/im/redpanda/core/Saver.java
@@ -64,9 +64,18 @@ public class Saver {
     for (Peer peer : peers) {
       // Bootstrap peers may have a NodeId with a known KademliaId but no verify key yet
       // (handshake not completed) - skip those, serializing them would NPE in NodeId#writeObject.
-      if (peer.getNodeId() != null && peer.getNodeId().hasKey()) {
-        arrayList.add(peer.toSaveable());
+      if (peer.getNodeId() == null || !peer.getNodeId().hasKey()) {
+        continue;
       }
+      // Only dialable peers are worth restoring: the whole point of peers.dat is to have addresses
+      // to connect to on the next start. Inbound-only entries (a light client announces port 0,
+      // see Peer#isDialable) cannot be dialled by anyone, and persisting them is what let them
+      // survive restarts and be re-gossiped afterwards - the affected node's peers.dat held 82
+      // loopback entries alone (T86).
+      if (!peer.isDialable()) {
+        continue;
+      }
+      arrayList.add(peer.toSaveable());
     }
 
     File mkdirs = new File(SAVE_DIR);

--- a/src/main/java/im/redpanda/core/Settings.java
+++ b/src/main/java/im/redpanda/core/Settings.java
@@ -40,9 +40,26 @@ public class Settings {
     }
   }
 
-  private static final String[] DEFAULT_KNOWN_NODES = {
-    "195.201.25.223:59558", "redpanda.im:59559", "127.0.0.1:59558"
-  };
+  /**
+   * {@code 127.0.0.1:59558} used to be part of this list and was removed: {@link #DEFAULT_PORT} is
+   * 59558 as well, so every node that is started without an explicit configuration dials its own
+   * listening port, accepts the connection and then carries the resulting loopback entry in its
+   * peer list — where {@code handleRequestPeerList} gossips it on to everyone else. Measured on a
+   * node bootstrapped from the testnet seeds: 82 of 278 peer-list entries were {@code 127.0.0.1}.
+   * Nothing needs the default: every local topology (the mobile e2e suite, the emulator gate)
+   * passes its loopback seeds explicitly via {@code REDPANDA_KNOWN_NODES} / {@code
+   * -Dredpanda.knownNodes}, and for a hand-started local node the same one variable does the job.
+   */
+  private static final String[] DEFAULT_KNOWN_NODES = {"195.201.25.223:59558", "redpanda.im:59559"};
+
+  /**
+   * Upper bound on the peer list. Peer-list gossip is unauthenticated and we re-gossip what we
+   * accept, so without a bound a single peer can grow every other node's list without limit. Well
+   * above {@link #MAX_CONNECTIONS} so that bootstrapping keeps a healthy reserve of dialable
+   * addresses; only the gossip ingest path is capped, connections we actually established are never
+   * refused.
+   */
+  public static int MAX_PEERLIST_SIZE = 200;
 
   /**
    * Bootstrap peers as {@code host:port}. Overridable without rebuilding via the system property

--- a/src/main/java/im/redpanda/crypt/Utils.java
+++ b/src/main/java/im/redpanda/crypt/Utils.java
@@ -1,8 +1,16 @@
 package im.redpanda.crypt;
 
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import org.bouncycastle.util.encoders.Hex;
 
 public class Utils {
@@ -83,7 +91,187 @@ public class Utils {
     return seconds < 0 ? "-" + positive : positive;
   }
 
+  /**
+   * Whether the given host is only meaningful inside the network of whoever is using it: loopback,
+   * the RFC1918 private ranges, carrier-grade NAT, link-local and the unspecified address, plus the
+   * IPv6 equivalents. Such an address must never be handed to a peer outside that network — it
+   * either points nowhere or, worse, at something in the receiver's own LAN.
+   *
+   * <p>Matching is done on the string on purpose: this runs on the peer-list gossip path, where a
+   * DNS lookup would block a network thread on input an attacker controls. A host name we cannot
+   * classify without resolving it (anything that is not an IP literal) is reported as non-local.
+   *
+   * <p>A {@code null} or blank host counts as local: it is not usable by anyone else either, and
+   * every caller wants the conservative answer for it.
+   *
+   * <p>Historically this method returned true for all of {@code 192.*}, which also covers public
+   * space; only {@code 192.168.0.0/16} is private.
+   */
   public static boolean isLocalAddress(String string) {
-    return string.equals("127.0.0.1") || string.equals("localhost") || string.startsWith("192.");
+    String host = normalizeHost(string);
+    if (host.isEmpty()) {
+      return true;
+    }
+    if (host.equals("localhost") || host.endsWith(".localhost") || host.equals("localhost.")) {
+      return true;
+    }
+    if (host.startsWith("::ffff:")) {
+      // IPv4-mapped IPv6 literal, classify by the embedded IPv4 address
+      host = host.substring("::ffff:".length());
+    }
+    if (host.indexOf(':') >= 0) {
+      // IPv6 literal
+      if (host.equals("::") || host.equals("::1")) {
+        return true; // unspecified / loopback
+      }
+      if (host.matches("0(:0)*:0*1")) {
+        return true; // fully written out loopback, e.g. 0:0:0:0:0:0:0:1
+      }
+      if (host.matches("0(:0)*")) {
+        return true; // fully written out unspecified address
+      }
+      // fc00::/7 unique local, fe80::/10 link local
+      return host.startsWith("fc")
+          || host.startsWith("fd")
+          || host.startsWith("fe8")
+          || host.startsWith("fe9")
+          || host.startsWith("fea")
+          || host.startsWith("feb");
+    }
+
+    int[] octets = parseIpv4(host);
+    if (octets == null) {
+      // not an IP literal, so a host name — we do not resolve it here, see javadoc
+      return false;
+    }
+    return octets[0] == 0 // "this network", includes 0.0.0.0
+        || octets[0] == 127 // loopback
+        || octets[0] == 10 // RFC1918
+        || (octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31) // RFC1918
+        || (octets[0] == 192 && octets[1] == 168) // RFC1918
+        || (octets[0] == 100 && octets[1] >= 64 && octets[1] <= 127) // RFC6598 CGNAT
+        || (octets[0] == 169 && octets[1] == 254); // link local
+  }
+
+  /**
+   * Whether an {@code ip:port} that a peer advertises to us — or that we are about to advertise to
+   * a peer — is plausible for the other side of that exchange, which we reached (or which reached
+   * us) at {@code peerIp}.
+   *
+   * <p>Peer-list gossip is unauthenticated, so without this check any peer can make us dial
+   * arbitrary addresses: a list full of {@code 127.0.0.1} or LAN addresses turns every node into a
+   * scanner of its own host and network, and the entries spread further because we re-gossip our
+   * peer list verbatim.
+   *
+   * <p>The rule is deliberately about <em>who</em> advertises <em>what</em> rather than a blanket
+   * ban on local addresses, because the local test topologies depend on the latter: nodes started
+   * on {@code 127.0.0.1} by the mobile e2e suite must keep discovering each other, and the emulator
+   * gate reaches the host at {@code 10.0.2.2}. A peer we talk to over a local address may therefore
+   * gossip local addresses; a peer we talk to over a public address may not.
+   *
+   * <p>The same predicate serves the outgoing direction with {@code peerIp} set to the recipient's
+   * address, which stops us from being an amplifier for entries we do accept locally.
+   *
+   * @param advertisedIp the address contained in the peer-list entry
+   * @param advertisedPort the port contained in the peer-list entry
+   * @param peerIp the address of the peer we received the entry from / are sending it to
+   */
+  public static boolean isPlausibleAdvertisedAddress(
+      String advertisedIp, int advertisedPort, String peerIp) {
+    if (advertisedIp == null || advertisedIp.isBlank()) {
+      return false;
+    }
+    if (advertisedPort < 1 || advertisedPort > 65535) {
+      // Port 0 is what a Peer carries while we only know the remote end of an inbound connection
+      // and not its listening port. Such an entry can never be dialled by anyone, so passing it
+      // around is pure noise — it made up the bulk of the observed peer-list growth.
+      return false;
+    }
+    String normalized = normalizeHost(advertisedIp);
+    if (normalized.equals("0.0.0.0") || normalized.equals("::")) {
+      return false; // unspecified address, never a destination
+    }
+    if (!isLocalAddress(advertisedIp)) {
+      return true;
+    }
+    // Local-only address: believable exactly from a peer that is itself local to us. An unknown
+    // peer address (connection details already cleared) counts as not local.
+    return peerIp != null && !peerIp.isBlank() && isLocalAddress(peerIp);
+  }
+
+  /**
+   * Whether the given host is one of this machine's own addresses. Used together with our listening
+   * port to drop peer-list entries that point back at us; the identity-based check upstream only
+   * catches entries that carry our node id.
+   */
+  public static boolean isOwnHostAddress(String ip) {
+    String host = normalizeHost(ip);
+    if (host.isEmpty()) {
+      return false;
+    }
+    Set<String> addresses = ownHostAddresses;
+    if (addresses == null) {
+      addresses = collectOwnHostAddresses();
+      ownHostAddresses = addresses;
+    }
+    return addresses.contains(host);
+  }
+
+  private static volatile Set<String> ownHostAddresses;
+
+  private static Set<String> collectOwnHostAddresses() {
+    Set<String> addresses = new HashSet<>(List.of("localhost", "127.0.0.1", "::1"));
+    try {
+      Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+      while (interfaces != null && interfaces.hasMoreElements()) {
+        Enumeration<InetAddress> inetAddresses = interfaces.nextElement().getInetAddresses();
+        while (inetAddresses.hasMoreElements()) {
+          addresses.add(normalizeHost(inetAddresses.nextElement().getHostAddress()));
+        }
+      }
+    } catch (SocketException e) {
+      // no interface list available, the loopback defaults above still apply
+    }
+    return addresses;
+  }
+
+  /** Lower-cases the host and strips IPv6 brackets and a zone index, so hosts compare equal. */
+  private static String normalizeHost(String host) {
+    if (host == null) {
+      return "";
+    }
+    String normalized = host.trim().toLowerCase(Locale.ROOT);
+    if (normalized.startsWith("[") && normalized.endsWith("]") && normalized.length() > 2) {
+      normalized = normalized.substring(1, normalized.length() - 1);
+    }
+    int zone = normalized.indexOf('%');
+    if (zone >= 0) {
+      normalized = normalized.substring(0, zone);
+    }
+    return normalized;
+  }
+
+  /** Parses a dotted-quad IPv4 literal, or null if the string is not one. */
+  private static int[] parseIpv4(String host) {
+    String[] parts = host.split("\\.", -1);
+    if (parts.length != 4) {
+      return null;
+    }
+    int[] octets = new int[4];
+    for (int i = 0; i < 4; i++) {
+      if (parts[i].isEmpty() || parts[i].length() > 3) {
+        return null;
+      }
+      for (int c = 0; c < parts[i].length(); c++) {
+        if (parts[i].charAt(c) < '0' || parts[i].charAt(c) > '9') {
+          return null;
+        }
+      }
+      octets[i] = Integer.parseInt(parts[i]);
+      if (octets[i] > 255) {
+        return null;
+      }
+    }
+    return octets;
   }
 }

--- a/src/main/java/im/redpanda/crypt/Utils.java
+++ b/src/main/java/im/redpanda/crypt/Utils.java
@@ -187,6 +187,21 @@ public class Utils {
       // around is pure noise — it made up the bulk of the observed peer-list growth.
       return false;
     }
+    if (!isIpLiteral(advertisedIp)) {
+      // Gossip may only carry IP literals. isLocalAddress() classifies by string and cannot see
+      // through a name, and OutboundHandler dials with `new InetSocketAddress(peer.ip, peer.port)`,
+      // which resolves — so a gossiped name that resolves, or is later re-pointed, to 127.0.0.1 or
+      // a LAN address would walk straight past the locality rule below. That is exactly the
+      // injection this predicate exists to stop, and re-checking after an off-thread resolve would
+      // still race the next DNS answer.
+      //
+      // Names remain fine as *operator* input: Settings.knownNodes ships redpanda.im:59559 and
+      // REDPANDA_KNOWN_NODES may carry names. Those reach the peer list through
+      // OutboundHandler.addKnownNodes() and never pass through here — configured seeds are trusted,
+      // an unauthenticated peer is not. A peer that wants to be reachable can advertise its
+      // address.
+      return false;
+    }
     String normalized = normalizeHost(advertisedIp);
     if (normalized.equals("0.0.0.0") || normalized.equals("::")) {
       return false; // unspecified address, never a destination
@@ -197,6 +212,34 @@ public class Utils {
     // Local-only address: believable exactly from a peer that is itself local to us. An unknown
     // peer address (connection details already cleared) counts as not local.
     return peerIp != null && !peerIp.isBlank() && isLocalAddress(peerIp);
+  }
+
+  /**
+   * Whether the given host is an IP literal, i.e. something {@link #isLocalAddress(String)} can
+   * classify without asking a resolver and that {@code InetSocketAddress} will not send to DNS.
+   *
+   * <p>The IPv6 side is deliberately shape-based rather than a full grammar check: a DNS label can
+   * only hold letters, digits and hyphens, so a string made of hex digits, colons and the dots of
+   * an embedded IPv4 tail is never a resolvable name. A malformed one simply fails to connect,
+   * which is a harmless outcome — the property this method has to guarantee is "no name lookup",
+   * not "valid address".
+   */
+  public static boolean isIpLiteral(String host) {
+    String normalized = normalizeHost(host);
+    if (normalized.isEmpty()) {
+      return false;
+    }
+    if (normalized.indexOf(':') >= 0) {
+      for (int i = 0; i < normalized.length(); i++) {
+        char c = normalized.charAt(i);
+        boolean allowed = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || c == ':' || c == '.';
+        if (!allowed) {
+          return false;
+        }
+      }
+      return true;
+    }
+    return parseIpv4(normalized) != null;
   }
 
   /**

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorPeerListFilterTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorPeerListFilterTest.java
@@ -1,6 +1,7 @@
 package im.redpanda.core;
 
 import static com.google.protobuf.ByteString.copyFrom;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -99,6 +100,59 @@ public class InboundCommandProcessorPeerListFilterTest {
     assertTrue(contains("10.0.2.2", 59558));
     assertTrue(contains("192.168.1.5", 59558));
     assertTrue(contains("46.224.156.238", 59558));
+  }
+
+  /**
+   * A gossiped host name is resolved by {@code InetSocketAddress} at dial time, so it can point at
+   * loopback or the LAN without the string-based locality rule ever seeing it. Rejected on ingest
+   * regardless of who sends it — configured seeds are a different, trusted path (see {@link
+   * #configuredSeedsMayStillUseHostNames()}).
+   */
+  @Test
+  public void gossipedHostNames_areDropped() {
+    Peer advertiser = connectedPeer(PUBLIC_PEER_IP, 59558);
+
+    gossip(
+        advertiser,
+        entry("redpanda.im", 59559),
+        entry("evil.example.com", 59558),
+        entry("localhost", 59558),
+        entry("localtest.me", 59558), // resolves to 127.0.0.1
+        entry("46.224.156.238", 59558));
+
+    assertFalse(contains("redpanda.im", 59559));
+    assertFalse(contains("evil.example.com", 59558));
+    assertFalse(contains("localhost", 59558));
+    assertFalse(contains("localtest.me", 59558));
+    assertTrue(contains("46.224.156.238", 59558));
+  }
+
+  @Test
+  public void gossipedHostNames_areDroppedFromALoopbackPeerToo() {
+    Peer advertiser = connectedPeer(LOOPBACK_PEER_IP, 59559);
+
+    gossip(advertiser, entry("localhost", 59560), entry("127.0.0.1", 59560));
+
+    assertFalse("a name is untrusted no matter who sends it", contains("localhost", 59560));
+    assertTrue("the literal the e2e topology exchanges still works", contains("127.0.0.1", 59560));
+  }
+
+  @Test
+  public void weDoNotAdvertiseHostNames() {
+    ctx.getPeerList().add(connectedPeer("redpanda.im", 59559)); // as reseeding creates it
+    ctx.getPeerList().add(connectedPeer("46.224.156.238", 59558));
+
+    assertEquals(List.of("46.224.156.238:59558"), requestPeerListAsSeenBy(PUBLIC_PEER_IP));
+  }
+
+  /** Operator input is trusted and must keep working — the default seed list ships a name. */
+  @Test
+  public void configuredSeedsMayStillUseHostNames() {
+    assertArrayEquals(
+        new String[] {"redpanda.im:59559"}, Settings.parseKnownNodes("redpanda.im:59559"));
+    assertTrue(
+        "the default seed list must keep its host name entry",
+        List.of(Settings.parseKnownNodes(null)).contains("redpanda.im:59559"));
   }
 
   @Test

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorPeerListFilterTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorPeerListFilterTest.java
@@ -1,0 +1,240 @@
+package im.redpanda.core;
+
+import static com.google.protobuf.ByteString.copyFrom;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import im.redpanda.proto.NodeIdProto;
+import im.redpanda.proto.PeerInfoProto;
+import im.redpanda.proto.SendPeerList;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Pins the plausibility filter on the peer-list gossip path (T86).
+ *
+ * <p>The bug: {@code handleSendPeerList} accepted every advertised address, so a node bootstrapped
+ * from the testnet seeds ended up with 278 peer-list entries within two minutes, 82 of them {@code
+ * 127.0.0.1} and 273 of them with port 0. Since {@code handleRequestPeerList} re-gossips the list
+ * verbatim, the entries spread. Peer-list gossip is unauthenticated, so this is an injection vector
+ * and not only a cosmetic problem.
+ *
+ * <p>The filter must stay compatible with the local topologies that really do run on loopback (the
+ * mobile e2e suite starts several nodes on {@code 127.0.0.1}, the emulator gate reaches the host at
+ * {@code 10.0.2.2}), hence the "who advertises what" rule rather than a blanket ban — the {@code
+ * fromLoopbackPeer} cases below are what guards that.
+ */
+public class InboundCommandProcessorPeerListFilterTest {
+
+  private static final String PUBLIC_PEER_IP = "84.147.60.253";
+  private static final String LOOPBACK_PEER_IP = "127.0.0.1";
+
+  private ServerContext ctx;
+  private InboundCommandProcessor proc;
+  private int originalMaxPeerListSize;
+
+  @Before
+  public void setup() {
+    ctx = ServerContext.buildDefaultServerContext();
+    ctx.setPort(59558);
+    proc = new InboundCommandProcessor(ctx);
+    ByteBufferPool.init();
+    originalMaxPeerListSize = Settings.MAX_PEERLIST_SIZE;
+  }
+
+  @After
+  public void tearDown() {
+    Settings.MAX_PEERLIST_SIZE = originalMaxPeerListSize;
+  }
+
+  @Test
+  public void gossipFromPublicPeer_dropsLoopbackPrivateAndPortlessEntries() {
+    Peer advertiser = connectedPeer(PUBLIC_PEER_IP, 59558);
+
+    gossip(
+        advertiser,
+        entry("127.0.0.1", 59558),
+        entry("127.0.0.1", 59560),
+        entry("10.0.0.9", 59558),
+        entry("192.168.1.5", 59558),
+        entry("172.20.3.4", 59558),
+        entry("169.254.1.1", 59558),
+        entry("0.0.0.0", 59558),
+        entry("::1", 59558),
+        entry(PUBLIC_PEER_IP, 0), // inbound-only peer, not dialable by anyone
+        entry("46.224.156.238", 59558)); // the only plausible entry
+
+    assertFalse(contains("127.0.0.1", 59558));
+    assertFalse(contains("127.0.0.1", 59560));
+    assertFalse(contains("10.0.0.9", 59558));
+    assertFalse(contains("192.168.1.5", 59558));
+    assertFalse(contains("172.20.3.4", 59558));
+    assertFalse(contains("169.254.1.1", 59558));
+    assertFalse(contains("0.0.0.0", 59558));
+    assertFalse(contains("::1", 59558));
+    assertFalse(contains(PUBLIC_PEER_IP, 0));
+    assertTrue(contains("46.224.156.238", 59558));
+  }
+
+  /** The loopback e2e topology: nodes on 127.0.0.1 must keep discovering each other. */
+  @Test
+  public void gossipFromLoopbackPeer_keepsLoopbackAndPrivateEntries() {
+    Peer advertiser = connectedPeer(LOOPBACK_PEER_IP, 59559);
+
+    gossip(
+        advertiser,
+        entry("127.0.0.1", 59560),
+        entry("127.0.0.1", 59561),
+        entry("10.0.2.2", 59558), // emulator gate reaches the host here
+        entry("192.168.1.5", 59558),
+        entry("46.224.156.238", 59558));
+
+    assertTrue(contains("127.0.0.1", 59560));
+    assertTrue(contains("127.0.0.1", 59561));
+    assertTrue(contains("10.0.2.2", 59558));
+    assertTrue(contains("192.168.1.5", 59558));
+    assertTrue(contains("46.224.156.238", 59558));
+  }
+
+  @Test
+  public void gossipedEntryPointingBackAtUs_isDropped() {
+    // even a loopback peer may not make us dial our own listening address
+    Peer advertiser = connectedPeer(LOOPBACK_PEER_IP, 59559);
+
+    gossip(advertiser, entry("127.0.0.1", ctx.getPort()), entry("127.0.0.1", ctx.getPort() + 1));
+
+    assertFalse(contains("127.0.0.1", ctx.getPort()));
+    assertTrue(contains("127.0.0.1", ctx.getPort() + 1));
+  }
+
+  @Test
+  public void gossipWithIdentity_isFilteredTheSameWay() {
+    Peer advertiser = connectedPeer(PUBLIC_PEER_IP, 59558);
+    NodeId loopbackNode = NodeId.generateWithSimpleKey();
+    NodeId publicNode = NodeId.generateWithSimpleKey();
+
+    gossip(
+        advertiser,
+        identifiedEntry("127.0.0.1", 59560, loopbackNode),
+        identifiedEntry("46.224.156.238", 59558, publicNode));
+
+    assertFalse(ctx.getPeerList().contains(loopbackNode.getKademliaId()));
+    assertTrue(ctx.getPeerList().contains(publicNode.getKademliaId()));
+  }
+
+  @Test
+  public void gossipStopsAtThePeerListBound() {
+    Peer advertiser = connectedPeer(LOOPBACK_PEER_IP, 59559);
+    Settings.MAX_PEERLIST_SIZE = ctx.getPeerList().size() + 3;
+
+    List<PeerInfoProto> entries = new ArrayList<>();
+    for (int i = 0; i < 50; i++) {
+      entries.add(entry("127.0.0.1", 40000 + i));
+    }
+    gossip(advertiser, entries.toArray(new PeerInfoProto[0]));
+
+    assertEquals(Settings.MAX_PEERLIST_SIZE, ctx.getPeerList().size());
+  }
+
+  @Test
+  public void weDoNotAdvertiseLocalAddressesToAPublicPeer() {
+    ctx.getPeerList().add(connectedPeer("127.0.0.1", 59560));
+    ctx.getPeerList().add(connectedPeer("192.168.1.5", 59558));
+    ctx.getPeerList().add(connectedPeer("46.224.156.238", 59558));
+    ctx.getPeerList().add(connectedPeer("5.75.137.166", 0)); // no dialable port
+
+    List<String> advertised = requestPeerListAsSeenBy(PUBLIC_PEER_IP);
+
+    assertEquals(List.of("46.224.156.238:59558"), advertised);
+  }
+
+  @Test
+  public void weStillAdvertiseLocalAddressesToALoopbackPeer() {
+    ctx.getPeerList().add(connectedPeer("127.0.0.1", 59560));
+    ctx.getPeerList().add(connectedPeer("192.168.1.5", 59558));
+    ctx.getPeerList().add(connectedPeer("46.224.156.238", 59558));
+
+    List<String> advertised = requestPeerListAsSeenBy(LOOPBACK_PEER_IP);
+
+    assertTrue(advertised.contains("127.0.0.1:59560"));
+    assertTrue(advertised.contains("192.168.1.5:59558"));
+    assertTrue(advertised.contains("46.224.156.238:59558"));
+  }
+
+  private Peer connectedPeer(String ip, int port) {
+    Peer peer = new Peer(ip, port, NodeId.generateWithSimpleKey());
+    // no SelectionKey in a unit test, so setWriteBufferFilled() must stay a no-op
+    peer.setConnected(false);
+    return peer;
+  }
+
+  private static PeerInfoProto entry(String ip, int port) {
+    return PeerInfoProto.newBuilder().setIp(ip).setPort(port).build();
+  }
+
+  private static PeerInfoProto identifiedEntry(String ip, int port, NodeId nodeId) {
+    return PeerInfoProto.newBuilder()
+        .setIp(ip)
+        .setPort(port)
+        .setNodeId(
+            NodeIdProto.newBuilder().setPublicKeyBytes(copyFrom(nodeId.exportPublic())).build())
+        .build();
+  }
+
+  private void gossip(Peer advertiser, PeerInfoProto... entries) {
+    ctx.getPeerList().add(advertiser);
+    byte[] payload = SendPeerList.newBuilder().addAllPeers(List.of(entries)).build().toByteArray();
+    ByteBuffer frame = ByteBuffer.allocate(4 + payload.length);
+    frame.putInt(payload.length);
+    frame.put(payload);
+    frame.flip();
+    assertEquals(
+        1 + 4 + payload.length, proc.parseCommand(Command.SEND_PEERLIST, frame, advertiser));
+  }
+
+  /** Runs REQUEST_PEERLIST for a peer at the given address and returns the advertised addresses. */
+  private List<String> requestPeerListAsSeenBy(String requesterIp) {
+    Peer requester = connectedPeer(requesterIp, 59558);
+    ctx.getPeerList().add(requester);
+    requester.writeBuffer = ByteBuffer.allocate(1024 * 64);
+
+    assertEquals(1, proc.parseCommand(Command.REQUEST_PEERLIST, ByteBuffer.allocate(0), requester));
+
+    requester.writeBuffer.flip();
+    assertEquals(Command.SEND_PEERLIST, requester.writeBuffer.get());
+    byte[] payload = new byte[requester.writeBuffer.getInt()];
+    requester.writeBuffer.get(payload);
+
+    List<String> advertised = new ArrayList<>();
+    try {
+      for (PeerInfoProto p : SendPeerList.parseFrom(payload).getPeersList()) {
+        if (p.getIp().equals(requesterIp) && p.getPort() == requester.getPort()) {
+          continue; // the requester's own entry is not interesting here
+        }
+        advertised.add(p.getIp() + ":" + p.getPort());
+      }
+    } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+      throw new AssertionError("peer list frame did not parse", e);
+    }
+    return advertised;
+  }
+
+  private boolean contains(String ip, int port) {
+    ctx.getPeerList().getReadWriteLock().readLock().lock();
+    try {
+      for (Peer peer : ctx.getPeerList().getPeerArrayList()) {
+        if (ip.equals(peer.getIp()) && peer.getPort() == port) {
+          return true;
+        }
+      }
+      return false;
+    } finally {
+      ctx.getPeerList().getReadWriteLock().readLock().unlock();
+    }
+  }
+}

--- a/src/test/java/im/redpanda/core/ParseCommandTest.java
+++ b/src/test/java/im/redpanda/core/ParseCommandTest.java
@@ -199,7 +199,9 @@ public class ParseCommandTest {
 
     int i = 0;
     for (i = 0; i < peersToTest; i++) {
-      Peer testpeer1 = new Peer("rand_rewrewR_testip" + i, i);
+      // port i + 1, not i: port 0 is not a dialable address and the peer-list gossip
+      // filter drops such entries in both directions (T86).
+      Peer testpeer1 = new Peer("rand_rewrewR_testip" + i, i + 1);
       testpeer1.setNodeId(new NodeId());
       testpeer1.setConnected(true);
       peerList.add(testpeer1);
@@ -255,7 +257,7 @@ public class ParseCommandTest {
 
     // cleanup
     for (i = 0; i < peersToTest; i++) {
-      peerList.removeIpPort("rand_rewrewR_testip" + i, i);
+      peerList.removeIpPort("rand_rewrewR_testip" + i, i + 1);
     }
 
     assertThat(startingPeerListSize).isEqualTo(peerList.size());
@@ -273,7 +275,8 @@ public class ParseCommandTest {
 
     int i = 0;
     for (i = 0; i < peersToTest; i++) {
-      Peer testpeer1 = new Peer("rand_dwhrgfwer_testip" + i, i);
+      // port i + 1, see testREQUEST_PEERLIST
+      Peer testpeer1 = new Peer("rand_dwhrgfwer_testip" + i, i + 1);
       testpeer1.setNodeId(new NodeId());
       testpeer1.setConnected(true);
       // System.out.println("node id: " +

--- a/src/test/java/im/redpanda/core/ParseCommandTest.java
+++ b/src/test/java/im/redpanda/core/ParseCommandTest.java
@@ -199,9 +199,10 @@ public class ParseCommandTest {
 
     int i = 0;
     for (i = 0; i < peersToTest; i++) {
-      // port i + 1, not i: port 0 is not a dialable address and the peer-list gossip
-      // filter drops such entries in both directions (T86).
-      Peer testpeer1 = new Peer("rand_rewrewR_testip" + i, i + 1);
+      // T86: port i + 1, not i, because port 0 is not a dialable address; and a real IP
+      // literal instead of a made-up name, because gossip only carries literals (a name would
+      // be resolved at dial time and could point anywhere).
+      Peer testpeer1 = new Peer("203.0.113." + i, i + 1);
       testpeer1.setNodeId(new NodeId());
       testpeer1.setConnected(true);
       peerList.add(testpeer1);
@@ -238,11 +239,11 @@ public class ParseCommandTest {
         // Note: The order isn't guaranteed to be strictly predictable unless we sort,
         // but for this test setup
         // the peerList implementation might return them in order or not.
-        // However, the test logic was building peers with ip "rand_rewrewR_testip" + i
+        // However, the test logic was building peers with ip "203.0.113." + i
         // Let's verify that the ip matches the pattern or exists in our set
         // For simplicity, we just assert the structure is valid.
-        assertThat(peerProto.getIp()).contains("testip");
-        assertThat(peerProto.getPort()).isGreaterThanOrEqualTo(0);
+        assertThat(peerProto.getIp()).startsWith("203.0.113.");
+        assertThat(peerProto.getPort()).isGreaterThan(0);
         if (peerProto.hasNodeId()) {
           assertThat(peerProto.getNodeId().getPublicKeyBytes().size())
               .isEqualTo(NodeId.PUBLIC_KEYLEN);
@@ -257,7 +258,7 @@ public class ParseCommandTest {
 
     // cleanup
     for (i = 0; i < peersToTest; i++) {
-      peerList.removeIpPort("rand_rewrewR_testip" + i, i + 1);
+      peerList.removeIpPort("203.0.113." + i, i + 1);
     }
 
     assertThat(startingPeerListSize).isEqualTo(peerList.size());
@@ -276,7 +277,7 @@ public class ParseCommandTest {
     int i = 0;
     for (i = 0; i < peersToTest; i++) {
       // port i + 1, see testREQUEST_PEERLIST
-      Peer testpeer1 = new Peer("rand_dwhrgfwer_testip" + i, i + 1);
+      Peer testpeer1 = new Peer("198.51.100." + i, i + 1);
       testpeer1.setNodeId(new NodeId());
       testpeer1.setConnected(true);
       // System.out.println("node id: " +

--- a/src/test/java/im/redpanda/core/PeerJobsUndialablePeerEvictionTest.java
+++ b/src/test/java/im/redpanda/core/PeerJobsUndialablePeerEvictionTest.java
@@ -1,0 +1,91 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Pins the retention fix for T86.
+ *
+ * <p>Every inbound connection puts a {@link Peer} into the peer list. The handshake carries the
+ * sender's listening port, which is 0 for a light client, so those entries are undialable — and
+ * nothing ever removed them again, because {@code OutboundHandler} skips undialable peers before it
+ * reaches its retry-based eviction. On the affected node that produced 273 undialable entries out
+ * of 278, one per mobile app instance, per re-install and per e2e run, persisted to {@code
+ * peers.dat} and gossiped on.
+ */
+public class PeerJobsUndialablePeerEvictionTest {
+
+  @After
+  public void tearDown() {
+    ConnectionHandler.peerInHandshakes.clear();
+  }
+
+  private ServerContext context() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    serverContext.setConnectionHandler(new ConnectionHandler(serverContext, false));
+    ConnectionHandler.peerInHandshakes.clear();
+    return serverContext;
+  }
+
+  /**
+   * An inbound peer as ConnectionHandler.setupConnection builds it: remote ip, announced port 0.
+   */
+  private Peer inboundPeer(String ip) {
+    Peer peer = new Peer(ip, 0);
+    peer.setNodeId(NodeId.generateWithSimpleKey());
+    return peer;
+  }
+
+  @Test
+  public void runOnce_dropsDisconnectedUndialablePeers() {
+    ServerContext ctx = context();
+    Peer lightClient = inboundPeer("84.147.60.253");
+    Peer loopbackLightClient = inboundPeer("127.0.0.1");
+    ctx.getPeerList().add(lightClient);
+    ctx.getPeerList().add(loopbackLightClient);
+
+    new PeerJobs(ctx).runOnce();
+
+    assertThat(ctx.getPeerList().size()).isZero();
+  }
+
+  @Test
+  public void runOnce_keepsTheLiveInboundConnection() {
+    ServerContext ctx = context();
+    Peer connectedLightClient = inboundPeer("84.147.60.253");
+    connectedLightClient.setConnected(true);
+    ctx.getPeerList().add(connectedLightClient);
+
+    new PeerJobs(ctx).runOnce();
+
+    assertThat(ctx.getPeerList().contains(connectedLightClient.getKademliaId()))
+        .as("a connected inbound peer is the one thing such an entry is good for")
+        .isTrue();
+  }
+
+  @Test
+  public void runOnce_keepsDialablePeersEvenWhileDisconnected() {
+    ServerContext ctx = context();
+    Peer node = new Peer("46.224.156.238", 59558);
+    node.setNodeId(NodeId.generateWithSimpleKey());
+    Peer loopbackNode = new Peer("127.0.0.1", 59560); // e2e topology: real port on loopback
+    loopbackNode.setNodeId(NodeId.generateWithSimpleKey());
+    ctx.getPeerList().add(node);
+    ctx.getPeerList().add(loopbackNode);
+
+    new PeerJobs(ctx).runOnce();
+
+    assertThat(ctx.getPeerList().contains(node.getKademliaId())).isTrue();
+    assertThat(ctx.getPeerList().contains(loopbackNode.getKademliaId())).isTrue();
+  }
+
+  @Test
+  public void isDialableRejectsMissingConnectionDetails() {
+    Peer peer = new Peer("46.224.156.238", 59558);
+    assertThat(peer.isDialable()).isTrue();
+    peer.removeIpAndPort();
+    assertThat(peer.isDialable()).isFalse();
+  }
+}

--- a/src/test/java/im/redpanda/core/SaverTest.java
+++ b/src/test/java/im/redpanda/core/SaverTest.java
@@ -65,6 +65,29 @@ public class SaverTest {
   }
 
   @Test
+  public void testSavePeersSkipsUndialablePeers() {
+    // T86: an inbound-only peer (a light client announces port 0 in the handshake) cannot be
+    // dialled by anyone. Persisting it is what let hundreds of such entries survive restarts and
+    // be re-gossiped afterwards - the affected node's peers.dat held 82 loopback entries alone.
+    ArrayList<Peer> peers = new ArrayList<>();
+
+    Peer inboundOnly = new Peer("84.147.60.253", 0);
+    inboundOnly.setNodeId(new NodeId());
+    peers.add(inboundOnly);
+
+    Peer dialable = new Peer("46.224.156.238", 59558);
+    dialable.setNodeId(new NodeId());
+    peers.add(dialable);
+
+    Saver.savePeers(peers);
+
+    Map<KademliaId, Peer> loadedPeers = Saver.loadPeers();
+
+    assertEquals(1, loadedPeers.size());
+    assertNotNull(loadedPeers.get(dialable.getKademliaId()));
+  }
+
+  @Test
   public void testSavePeersSkipsPeerWithoutVerifyKey() {
     // Simulates the first-boot race: a bootstrap peer's KademliaId is known (e.g. from the DHT)
     // but its handshake has not completed yet, so its NodeId has no verify key. Saving must not

--- a/src/test/java/im/redpanda/core/SettingsKnownNodesTest.java
+++ b/src/test/java/im/redpanda/core/SettingsKnownNodesTest.java
@@ -6,9 +6,21 @@ import org.junit.Test;
 
 public class SettingsKnownNodesTest {
 
-  private static final String[] DEFAULTS = {
-    "195.201.25.223:59558", "redpanda.im:59559", "127.0.0.1:59558"
-  };
+  /**
+   * No loopback entry: {@code 127.0.0.1:59558} is the node's own listening address by default, so
+   * shipping it as a bootstrap peer made every unconfigured node dial itself (T86). Local setups
+   * pass their loopback seeds explicitly.
+   */
+  private static final String[] DEFAULTS = {"195.201.25.223:59558", "redpanda.im:59559"};
+
+  @Test
+  public void defaultsDoNotContainLoopback() {
+    for (String defaultNode : Settings.parseKnownNodes(null)) {
+      org.junit.Assert.assertFalse(
+          "loopback must not be a default bootstrap peer: " + defaultNode,
+          im.redpanda.crypt.Utils.isLocalAddress(defaultNode.split(":")[0]));
+    }
+  }
 
   @Test
   public void nullFallsBackToDefaults() {

--- a/src/test/java/im/redpanda/crypt/UtilsIsLocalAddressTest.java
+++ b/src/test/java/im/redpanda/crypt/UtilsIsLocalAddressTest.java
@@ -9,10 +9,87 @@ public class UtilsIsLocalAddressTest {
 
   @Test
   public void testLocalAndNonLocalAddresses() {
-    assertTrue(im.redpanda.crypt.Utils.isLocalAddress("127.0.0.1"));
-    assertTrue(im.redpanda.crypt.Utils.isLocalAddress("localhost"));
-    assertTrue(im.redpanda.crypt.Utils.isLocalAddress("192.168.1.10"));
-    assertFalse(im.redpanda.crypt.Utils.isLocalAddress("10.0.0.1"));
-    assertFalse(im.redpanda.crypt.Utils.isLocalAddress("example.com"));
+    assertTrue(Utils.isLocalAddress("127.0.0.1"));
+    assertTrue(Utils.isLocalAddress("localhost"));
+    assertTrue(Utils.isLocalAddress("192.168.1.10"));
+    // 10/8 is RFC1918 and used to be reported as non-local
+    assertTrue(Utils.isLocalAddress("10.0.0.1"));
+    assertFalse(Utils.isLocalAddress("example.com"));
+  }
+
+  @Test
+  public void coversTheWholeLoopbackAndPrivateSpace() {
+    assertTrue(Utils.isLocalAddress("127.0.0.1"));
+    assertTrue(Utils.isLocalAddress("127.255.255.254"));
+    assertTrue(Utils.isLocalAddress("10.0.2.2")); // emulator gate host address
+    assertTrue(Utils.isLocalAddress("172.16.0.1"));
+    assertTrue(Utils.isLocalAddress("172.31.255.255"));
+    assertTrue(Utils.isLocalAddress("192.168.0.1"));
+    assertTrue(Utils.isLocalAddress("169.254.10.1"));
+    assertTrue(Utils.isLocalAddress("100.64.0.1")); // CGNAT
+    assertTrue(Utils.isLocalAddress("0.0.0.0"));
+    assertTrue(Utils.isLocalAddress("::1"));
+    assertTrue(Utils.isLocalAddress("0:0:0:0:0:0:0:1"));
+    assertTrue(Utils.isLocalAddress("[::1]"));
+    assertTrue(Utils.isLocalAddress("::"));
+    assertTrue(Utils.isLocalAddress("fd00::1"));
+    assertTrue(Utils.isLocalAddress("fe80::1%eth0"));
+    assertTrue(Utils.isLocalAddress("::ffff:127.0.0.1"));
+    assertTrue(Utils.isLocalAddress(null));
+    assertTrue(Utils.isLocalAddress("  "));
+  }
+
+  @Test
+  public void publicAddressesAreNotLocal() {
+    assertFalse(Utils.isLocalAddress("5.75.137.166"));
+    assertFalse(Utils.isLocalAddress("195.201.25.223"));
+    assertFalse(Utils.isLocalAddress("84.147.60.253"));
+    // only 192.168/16 is private, the rest of 192/8 is public - this was over-matched before
+    assertFalse(Utils.isLocalAddress("192.0.2.5"));
+    assertFalse(Utils.isLocalAddress("172.32.0.1"));
+    assertFalse(Utils.isLocalAddress("100.128.0.1"));
+    assertFalse(Utils.isLocalAddress("2a01:4f8::1"));
+    assertFalse(Utils.isLocalAddress("redpanda.im"));
+  }
+
+  @Test
+  public void publicAdvertisementIsAlwaysPlausible() {
+    assertTrue(Utils.isPlausibleAdvertisedAddress("5.75.137.166", 59558, "46.224.156.238"));
+    assertTrue(Utils.isPlausibleAdvertisedAddress("5.75.137.166", 59558, "127.0.0.1"));
+  }
+
+  @Test
+  public void localAdvertisementOnlyPlausibleFromLocalPeer() {
+    // a peer we reached over loopback may gossip loopback and LAN addresses...
+    assertTrue(Utils.isPlausibleAdvertisedAddress("127.0.0.1", 59560, "127.0.0.1"));
+    assertTrue(Utils.isPlausibleAdvertisedAddress("192.168.1.5", 59558, "10.0.2.2"));
+    // ...a peer we reached over a public address may not
+    assertFalse(Utils.isPlausibleAdvertisedAddress("127.0.0.1", 59558, "84.147.60.253"));
+    assertFalse(Utils.isPlausibleAdvertisedAddress("10.0.0.9", 59558, "84.147.60.253"));
+    assertFalse(Utils.isPlausibleAdvertisedAddress("192.168.1.5", 59558, "84.147.60.253"));
+    assertFalse(Utils.isPlausibleAdvertisedAddress("172.20.1.1", 59558, "84.147.60.253"));
+    // an unknown peer address is treated as not local
+    assertFalse(Utils.isPlausibleAdvertisedAddress("127.0.0.1", 59558, null));
+  }
+
+  @Test
+  public void unusableAdvertisementsAreRejectedRegardlessOfOrigin() {
+    // port 0 is what an inbound-only peer carries; nobody can dial it
+    assertFalse(Utils.isPlausibleAdvertisedAddress("84.147.60.253", 0, "127.0.0.1"));
+    assertFalse(Utils.isPlausibleAdvertisedAddress("84.147.60.253", 70000, "127.0.0.1"));
+    assertFalse(Utils.isPlausibleAdvertisedAddress("84.147.60.253", -1, "127.0.0.1"));
+    assertFalse(Utils.isPlausibleAdvertisedAddress("", 59558, "127.0.0.1"));
+    assertFalse(Utils.isPlausibleAdvertisedAddress(null, 59558, "127.0.0.1"));
+    assertFalse(Utils.isPlausibleAdvertisedAddress("0.0.0.0", 59558, "127.0.0.1"));
+    assertFalse(Utils.isPlausibleAdvertisedAddress("::", 59558, "127.0.0.1"));
+  }
+
+  @Test
+  public void ownHostAddressRecognisesLoopback() {
+    assertTrue(Utils.isOwnHostAddress("127.0.0.1"));
+    assertTrue(Utils.isOwnHostAddress("localhost"));
+    assertTrue(Utils.isOwnHostAddress("::1"));
+    assertFalse(Utils.isOwnHostAddress("84.147.60.253"));
+    assertFalse(Utils.isOwnHostAddress(null));
   }
 }

--- a/src/test/java/im/redpanda/crypt/UtilsIsLocalAddressTest.java
+++ b/src/test/java/im/redpanda/crypt/UtilsIsLocalAddressTest.java
@@ -72,6 +72,42 @@ public class UtilsIsLocalAddressTest {
     assertFalse(Utils.isPlausibleAdvertisedAddress("127.0.0.1", 59558, null));
   }
 
+  /**
+   * A gossiped host name is never plausible: {@code isLocalAddress} classifies by string and cannot
+   * see through a name, while {@code OutboundHandler} dials via {@code InetSocketAddress}, which
+   * resolves it — so a name an attacker controls could resolve (or later be re-pointed) to loopback
+   * or a LAN address and bypass the locality rule entirely.
+   */
+  @Test
+  public void gossipedHostNamesAreNeverPlausible() {
+    assertFalse(Utils.isPlausibleAdvertisedAddress("redpanda.im", 59559, "84.147.60.253"));
+    assertFalse(Utils.isPlausibleAdvertisedAddress("evil.example.com", 59558, "84.147.60.253"));
+    // also from a loopback peer - a name is untrusted regardless of who sends it
+    assertFalse(Utils.isPlausibleAdvertisedAddress("redpanda.im", 59559, "127.0.0.1"));
+    assertFalse(Utils.isPlausibleAdvertisedAddress("localhost", 59558, "127.0.0.1"));
+    // a name that resolves to loopback today and to anything else tomorrow
+    assertFalse(Utils.isPlausibleAdvertisedAddress("localtest.me", 59558, "127.0.0.1"));
+    // literals stay plausible, including the loopback ones the e2e topology exchanges
+    assertTrue(Utils.isPlausibleAdvertisedAddress("127.0.0.1", 59560, "127.0.0.1"));
+    assertTrue(Utils.isPlausibleAdvertisedAddress("2a01:4f8::1", 59558, "84.147.60.253"));
+  }
+
+  @Test
+  public void ipLiteralsAreDistinguishedFromNames() {
+    assertTrue(Utils.isIpLiteral("127.0.0.1"));
+    assertTrue(Utils.isIpLiteral("5.75.137.166"));
+    assertTrue(Utils.isIpLiteral("::1"));
+    assertTrue(Utils.isIpLiteral("[2a01:4f8::1]"));
+    assertTrue(Utils.isIpLiteral("fe80::1%eth0"));
+    assertTrue(Utils.isIpLiteral("::ffff:127.0.0.1"));
+    assertFalse(Utils.isIpLiteral("redpanda.im"));
+    assertFalse(Utils.isIpLiteral("localhost"));
+    assertFalse(Utils.isIpLiteral("127.0.0.1.example.com"));
+    assertFalse(Utils.isIpLiteral("999.1.1.1"));
+    assertFalse(Utils.isIpLiteral(""));
+    assertFalse(Utils.isIpLiteral(null));
+  }
+
   @Test
   public void unusableAdvertisementsAreRejectedRegardlessOfOrigin() {
     // port 0 is what an inbound-only peer carries; nobody can dial it


### PR DESCRIPTION
## The bug

An affected node carries ~280 peer-list entries. Two distinct mechanisms compose; both are measured below.

### 1. Retention (the origin)

Every inbound connection puts a `Peer` into the peer list, built from the remote end of the socket plus the listening port the handshake announces (`ConnectionReaderThread:151`). A **light client has no listening socket and announces port 0**, so its entry is undialable from birth and dead weight the moment the connection drops. Visible verbatim in the light-client e2e log:

```
ConnectionHandler - Connected successfully to 127.0.0.1:0 (KadId: 2CD4kqk6Lh)
```

Nothing ever removed it. The only eviction path, `OutboundHandler`, does `if (peer.port == 0) continue;` **before** its retry-based removal, so `retries` never moves for exactly those peers. They are then written to `peers.dat` (`Saver` persisted anything with a verify key), restored by `Server.startUpRoutines` on the next start and gossiped on. One entry per mobile app instance, per re-install, per e2e run — which is why the `127.0.0.1` rows are the most numerous.

### 2. Gossip (the propagation)

`handleRequestPeerList` re-gossips the list verbatim and `handleSendPeerList` accepted every advertised `ip`/`port` with no check at all. So the junk does not stay on the node that produced it.

## Measured

Throwaway node, `REDPANDA_KNOWN_NODES` = the two testnet seeds, peer table dumped at t=150 s and t=270 s (identical both times). This node had **2 connections and zero inbound light clients** — it inherited the whole list from a seed by gossip alone:

| | before | after |
|---|---|---|
| peer-list entries | **278** | **5** |
| port 0 (undialable) | **273** | 0 |
| `127.0.0.1` | **82** | 0 |
| `peers.dat` | 28 809 B, 82 loopback entries | 776 B, 4 public ips, 0 local |

Peer-list size is also the amplifier behind TD026: `PeerJobs` sleeps 20 ms per peer, so a full maintenance pass took 278 × 20 ms ≈ **5.6 s** and now takes ≈ 0.1 s. (#293 already stopped that from being held under the read lock; this removes the pressure at the source.)

## The fix

**Retention — the root cause:**
- `Peer.isDialable()` is the one predicate for "has connection details we could dial", used by `PeerJobs`, `Saver` and `OutboundHandler`.
- `PeerJobs.runOnce` drops peers that are neither connected/connecting **nor** dialable. A *connected* inbound peer is kept — that is the live connection and the only thing such an entry is good for; the next handshake recreates it, which is how it came about in the first place.
- `Saver.savePeers` no longer persists undialable peers, so the leak stops surviving restarts.

**Gossip — containment, kept because it is measured, not hypothetical:**
- One shared predicate `Utils.isPlausibleAdvertisedAddress(advertisedIp, advertisedPort, peerIp)` guards the ingest **and** the send path. Entries with no dialable port are rejected in both directions — that alone accounts for the 273. The dart light client already drops `port <= 0` on its side, so nothing regresses there.
- Locality rule, defence in depth: peer-list gossip is unauthenticated, so a peer can otherwise steer us into dialling anything. The rule is about *who advertises what*, not a blanket ban, because the loopback topologies are real — the mobile e2e suite runs several nodes on `127.0.0.1`, the emulator gate reaches the host at `10.0.2.2`. A peer we reached over a local address may gossip local addresses; a peer we reached over a public address may not. There is a concrete instance class: `127.0.0.1:59558` was a **default** bootstrap peer while `DEFAULT_PORT` is 59558, so every unconfigured node dialled its own listening port and gossiped the resulting real-port loopback entry outward. Removed from `DEFAULT_KNOWN_NODES`, reason in the code; every local topology passes its loopback seeds explicitly via `REDPANDA_KNOWN_NODES`.
- **Gossip carries IP literals only** (Copilot review). `isLocalAddress` classifies by string and returns false for anything that is not a literal, so a gossiped host name was always "plausible" — and `OutboundHandler:57` dials via `new InetSocketAddress(peer.ip, peer.port)`, which resolves. An attacker could gossip a name they control, have it resolve (or later be re-pointed) to `127.0.0.1` / RFC1918 / link-local, and bypass the locality rule entirely. `Utils.isIpLiteral` is shape-based for IPv6 on purpose: a DNS label holds only letters, digits and hyphens, so hex digits + colons + an embedded IPv4 tail is never resolvable, and a malformed one just fails to connect — the property that must hold is "no name lookup", not "valid address". **Configured seeds are unaffected**: `Settings.knownNodes` (which ships `redpanda.im:59559`) and `REDPANDA_KNOWN_NODES` reach the peer list through `OutboundHandler.addKnownNodes()` and never pass through this predicate. Operator input is trusted, an unauthenticated peer is not.
- Entries pointing back at our own listening address are dropped (`Utils.isOwnHostAddress` + our port); the existing check only caught entries carrying our node id.
- `Utils.isLocalAddress` was **extended, not duplicated**: it covered `127.0.0.1`, `localhost` and all of `192.*`, and now covers the full RFC1918 space, CGNAT, link-local, the unspecified address and the IPv6 equivalents, while narrowing `192.*` to `192.168/16` (the rest of `192/8` is public). Its one existing caller, `NodeInfoSetRefreshJob`, only gets more correct.
- `Settings.MAX_PEERLIST_SIZE = 200` bounds the gossip ingest path; connections we established ourselves are never refused.

## Tests

- `PeerJobsUndialablePeerEvictionTest` — undialable + disconnected is dropped; the live inbound connection is kept; **dialable loopback peers (`127.0.0.1:59560`, the e2e node topology) are kept**.
- `SaverTest.testSavePeersSkipsUndialablePeers` — save/load round trip.
- `InboundCommandProcessorPeerListFilterTest` — gossip carrying loopback, RFC1918, link-local, unspecified, port-0 and our own address, **from a public peer and from a loopback peer**, plus the bound and both directions of the send path.
- `UtilsIsLocalAddressTest` extended to the full range matrix, plus `gossipedHostNamesAreNeverPlausible` and `ipLiteralsAreDistinguishedFromNames`; `InboundCommandProcessorPeerListFilterTest` gained `gossipedHostNames_areDropped`, `.._areDroppedFromALoopbackPeerToo`, `weDoNotAdvertiseHostNames` and `configuredSeedsMayStillUseHostNames`.
- `ParseCommandTest` built its 100 synthetic peers on ports `0..99` and made-up host names; they are now ports `1..100` on IP literals, which is what the protocol actually carries. `SettingsKnownNodesTest` defaults updated.
- `mvn -ntp test`: **485 tests, 0 failures**.
- `t42_multi_oh_e2e_test.dart` + `ms01_full_exchange_test.dart` (3 redPandaj nodes on `127.0.0.1`, 2 light clients, full message exchange) run against a jar built from this branch: **passed**. The reference jar was restored afterwards.

No deploy, no merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm
