### PR TITLE
fix(T87): break the PeerList <-> writeBufferLock deadlock that wedged a seed node

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -47,6 +47,14 @@ public class ConnectionHandler extends Thread {
   /** Longest plaintext handshake command: SEND_PUBLIC_KEY plus its 64-byte key export. */
   static final int MAX_PLAINTEXT_HANDSHAKE_COMMAND_LEN = 1 + NodeId.PUBLIC_KEYLEN;
 
+  /**
+   * How long {@link #setupConnection} waits for the peer list write lock before it gives up on this
+   * one connection (T87). Far longer than any legitimate hold — the list is only ever iterated or
+   * snapshotted under it — so a timeout means something is stuck, and the selector thread must not
+   * be the one that waits it out.
+   */
+  static final long PEERLIST_LOCK_TIMEOUT_MS = 5000;
+
   public static ArrayList<PeerInHandshake> peerInHandshakes = new ArrayList<>();
   @Getter private ReentrantLock peerInHandshakesLock = new ReentrantLock(false);
   public static BlockingQueue<Peer> peersToReadAndParse = new LinkedBlockingQueue<>(600);
@@ -861,6 +869,13 @@ public class ConnectionHandler extends Thread {
     }
   }
 
+  /**
+   * Completes a handshake and registers the peer. <b>Runs on the NIO selector thread.</b>
+   *
+   * <p>It holds {@code peerOrigin.writeBufferLock} across the whole body and takes the peer list
+   * write lock inside it — that is the documented order (see {@link PeerList}, "Lock order"), and
+   * no code may take those two the other way round.
+   */
   public void setupConnection(Peer peerOrigin, PeerInHandshake peerInHandshake) {
 
     ReentrantLock writeBufferLock = peerOrigin.getWriteBufferLock();
@@ -878,7 +893,27 @@ public class ConnectionHandler extends Thread {
        * If this is a new connection not initialzed by us this peer might not be in our PeerList,
        * lets add it by KademliaId
        */
-      Peer oldPeer = peerList.add(peerOrigin);
+      Peer oldPeer;
+      try {
+        oldPeer = peerList.add(peerOrigin, PEERLIST_LOCK_TIMEOUT_MS);
+      } catch (PeerList.PeerListBusyException e) {
+        // T87 safety net. The selector thread is the single thread that accepts new sockets and
+        // services the reads and writes of every existing connection, so parking it here does not
+        // cost one connection, it takes the node off the network — which is exactly what happened
+        // on 2026-07-29, where the wedged selector left the listen backlog full and the process
+        // alive but unreachable. Whatever holds the peer list lock for this long is a bug of its
+        // own, so make it loud rather than silent, and keep the event loop running.
+        logger.error(
+            "peer list lock unavailable on the selector thread, dropping the connection to {}:{}"
+                + " (KadId: {})",
+            peerOrigin.getIp(),
+            peerOrigin.getPort(),
+            peerInHandshake.getIdentity(),
+            e);
+        Log.sentry(e);
+        peerOrigin.disconnect("peer list lock unavailable on the selector thread");
+        return;
+      }
       if (oldPeer != null && oldPeer != peerOrigin) {
         // TD020: two inbound connections from the same node raced. Both handshakes saw
         // peerList.get(identity) == null in ConnectionReaderThread.parseHandshake and each built

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -31,7 +31,9 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.concurrent.locks.Lock;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -499,44 +501,60 @@ public class InboundCommandProcessor {
   }
 
   private int handleRequestPeerList(Peer peer) {
-    serverContext.getPeerList().getReadWriteLock().readLock().lock();
+    // T87: snapshot under the peer list read lock, then release it — the response is built and
+    // written WITHOUT it. Holding it across peer.getWriteBufferLock() inverted the lock order
+    // documented on PeerList: ConnectionHandler.setupConnection() holds a peer's writeBufferLock
+    // and then takes the peer list WRITE lock, on the NIO selector thread. Reader thread and
+    // selector thread could therefore each hold one of the two and wait for the other, and because
+    // a ReentrantReadWriteLock is non-fair the selector's queued write request then blocked every
+    // subsequent reader as well. That deadlocked a public seed node on 2026-07-29: the selector
+    // stopped calling accept(), the listen backlog filled up and no client could connect any more.
+    //
+    // Snapshotting is also the pattern every other iteration site uses (NodeStore.addServerEdges,
+    // PeerJobs.runOnce, Saver.savePeers, OhForwarder.selectNextPeer); the peers themselves were
+    // never guarded by this lock, only the list structure, so nothing weakens by copying first.
+    ArrayList<Peer> snapshot;
+    Lock peerListLock = serverContext.getPeerList().getReadWriteLock().readLock();
+    peerListLock.lock();
     try {
-      var builder = SendPeerList.newBuilder();
-      for (Peer peerToCheck : serverContext.getPeerList().getPeerArrayList()) {
-        if (peerToCheck.ip == null) {
-          continue;
-        }
-        // Same predicate as on the ingest path, with the recipient as the "other side": do not
-        // hand a local-only address to a peer outside that network, and do not pass on entries
-        // that carry no dialable port. Without this we amplify exactly what we refuse to accept.
-        if (!Utils.isPlausibleAdvertisedAddress(peerToCheck.ip, peerToCheck.getPort(), peer.ip)) {
-          continue;
-        }
-        var peerBuilder =
-            PeerInfoProto.newBuilder().setIp(peerToCheck.ip).setPort(peerToCheck.getPort());
-        if (peerToCheck.getNodeId() != null && peerToCheck.getNodeId().hasKey()) {
-          peerBuilder.setNodeId(
-              NodeIdProto.newBuilder()
-                  .setPublicKeyBytes(copyFrom(peerToCheck.getNodeId().exportPublic()))
-                  .build());
-          // MS04: explicit X25519 key so light clients can pick garlic hops directly
-          peerBuilder.setEncryptionPublicKey(
-              copyFrom(peerToCheck.getNodeId().getEncryptionPubKey().getEncoded()));
-        }
-        builder.addPeers(peerBuilder.build());
-      }
-      byte[] data = builder.build().toByteArray();
-      peer.getWriteBufferLock().lock();
-      try {
-        peer.writeBuffer.put(Command.SEND_PEERLIST);
-        peer.writeBuffer.putInt(data.length);
-        peer.writeBuffer.put(data);
-        peer.setWriteBufferFilled();
-      } finally {
-        peer.getWriteBufferLock().unlock();
-      }
+      snapshot = new ArrayList<>(serverContext.getPeerList().getPeerArrayList());
     } finally {
-      serverContext.getPeerList().getReadWriteLock().readLock().unlock();
+      peerListLock.unlock();
+    }
+
+    var builder = SendPeerList.newBuilder();
+    for (Peer peerToCheck : snapshot) {
+      if (peerToCheck.ip == null) {
+        continue;
+      }
+      // Same predicate as on the ingest path, with the recipient as the "other side": do not
+      // hand a local-only address to a peer outside that network, and do not pass on entries
+      // that carry no dialable port. Without this we amplify exactly what we refuse to accept.
+      if (!Utils.isPlausibleAdvertisedAddress(peerToCheck.ip, peerToCheck.getPort(), peer.ip)) {
+        continue;
+      }
+      var peerBuilder =
+          PeerInfoProto.newBuilder().setIp(peerToCheck.ip).setPort(peerToCheck.getPort());
+      if (peerToCheck.getNodeId() != null && peerToCheck.getNodeId().hasKey()) {
+        peerBuilder.setNodeId(
+            NodeIdProto.newBuilder()
+                .setPublicKeyBytes(copyFrom(peerToCheck.getNodeId().exportPublic()))
+                .build());
+        // MS04: explicit X25519 key so light clients can pick garlic hops directly
+        peerBuilder.setEncryptionPublicKey(
+            copyFrom(peerToCheck.getNodeId().getEncryptionPubKey().getEncoded()));
+      }
+      builder.addPeers(peerBuilder.build());
+    }
+    byte[] data = builder.build().toByteArray();
+    peer.getWriteBufferLock().lock();
+    try {
+      peer.writeBuffer.put(Command.SEND_PEERLIST);
+      peer.writeBuffer.putInt(data.length);
+      peer.writeBuffer.put(data);
+      peer.setWriteBufferFilled();
+    } finally {
+      peer.getWriteBufferLock().unlock();
     }
     return 1;
   }

--- a/src/main/java/im/redpanda/core/ListenConsole.java
+++ b/src/main/java/im/redpanda/core/ListenConsole.java
@@ -211,11 +211,16 @@ public class ListenConsole extends Thread {
       } else if (readLine.equals("c")) {
         System.out.println("closing all connections...");
 
+        // try/finally: without it a throw inside disconnect() left the peer list write lock held
+        // forever, which wedges every thread that touches the list — the T87 failure mode.
         peerList.getReadWriteLock().writeLock().lock();
-        for (Peer peer : peerList.getPeerArrayList()) {
-          peer.disconnect("disconnect by user");
+        try {
+          for (Peer peer : peerList.getPeerArrayList()) {
+            peer.disconnect("disconnect by user");
+          }
+        } finally {
+          peerList.getReadWriteLock().writeLock().unlock();
         }
-        peerList.getReadWriteLock().writeLock().unlock();
 
       } else if (readLine.equals("alloc")) {
         System.out.println("allocating buffers by pool");

--- a/src/main/java/im/redpanda/core/ListenConsole.java
+++ b/src/main/java/im/redpanda/core/ListenConsole.java
@@ -211,15 +211,21 @@ public class ListenConsole extends Thread {
       } else if (readLine.equals("c")) {
         System.out.println("closing all connections...");
 
-        // try/finally: without it a throw inside disconnect() left the peer list write lock held
-        // forever, which wedges every thread that touches the list — the T87 failure mode.
-        peerList.getReadWriteLock().writeLock().lock();
+        // T87: snapshot under the lock, disconnect without it. Peer.disconnect() takes that peer's
+        // writeBufferLock (Peer:215) and closes the socket, so doing it under the peer list lock
+        // is the exact order PeerList's javadoc forbids and the same ABBA pair against
+        // ConnectionHandler.setupConnection(). Unreachable today only because systemd gives this
+        // thread /dev/null on stdin — which is a reason to fix it, not to keep it. The try/finally
+        // matters independently: a throw out of disconnect() used to leak the write lock forever.
+        ArrayList<Peer> peersToDisconnect;
+        peerList.getReadWriteLock().readLock().lock();
         try {
-          for (Peer peer : peerList.getPeerArrayList()) {
-            peer.disconnect("disconnect by user");
-          }
+          peersToDisconnect = new ArrayList<>(peerList.getPeerArrayList());
         } finally {
-          peerList.getReadWriteLock().writeLock().unlock();
+          peerList.getReadWriteLock().readLock().unlock();
+        }
+        for (Peer peer : peersToDisconnect) {
+          peer.disconnect("disconnect by user");
         }
 
       } else if (readLine.equals("alloc")) {

--- a/src/main/java/im/redpanda/core/OutboundHandler.java
+++ b/src/main/java/im/redpanda/core/OutboundHandler.java
@@ -151,181 +151,193 @@ public class OutboundHandler extends Thread {
         peerListLock.writeLock().unlock();
       }
 
+      // T87: snapshot under the read lock, then iterate WITHOUT holding it. The loop below calls
+      // connectTo() (socket open + connect, and peer.disconnect() when the selector registration
+      // fails) and peer.disconnect("max cons") — both take a peer's writeBufferLock. Holding the
+      // peer list read lock across that inverts the documented lock order (see PeerList): the
+      // selector thread holds a peer's writeBufferLock in ConnectionHandler.setupConnection() and
+      // then takes the peer list WRITE lock, so the two could deadlock — and a wedged selector
+      // takes the whole node down. Independently of that, this loop did network I/O under the read
+      // lock, which starves the selector's writer for as long as a connect attempt takes.
+      //
+      // Same reasoning and same shape as TD026 in PeerJobs.runOnce(): the copy keeps the iteration
+      // CME-safe exactly as the held lock did, and nothing in the loop touches the peer list
+      // itself, only the Peer objects, which this lock never guarded.
+      ArrayList<Peer> peers;
       peerListLock.readLock().lock();
       try {
-        int actCons = 0;
-        int connectingCons = 0;
-        int newConnections = 0;
-        for (Peer peer : peerListArray) {
-          if (peer.isConnected()) {
-            actCons++;
-          } else if (peer.isConnecting) {
-            connectingCons++;
-          }
+        peers = new ArrayList<>(peerListArray);
+      } finally {
+        peerListLock.readLock().unlock();
+      }
 
-          // if ((peer.isConnecting || peer.isConnected()) && (System.currentTimeMillis()
-          // - peer.lastActionOnConnection > 30000)) {
-          // peer.disconnect("timeout ...");
-          // }
-
+      int actCons = 0;
+      int connectingCons = 0;
+      int newConnections = 0;
+      for (Peer peer : peers) {
+        if (peer.isConnected()) {
+          actCons++;
+        } else if (peer.isConnecting) {
+          connectingCons++;
         }
 
-        actCons += connectingCons;
-        int cnt = 0;
-        for (Peer peer : peerListArray) {
+        // if ((peer.isConnecting || peer.isConnected()) && (System.currentTimeMillis()
+        // - peer.lastActionOnConnection > 30000)) {
+        // peer.disconnect("timeout ...");
+        // }
 
-          cnt++;
+      }
 
-          if (newConnections >= 10) {
-            break;
-          }
+      actCons += connectingCons;
+      int cnt = 0;
+      for (Peer peer : peers) {
 
-          if (actCons >= Settings.MIN_CONNECTIONS) {
+        cnt++;
 
-            Log.put("peers " + actCons + " are enough...", 300);
+        if (newConnections >= 10) {
+          break;
+        }
 
-            if (cnt == 1 && actCons >= Settings.MAX_CONNECTIONS) {
-              for (Peer p1 : peerListArray) {
-                if (p1.isConnected()) {
-                  p1.disconnect("max cons");
+        if (actCons >= Settings.MIN_CONNECTIONS) {
 
-                  System.out.println("closed one connection...");
+          Log.put("peers " + actCons + " are enough...", 300);
 
-                  break;
-                }
+          if (cnt == 1 && actCons >= Settings.MAX_CONNECTIONS) {
+            for (Peer p1 : peers) {
+              if (p1.isConnected()) {
+                p1.disconnect("max cons");
+
+                System.out.println("closed one connection...");
+
+                break;
               }
             }
+          }
+          break;
+        }
+
+        if (!peer.isDialable()) {
+          // Nothing to connect to. Note this skip happens before the retry-based removal below,
+          // so such a peer could never be evicted here - PeerJobs does it instead (T86).
+          continue;
+        }
+
+        if (peerList.isBlacklisted(peer.getIp())) {
+          continue;
+        }
+
+        if (peer.isConnected()) {
+          continue;
+        }
+
+        boolean alreadyConnectedToSameIpandPort = false;
+        for (Peer p2 : peers) {
+          if (peer.equalsIpAndPort(p2) && (peer.isConnected() || peer.isConnecting)) {
+            alreadyConnectedToSameIpandPort = true;
             break;
           }
+        }
 
-          if (!peer.isDialable()) {
-            // Nothing to connect to. Note this skip happens before the retry-based removal below,
-            // so such a peer could never be evicted here - PeerJobs does it instead (T86).
-            continue;
-          }
+        if (alreadyConnectedToSameIpandPort) {
+          continue;
+        }
 
-          if (peerList.isBlacklisted(peer.getIp())) {
-            continue;
-          }
+        if (Settings.IPV6_ONLY && peer.ip.length() <= 15) {
+          peersToRemove.add(peer);
+          Log.put("removed peer from peerList, no ipv6 address: " + peer.ip + ":" + peer.port, 200);
+          continue;
+        }
 
-          if (peer.isConnected()) {
-            continue;
-          }
+        if (Settings.IPV4_ONLY && peer.ip.length() > 15) {
+          peersToRemove.add(peer);
+          Log.put("removed peer from peerList, no ipv4 address: " + peer.ip + ":" + peer.port, 200);
+          continue;
+        }
 
-          boolean alreadyConnectedToSameIpandPort = false;
-          for (Peer p2 : peerListArray) {
-            if (peer.equalsIpAndPort(p2) && (peer.isConnected() || peer.isConnecting)) {
-              alreadyConnectedToSameIpandPort = true;
+        boolean alreadyConnectedToSameNodeId = false;
+        if (peer.getKademliaId() != null) {
+          // already connected to same trusted node?
+          for (Peer p2 : peers) {
+
+            if (alreadyConnectedToSameNodeId) {
+              break;
+            }
+
+            if (!p2.isConnected() && !p2.isConnecting) {
+              continue;
+            }
+
+            if (peer.equalsNonce(p2)) {
+              alreadyConnectedToSameNodeId = true;
               break;
             }
           }
+        }
 
-          if (alreadyConnectedToSameIpandPort) {
-            continue;
-          }
+        if (alreadyConnectedToSameNodeId) {
+          Log.put("Do not connect to this peer, already connected to same KadId...", 70);
+          continue;
+        }
 
-          if (Settings.IPV6_ONLY && peer.ip.length() <= 15) {
-            peersToRemove.add(peer);
+        if (peer.isConnected() || peer.isConnecting) {
+          continue;
+          // peer.disconnect();
+          // if (DEBUG) {
+          // System.out.println("closing con, cuz i wanna connect...");
+          // }
+        }
+
+        // if (peerList.size() > 20) {
+        // (System.currentTimeMillis() - peer.lastActionOnConnection > 1000 * 60 * 60 *
+        // 4)
+        if ((peer.retries > 10 || (peer.getKademliaId() == null && peer.retries >= 5))
+            && peer.ping != -1) {
+          // peerList.remove(peer);
+          peersToRemove.add(peer);
+
+          if (peer.retries < 200) {
+
+            // Test.messageStore.insertPeerConnectionInformation(peer.ip, peer.port, 0, 0);
+            // Test.messageStore.setStatusForPeerConnectionInformation(peer.ip, peer.port,
+            // peer.retries, System.currentTimeMillis() + 1000L * 60L * peer.retries);
+            // Test.messageStore.setStatusForPeerConnectionInformation(peer.ip, peer.port,
+            // peer.retries, System.currentTimeMillis() + 1000L * 60L * 5L);
+
             Log.put(
-                "removed peer from peerList, no ipv6 address: " + peer.ip + ":" + peer.port, 200);
-            continue;
-          }
-
-          if (Settings.IPV4_ONLY && peer.ip.length() > 15) {
-            peersToRemove.add(peer);
-            Log.put(
-                "removed peer from peerList, no ipv4 address: " + peer.ip + ":" + peer.port, 200);
-            continue;
-          }
-
-          boolean alreadyConnectedToSameNodeId = false;
-          if (peer.getKademliaId() != null) {
-            // already connected to same trusted node?
-            for (Peer p2 : peerListArray) {
-
-              if (alreadyConnectedToSameNodeId) {
-                break;
-              }
-
-              if (!p2.isConnected() && !p2.isConnecting) {
-                continue;
-              }
-
-              if (peer.equalsNonce(p2)) {
-                alreadyConnectedToSameNodeId = true;
-                break;
-              }
-            }
-          }
-
-          if (alreadyConnectedToSameNodeId) {
-            Log.put("Do not connect to this peer, already connected to same KadId...", 70);
-            continue;
-          }
-
-          if (peer.isConnected() || peer.isConnecting) {
-            continue;
-            // peer.disconnect();
-            // if (DEBUG) {
-            // System.out.println("closing con, cuz i wanna connect...");
-            // }
-          }
-
-          // if (peerList.size() > 20) {
-          // (System.currentTimeMillis() - peer.lastActionOnConnection > 1000 * 60 * 60 *
-          // 4)
-          if ((peer.retries > 10 || (peer.getKademliaId() == null && peer.retries >= 5))
-              && peer.ping != -1) {
-            // peerList.remove(peer);
-            peersToRemove.add(peer);
-
-            if (peer.retries < 200) {
-
-              // Test.messageStore.insertPeerConnectionInformation(peer.ip, peer.port, 0, 0);
-              // Test.messageStore.setStatusForPeerConnectionInformation(peer.ip, peer.port,
-              // peer.retries, System.currentTimeMillis() + 1000L * 60L * peer.retries);
-              // Test.messageStore.setStatusForPeerConnectionInformation(peer.ip, peer.port,
-              // peer.retries, System.currentTimeMillis() + 1000L * 60L * 5L);
-
-              Log.put(
-                  "removed peer from peerList, too many retries: " + peer.ip + ":" + peer.port, 20);
-
-            } else {
-              // we do not have to remove peers here because every peer in peerlist should not
-              // be in the db!
-
-              Log.put(
-                  "removed peer permanently, too many retries: " + peer.ip + ":" + peer.port, 20);
-            }
-
-            continue;
-          }
-          peer.ping = 0;
-
-          if (peer.connectAble != -1) {
-
-            Log.put("try to connect to new node: " + peer.ip + ":" + peer.port, 150);
-
-            boolean success = connectTo(serverContext, peer);
-            actCons++;
-            newConnections++;
-            if (!success) {
-              // if the connect method was not successful we had to wait longer than normally,
-              // thus we should release the peerlist lock sooner...
-              newConnections += 5;
-            }
-            // try {
-            // sleep(200);
-            // } catch (InterruptedException ex) {
-            // }
+                "removed peer from peerList, too many retries: " + peer.ip + ":" + peer.port, 20);
 
           } else {
-            System.out.println(
-                "connect state: " + peer.connectAble + " -- " + peer.ip + ":" + peer.port);
+            // we do not have to remove peers here because every peer in peerlist should not
+            // be in the db!
+
+            Log.put("removed peer permanently, too many retries: " + peer.ip + ":" + peer.port, 20);
           }
+
+          continue;
         }
-      } finally {
-        peerListLock.readLock().unlock();
+        peer.ping = 0;
+
+        if (peer.connectAble != -1) {
+
+          Log.put("try to connect to new node: " + peer.ip + ":" + peer.port, 150);
+
+          boolean success = connectTo(serverContext, peer);
+          actCons++;
+          newConnections++;
+          if (!success) {
+            // if the connect method was not successful we had to wait longer than normally,
+            // thus we should release the peerlist lock sooner...
+            newConnections += 5;
+          }
+          // try {
+          // sleep(200);
+          // } catch (InterruptedException ex) {
+          // }
+
+        } else {
+          System.out.println(
+              "connect state: " + peer.connectAble + " -- " + peer.ip + ":" + peer.port);
+        }
       }
 
       for (Peer toRemove : peersToRemove) {

--- a/src/main/java/im/redpanda/core/PeerList.java
+++ b/src/main/java/im/redpanda/core/PeerList.java
@@ -45,7 +45,8 @@ import org.jetbrains.annotations.Nullable;
  * acquisition sites. The rule for the peer list specifically: <b>never call anything that can block
  * while holding one of these locks.</b> Snapshot the list under the lock, release it, then do the
  * work — see {@code NodeStore.addServerEdges()}, {@code PeerJobs.runOnce()}, {@code
- * Saver.savePeers()}, {@code OhForwarder.selectNextPeer()} for the established pattern.
+ * Saver.savePeers()}, {@code OhForwarder.selectNextPeer()}, {@code OutboundHandler.run()} for the
+ * established pattern.
  */
 public class PeerList {
 

--- a/src/main/java/im/redpanda/core/PeerList.java
+++ b/src/main/java/im/redpanda/core/PeerList.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -19,8 +20,44 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p><b>Warning</b>: Do not change any of the required data ({@link KademliaId}, Ip, Port) of a
  * {@link Peer} if it is present in the Peerlist without updating the corresponding List/HashMap.
+ *
+ * <h2>Lock order (T87)</h2>
+ *
+ * <p>Three locks are routinely nested on the connection paths. They must always be acquired in this
+ * order, outermost first, and never in the reverse one:
+ *
+ * <ol>
+ *   <li>{@link Peer#writeBufferLock} — a single peer's write buffer
+ *   <li>{@code NodeStore.readWriteLock} — the node graph
+ *   <li>{@code PeerList.readWriteLock} — this lock
+ * </ol>
+ *
+ * <p>Violating it wedged a public seed node on 2026-07-29: {@code
+ * ConnectionHandler.setupConnection()} holds a peer's {@code writeBufferLock} and then calls {@link
+ * #add(Peer)} (the peer list <i>write</i> lock) on the NIO selector thread, while {@code
+ * InboundCommandProcessor.handleRequestPeerList()} held the peer list <i>read</i> lock and then
+ * took the same peer's {@code writeBufferLock} on a reader thread. Once the selector's write
+ * request was queued, every later reader queued behind it (the lock is non-fair, so a queued writer
+ * blocks new readers), so the whole node froze instead of merely slowing down — including {@code
+ * accept()}, which is why the listen backlog filled up and no client could connect any more.
+ *
+ * <p>Only the last of the three is guarded by this class; the other two are documented at their own
+ * acquisition sites. The rule for the peer list specifically: <b>never call anything that can block
+ * while holding one of these locks.</b> Snapshot the list under the lock, release it, then do the
+ * work — see {@code NodeStore.addServerEdges()}, {@code PeerJobs.runOnce()}, {@code
+ * Saver.savePeers()}, {@code OhForwarder.selectNextPeer()} for the established pattern.
  */
 public class PeerList {
+
+  /**
+   * Signals that the peer list write lock could not be acquired within the caller's budget. Only
+   * thrown by {@link #add(Peer, long)}; the unbounded {@link #add(Peer)} waits forever.
+   */
+  public static class PeerListBusyException extends RuntimeException {
+    public PeerListBusyException(String message) {
+      super(message);
+    }
+  }
 
   /** We store each Peer in a hashmap for fast get operations via KademliaId */
   private final HashMap<KademliaId, Peer> peerHashMap = new HashMap<>();
@@ -63,58 +100,97 @@ public class PeerList {
     // upgrade a read lock to a write lock. addPeer() re-acquires it reentrantly.
     readWriteLock.writeLock().lock();
     try {
-      Peer oldPeer = null;
-
-      // we have to check if the peer is already in the PeerList, for this we use the
-      // HashMaps since they are much faster
-      if (peer.getKademliaId() != null) {
-        oldPeer = peerHashMap.get(peer.getKademliaId());
-        if (oldPeer != null) {
-          // Peer with same KademliaId exists already
-          Log.put("Peer with same KademliaId exists already", 100);
-          return oldPeer;
-        } else {
-          /**
-           * Peer has a NodeId but was not found in list. If we would return without checking for ip
-           * and port, fast connections to same peer might make a problem.
-           */
-        }
-      }
-
-      /**
-       * We allow peers without connection details (ip,port) in the PeerList, since after a wipe of
-       * data the new Node has the same (ip,port) but different Identity. The (ip,port) will then be
-       * removed from the old Peer. Since we allow Peers without (ip,port) in general we allow to
-       * add Peers without (ip,port) here.
-       */
-      if (peer.getIp() != null) {
-        oldPeer = peerlistIpPort.get(getIpPortHash(peer));
-        if (oldPeer != null) {
-          // Peer with same Ip+Port exists already
-
-          if (peer.getNodeId() == null) {
-            // new peer to add has no node id, lets not add it
-            return oldPeer;
-          }
-
-          if (oldPeer.getNodeId() == null || !oldPeer.getNodeId().equals(peer.getNodeId())) {
-          } else {
-            return oldPeer;
-          }
-        }
-      }
-
-      return addPeer(peer);
+      return addLocked(peer);
     } finally {
       readWriteLock.writeLock().unlock();
     }
   }
 
+  /**
+   * Like {@link #add(Peer)}, but gives up instead of parking forever.
+   *
+   * <p>For callers that must not block indefinitely — above all {@code
+   * ConnectionHandler.setupConnection()}, which runs on the single NIO selector thread. A selector
+   * thread parked on a lock stops calling {@code accept()} and stops servicing every existing
+   * connection, so a peer list lock that is stuck for any reason takes the entire node down rather
+   * than costing one connection (T87). The timeout does not make a stuck lock correct; it turns a
+   * silent total wedge into one dropped connection plus a loud Sentry event.
+   *
+   * @param timeoutMillis how long to wait for the write lock
+   * @return old peer, null if no old peer or old peer null — same contract as {@link #add(Peer)}
+   * @throws PeerListBusyException if the write lock was not acquired in time, or the wait was
+   *     interrupted
+   */
+  public Peer add(Peer peer, long timeoutMillis) {
+    boolean locked;
+    try {
+      locked = readWriteLock.writeLock().tryLock(timeoutMillis, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new PeerListBusyException("interrupted while waiting for the peer list write lock");
+    }
+    if (!locked) {
+      throw new PeerListBusyException(
+          "peer list write lock not acquired within " + timeoutMillis + " ms");
+    }
+    try {
+      return addLocked(peer);
+    } finally {
+      readWriteLock.writeLock().unlock();
+    }
+  }
+
+  /** The body of {@link #add(Peer)}. Callers must hold the write lock. */
+  private Peer addLocked(Peer peer) {
+    Peer oldPeer = null;
+
+    // we have to check if the peer is already in the PeerList, for this we use the
+    // HashMaps since they are much faster
+    if (peer.getKademliaId() != null) {
+      oldPeer = peerHashMap.get(peer.getKademliaId());
+      if (oldPeer != null) {
+        // Peer with same KademliaId exists already
+        Log.put("Peer with same KademliaId exists already", 100);
+        return oldPeer;
+      } else {
+        /**
+         * Peer has a NodeId but was not found in list. If we would return without checking for ip
+         * and port, fast connections to same peer might make a problem.
+         */
+      }
+    }
+
+    /**
+     * We allow peers without connection details (ip,port) in the PeerList, since after a wipe of
+     * data the new Node has the same (ip,port) but different Identity. The (ip,port) will then be
+     * removed from the old Peer. Since we allow Peers without (ip,port) in general we allow to add
+     * Peers without (ip,port) here.
+     */
+    if (peer.getIp() != null) {
+      oldPeer = peerlistIpPort.get(getIpPortHash(peer));
+      if (oldPeer != null) {
+        // Peer with same Ip+Port exists already
+
+        if (peer.getNodeId() == null) {
+          // new peer to add has no node id, lets not add it
+          return oldPeer;
+        }
+
+        if (oldPeer.getNodeId() == null || !oldPeer.getNodeId().equals(peer.getNodeId())) {
+        } else {
+          return oldPeer;
+        }
+      }
+    }
+
+    return addPeer(peer);
+  }
+
   @Nullable
   private Peer addPeer(Peer peer) {
     Peer oldPeer = null;
+    readWriteLock.writeLock().lock();
     try {
-      readWriteLock.writeLock().lock();
       if (peer.getKademliaId() != null) {
         oldPeer = peerHashMap.put(peer.getKademliaId(), peer);
       }
@@ -222,8 +298,8 @@ public class PeerList {
    */
   public boolean remove(KademliaId id) {
     boolean removedOnePeer = false;
+    readWriteLock.writeLock().lock();
     try {
-      readWriteLock.writeLock().lock();
       Peer remove = peerHashMap.remove(id);
       if (remove == null) {
         return false;
@@ -246,8 +322,10 @@ public class PeerList {
   }
 
   public boolean contains(KademliaId id) {
+    // lock() outside the try: inside it, a throwing lock() would send the finally into an unlock()
+    // of a lock this thread never took.
+    readWriteLock.readLock().lock();
     try {
-      readWriteLock.readLock().lock();
       return peerHashMap.containsKey(id);
     } finally {
       readWriteLock.readLock().unlock();
@@ -255,8 +333,8 @@ public class PeerList {
   }
 
   public Peer get(KademliaId id) {
+    readWriteLock.readLock().lock();
     try {
-      readWriteLock.readLock().lock();
       return peerHashMap.get(id);
     } finally {
       readWriteLock.readLock().unlock();

--- a/src/main/java/im/redpanda/jobs/NodeInfoSetRefreshJob.java
+++ b/src/main/java/im/redpanda/jobs/NodeInfoSetRefreshJob.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.locks.Lock;
 import org.jgrapht.graph.DefaultDirectedWeightedGraph;
 
 public class NodeInfoSetRefreshJob extends Job {
@@ -53,7 +54,13 @@ public class NodeInfoSetRefreshJob extends Job {
   private List<GMEntryPointModel> getGoodEntryPoints() {
     ArrayList<NodeEdge> nodeEdges = new ArrayList<>();
     ArrayList<GMEntryPointModel> gmEntryPointModels = new ArrayList<>();
-    serverContext.getNodeStore().getReadWriteLock().readLock().lock();
+    // Same lock object for lock and unlock: NodeStore.saveToDisk()'s recovery path replaces
+    // serverContext's NodeStore, and re-reading getNodeStore() for the unlock would then release a
+    // lock this thread never took (IllegalMonitorStateException) — leaving the original read lock
+    // held forever. Same guard as in PeerPerformanceTestGarlicMessageJob.init() and
+    // OhForwarder.selectNextPeer().
+    Lock graphLock = serverContext.getNodeStore().getReadWriteLock().readLock();
+    graphLock.lock();
     try {
       nodeEdges.addAll(nodeGraph.incomingEdgesOf(serverContext.getNode()));
       Collections.sort(nodeEdges, Comparator.comparingDouble(nodeGraph::getEdgeWeight));
@@ -80,7 +87,7 @@ public class NodeInfoSetRefreshJob extends Job {
         cnt++;
       }
     } finally {
-      serverContext.getNodeStore().getReadWriteLock().readLock().unlock();
+      graphLock.unlock();
     }
 
     return gmEntryPointModels;

--- a/src/main/java/im/redpanda/jobs/NodeInfoSetRefreshJob.java
+++ b/src/main/java/im/redpanda/jobs/NodeInfoSetRefreshJob.java
@@ -7,6 +7,7 @@ import im.redpanda.kademlia.KadContent;
 import im.redpanda.kademlia.nodeinfo.GMEntryPointModel;
 import im.redpanda.kademlia.nodeinfo.NodeInfoModel;
 import im.redpanda.store.NodeEdge;
+import im.redpanda.store.NodeStore;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -17,7 +18,6 @@ import java.util.concurrent.locks.Lock;
 import org.jgrapht.graph.DefaultDirectedWeightedGraph;
 
 public class NodeInfoSetRefreshJob extends Job {
-  private DefaultDirectedWeightedGraph<Node, NodeEdge> nodeGraph;
 
   public NodeInfoSetRefreshJob(ServerContext serverContext) {
     super(serverContext, Duration.ofSeconds(15).toMillis(), true, true);
@@ -25,7 +25,7 @@ public class NodeInfoSetRefreshJob extends Job {
 
   @Override
   public void init() {
-    nodeGraph = serverContext.getNodeStore().getNodeGraph();
+    // Deliberately empty: the node graph must NOT be cached here. See getGoodEntryPoints().
   }
 
   @Override
@@ -54,14 +54,24 @@ public class NodeInfoSetRefreshJob extends Job {
   private List<GMEntryPointModel> getGoodEntryPoints() {
     ArrayList<NodeEdge> nodeEdges = new ArrayList<>();
     ArrayList<GMEntryPointModel> gmEntryPointModels = new ArrayList<>();
-    // Same lock object for lock and unlock: NodeStore.saveToDisk()'s recovery path replaces
-    // serverContext's NodeStore, and re-reading getNodeStore() for the unlock would then release a
-    // lock this thread never took (IllegalMonitorStateException) — leaving the original read lock
-    // held forever. Same guard as in PeerPerformanceTestGarlicMessageJob.init() and
-    // OhForwarder.selectNextPeer().
-    Lock graphLock = serverContext.getNodeStore().getReadWriteLock().readLock();
+    // Resolve the NodeStore ONCE and take the lock and the graph from that same instance.
+    // NodeStore.saveToDisk() replaces serverContext's store on its recovery path (NodeStore:205),
+    // and a new NodeStore brings both a new readWriteLock (:60, final per instance) and a new empty
+    // nodeGraph (:64). Two bugs follow from mixing instances, and this job used to have both:
+    //
+    //   - unlocking via a re-read getNodeStore() releases a lock this thread never took
+    //     (IllegalMonitorStateException) and leaks the original read hold forever;
+    //   - reading the graph from a field captured in init() — which Job runs exactly once
+    //     (Job:64-67), while this job is permanent and re-runs every 5 minutes — pairs the new
+    //     store's lock with the OLD store's graph, so the lock guards nothing that is being
+    //     iterated, and the job keeps publishing entry points from a dead graph forever.
+    //
+    // Same shape as PeerPerformanceTestGarlicMessageJob:355-360 and OhForwarder.selectNextPeer().
+    NodeStore nodeStore = serverContext.getNodeStore();
+    Lock graphLock = nodeStore.getReadWriteLock().readLock();
     graphLock.lock();
     try {
+      DefaultDirectedWeightedGraph<Node, NodeEdge> nodeGraph = nodeStore.getNodeGraph();
       nodeEdges.addAll(nodeGraph.incomingEdgesOf(serverContext.getNode()));
       Collections.sort(nodeEdges, Comparator.comparingDouble(nodeGraph::getEdgeWeight));
       Iterator<NodeEdge> iterator = nodeEdges.iterator();

--- a/src/test/java/im/redpanda/core/PeerListLockOrderTest.java
+++ b/src/test/java/im/redpanda/core/PeerListLockOrderTest.java
@@ -1,0 +1,128 @@
+package im.redpanda.core;
+
+import static org.junit.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression test for T87: the deadlock that took a public seed node off the network on 2026-07-29.
+ *
+ * <p>Two lock acquisition orders existed for the same pair of locks:
+ *
+ * <ul>
+ *   <li>{@code ConnectionHandler.setupConnection()} — on the <b>NIO selector thread</b> — holds
+ *       {@code peerOrigin.writeBufferLock} (ConnectionHandler.java:867) and then takes the peer
+ *       list <b>write</b> lock via {@code peerList.add()} (ConnectionHandler.java:881).
+ *   <li>{@code InboundCommandProcessor.handleRequestPeerList()} — on a reader thread — held the
+ *       peer list <b>read</b> lock (InboundCommandProcessor.java:502) and then took that same
+ *       peer's {@code writeBufferLock} (InboundCommandProcessor.java:529).
+ * </ul>
+ *
+ * <p>Classic ABBA. Two extra properties turned it from "one stuck connection" into a dead node: the
+ * {@code ReentrantReadWriteLock} is non-fair, so the selector's queued write request blocked every
+ * later reader too, and the blocked thread is the selector — the one that calls {@code accept()}.
+ * The node stayed alive with a full listen backlog ({@code ss -ltn} showed {@code LISTEN 51 50})
+ * and no journal output.
+ *
+ * <p>The test reproduces exactly that interleaving with the real command handler. The peer list
+ * lock is only ever released by the fix, never by timing, so this deadlocks (and fails on the
+ * timeout) without it.
+ */
+public class PeerListLockOrderTest {
+
+  /**
+   * Generous upper bound for the selector's {@code peerList.add()}. Without the fix the read lock
+   * is held until the handler finishes, and the handler cannot finish, so no bound helps; with it
+   * the lock is free the moment the snapshot is taken.
+   */
+  private static final long SELECTOR_LOCK_TIMEOUT_MS = 5000;
+
+  private ServerContext ctx;
+  private InboundCommandProcessor proc;
+
+  @Before
+  public void setup() {
+    ctx = ServerContext.buildDefaultServerContext();
+    ctx.setPort(59558);
+    proc = new InboundCommandProcessor(ctx);
+    ByteBufferPool.init();
+  }
+
+  @Test
+  public void requestPeerList_doesNotHoldThePeerListLockWhileTakingTheWriteBufferLock()
+      throws Exception {
+    Peer requester = connectedPeer("84.147.60.253", 59558);
+    requester.writeBuffer = ByteBuffer.allocate(1024 * 64);
+    ctx.getPeerList().add(requester);
+    ctx.getPeerList().add(connectedPeer("46.224.156.238", 59558));
+
+    // The selector thread's half of the inversion: setupConnection() holds this peer's
+    // writeBufferLock across its whole body. Held from the test thread here so the reader below
+    // must queue on it, which is the state the seed node was in.
+    requester.getWriteBufferLock().lock();
+    CountDownLatch handlerDone = new CountDownLatch(1);
+    Thread reader =
+        new Thread(
+            () -> {
+              proc.parseCommand(Command.REQUEST_PEERLIST, ByteBuffer.allocate(0), requester);
+              handlerDone.countDown();
+            },
+            "reader-under-test");
+    reader.setDaemon(true);
+
+    Lock peerListWriteLock = ctx.getPeerList().getReadWriteLock().writeLock();
+    boolean selectorGotTheLock;
+    try {
+      reader.start();
+
+      // Wait until the handler is genuinely parked on the writeBufferLock. Only then is the
+      // question below meaningful: with the defect it is parked there holding the peer list read
+      // lock, without it that lock was released before the buffer was touched. Polling the queue
+      // makes this deterministic rather than a sleep-and-hope race.
+      assertTrue(
+          "REQUEST_PEERLIST handler never reached the write buffer",
+          awaitQueuedOn(requester.getWriteBufferLock()));
+
+      // The selector thread's next step: peerList.add(). This is what wedged the node.
+      selectorGotTheLock =
+          peerListWriteLock.tryLock(SELECTOR_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      if (selectorGotTheLock) {
+        peerListWriteLock.unlock();
+      }
+    } finally {
+      requester.getWriteBufferLock().unlock();
+    }
+
+    assertTrue("REQUEST_PEERLIST completed", handlerDone.await(30, TimeUnit.SECONDS));
+    assertTrue(
+        "handleRequestPeerList() must not hold the peer list lock while it waits for a peer's"
+            + " writeBufferLock — ConnectionHandler.setupConnection() takes those two the other way"
+            + " round on the selector thread, and the resulting deadlock stops accept() (T87)",
+        selectorGotTheLock);
+  }
+
+  /** Waits until some thread is queued on {@code lock}, i.e. blocked trying to acquire it. */
+  private static boolean awaitQueuedOn(java.util.concurrent.locks.ReentrantLock lock)
+      throws InterruptedException {
+    long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+    while (System.currentTimeMillis() < deadline) {
+      if (lock.hasQueuedThreads()) {
+        return true;
+      }
+      Thread.sleep(5);
+    }
+    return false;
+  }
+
+  private Peer connectedPeer(String ip, int port) {
+    Peer peer = new Peer(ip, port, NodeId.generateWithSimpleKey());
+    // no SelectionKey in a unit test, so setWriteBufferFilled() must stay a no-op
+    peer.setConnected(false);
+    return peer;
+  }
+}

--- a/src/test/java/im/redpanda/core/PeerListLockOrderTest.java
+++ b/src/test/java/im/redpanda/core/PeerListLockOrderTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import org.junit.Before;
 import org.junit.Test;
@@ -66,11 +67,20 @@ public class PeerListLockOrderTest {
     // must queue on it, which is the state the seed node was in.
     requester.getWriteBufferLock().lock();
     CountDownLatch handlerDone = new CountDownLatch(1);
+    AtomicReference<Throwable> handlerFailure = new AtomicReference<>();
     Thread reader =
         new Thread(
             () -> {
-              proc.parseCommand(Command.REQUEST_PEERLIST, ByteBuffer.allocate(0), requester);
-              handlerDone.countDown();
+              // countDown() in a finally, and the throwable kept: without this a failure inside
+              // parseCommand() would surface as a 30 s latch timeout instead of the real cause —
+              // exactly the diagnosis this test exists to provide.
+              try {
+                proc.parseCommand(Command.REQUEST_PEERLIST, ByteBuffer.allocate(0), requester);
+              } catch (Throwable t) {
+                handlerFailure.set(t);
+              } finally {
+                handlerDone.countDown();
+              }
             },
             "reader-under-test");
     reader.setDaemon(true);
@@ -86,7 +96,7 @@ public class PeerListLockOrderTest {
       // makes this deterministic rather than a sleep-and-hope race.
       assertTrue(
           "REQUEST_PEERLIST handler never reached the write buffer",
-          awaitQueuedOn(requester.getWriteBufferLock()));
+          awaitQueuedOn(requester.getWriteBufferLock(), handlerDone));
 
       // The selector thread's next step: peerList.add(). This is what wedged the node.
       selectorGotTheLock =
@@ -99,6 +109,9 @@ public class PeerListLockOrderTest {
     }
 
     assertTrue("REQUEST_PEERLIST completed", handlerDone.await(30, TimeUnit.SECONDS));
+    if (handlerFailure.get() != null) {
+      throw new AssertionError("REQUEST_PEERLIST handler threw", handlerFailure.get());
+    }
     assertTrue(
         "handleRequestPeerList() must not hold the peer list lock while it waits for a peer's"
             + " writeBufferLock — ConnectionHandler.setupConnection() takes those two the other way"
@@ -106,13 +119,21 @@ public class PeerListLockOrderTest {
         selectorGotTheLock);
   }
 
-  /** Waits until some thread is queued on {@code lock}, i.e. blocked trying to acquire it. */
-  private static boolean awaitQueuedOn(java.util.concurrent.locks.ReentrantLock lock)
+  /**
+   * Waits until some thread is queued on {@code lock}, i.e. blocked trying to acquire it. Gives up
+   * early if the handler finished (or died) without ever getting there, so a broken handler fails
+   * fast instead of burning the full timeout.
+   */
+  private static boolean awaitQueuedOn(
+      java.util.concurrent.locks.ReentrantLock lock, CountDownLatch handlerDone)
       throws InterruptedException {
     long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
     while (System.currentTimeMillis() < deadline) {
       if (lock.hasQueuedThreads()) {
         return true;
+      }
+      if (handlerDone.getCount() == 0) {
+        return false;
       }
       Thread.sleep(5);
     }


### PR DESCRIPTION
## The incident (T87)

A public seed node stopped accepting connections on 2026-07-29. Process alive, unit `active`, 0.4% CPU, but `ss -ltn` showed `LISTEN 51 50` — the accept queue was full because `accept()` was no longer being called. No journal output since ~4 minutes after start. Restored by hand with a restart.

## Root cause: an ABBA deadlock between `Peer.writeBufferLock` and the `PeerList` lock

| thread | holds | wants |
| --- | --- | --- |
| `ConnectionHandler.setupConnection()` — **the NIO selector thread** | `peerOrigin.writeBufferLock` (ConnectionHandler.java:867) | peer list **write** lock via `peerList.add()` (ConnectionHandler.java:881) |
| `InboundCommandProcessor.handleRequestPeerList()` — a reader thread | peer list **read** lock (InboundCommandProcessor.java:502) | that same peer's `writeBufferLock` (InboundCommandProcessor.java:529) |

Two properties turned this from one stuck connection into a dead node:

1. The `ReentrantReadWriteLock` is non-fair, so once the selector's *write* request was queued, every later *reader* queued behind it. That is why the whole node froze rather than just slowing down.
2. The thread that blocks is the selector — the only thread that calls `accept()` and that services the reads and writes of every existing connection.

### It matches the thread dump

- `IncomingHandler` parked on the peer list write lock in `PeerList.add(:64)` ← `setupConnection(:881)` ← `handleFirstEncryptedCommand(:822)` ← `handlePeerInHandshake(:635)` — i.e. already holding a `writeBufferLock`.
- `Jobs-4` holds the NodeStore write lock (`maintainNodes`) and is parked on the peer list read lock in `addServerEdges`; `Jobs-0..3,5..7` parked on the NodeStore write lock behind it; `OutboundHandler` and `PeerJobs` parked on the peer list read lock in `PeerList.size()`. All collateral.
- **No thread reports holding the peer list lock**, and that is consistent rather than mysterious: read holders of a `ReentrantReadWriteLock` never show up in a thread dump, and the reader in question is a *virtual* thread (`ConnectionReaderThread` starts via `Thread.ofVirtual().name("ReaderThread")`), which a `jstack` dump does not list at all. That is also why no `ReaderThread` appears anywhere in the dump.

### What #280 changed

`#280` (`924681f`) made `PeerList.add()` take the write lock **unconditionally**; before that the fast path returned an existing peer without taking any lock. The inversion pre-dates it, but since 2026-07-27 the selector takes the peer list write lock on *every* completed handshake instead of only when the peer was really new — an enormously wider window. Not the defect, but the reason it started firing now.

## The fix

**1. Remove the reversed acquisition (the cure).** `handleRequestPeerList()` snapshots the peer list under the read lock, releases it, then builds and writes the response. That is the pattern every other iteration site already uses — `NodeStore.addServerEdges`, `PeerJobs.runOnce`, `Saver.savePeers`, `OhForwarder.selectNextPeer`. The peers themselves were never guarded by this lock, only the list structure, so nothing weakens by copying first.

**1b. Same inversion in `OutboundHandler.run()`.** It held the peer list **read** lock across its whole connect loop, and inside that loop calls `peer.disconnect("max cons")` and `connectTo()` — the latter reaching `PeerInHandshake.addConnection()` → `peer.disconnect()` on a failed selector registration. Both take a peer's `writeBufferLock`, so it could deadlock against the selector exactly like `handleRequestPeerList` did; it also did socket `open`/`connect` under the read lock, starving the selector's queued writer for the length of a connect attempt. Now snapshots the (already sorted) list and iterates the copy — the TD026 shape from `PeerJobs.runOnce()`. The diff looks large only because the body dedents by one level.

**2. Document a one-directional lock order.** On `PeerList`, outermost first, never reversed:

```
Peer.writeBufferLock  ->  NodeStore.readWriteLock  ->  PeerList.readWriteLock
```

Checked against every `readLock()`/`writeLock()` acquisition of both locks in the tree; after this PR it holds everywhere. The remaining sites that hold the peer list lock are clean: `Saver.savePeers`, `NodeStore.addServerEdges`, `PeerJobs.runOnce` and `OhForwarder`/`GMParser` already snapshot, and `NodeConnectionPointsSeenJob` (`Node.seen`), the Kademlia jobs (`PeerComparator`), `PeerList.getClosestGoodPeer`, `OutboundHandler.reseed` (`Peer.compareTo`) and `ListenConsole`'s status table (`NodeStore.printBlacklist`) take no further lock.

**3. The selector thread must never park indefinitely on a lock.** `setupConnection()` now uses a new `PeerList.add(peer, timeoutMillis)` that throws `PeerListBusyException` after 5 s instead of waiting forever; the handler logs, raises a Sentry event and drops that one connection. This does not make a stuck lock correct — it turns a silent, total, unrecoverable wedge into one lost connection plus a loud alert, and keeps the event loop running.

**4. Three smaller leaks of the same class**, found while auditing every acquisition of both locks:

- `ListenConsole`'s `c` command took the peer list write lock with no `try/finally` — a throw inside `disconnect()` leaves it held forever.
- `NodeInfoSetRefreshJob` re-read `serverContext.getNodeStore()` for the unlock. `NodeStore.saveToDisk()`'s recovery path replaces that store, so the unlock could target a different lock (`IllegalMonitorStateException`) and permanently leak the original read hold. This is the guard `PeerPerformanceTestGarlicMessageJob.init()` and `OhForwarder.selectNextPeer()` already carry.
- `PeerList.contains/get/remove` had `lock()` *inside* the `try`, so a throwing `lock()` would send the `finally` into an `unlock()` of a lock never held.

## Test

`PeerListLockOrderTest` reproduces the interleaving with the real command handler: the test thread holds the peer's `writeBufferLock` (the selector's half of the inversion), a second thread runs the real `parseCommand(REQUEST_PEERLIST, …)`, the test waits until that handler is *provably* parked on the write buffer lock (polling `hasQueuedThreads()`, not a sleep), and only then asks for the peer list write lock — the selector's very next step.

- **Negative control:** with `handleRequestPeerList` reverted the test fails on exactly that acquisition.
- With the fix it passes.
- Full suite: `mvn -ntp test` → **486 tests, 0 failures, 1 skipped**.

Not deployed, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm
