### PR TITLE
fix(T73): say what the >5 s read-cycle counter actually measures (REDPANDAJ-2DQ)

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionReaderThread.java
+++ b/src/main/java/im/redpanda/core/ConnectionReaderThread.java
@@ -690,14 +690,27 @@ public class ConnectionReaderThread implements Runnable {
       long diff = System.currentTimeMillis() - a;
 
       if (diff > 5000L) {
-        // Enriched with the peer and the last successfully-parsed command byte (unsigned, since
-        // command bytes go up to 141 and print negative as a plain signed byte) so the event is
-        // self-explanatory without having to correlate timestamps against other log lines
-        // (REDPANDAJ-2DQ). Note peer.lastCommand reflects the last command parsed in this read
-        // batch, which is the stalling one only if a single command was processed; if several
-        // commands were parsed in one read(), an earlier one in the same batch may be the culprit.
+        // What is measured here is the wall-clock duration of the whole readConnection() call —
+        // socket read, buffer borrow, decrypt and the dispatch of every command in that read —
+        // and it therefore includes any time spent BLOCKED on a lock, not just CPU time spent
+        // parsing. The old wording ("command took over 5 seconds to parse") claimed the opposite
+        // and sent REDPANDAJ-2DQ through two triage cycles that looked for slow parsing on weak
+        // (ARM) hardware. The actual cause of those 2028 events was lock starvation: PeerJobs
+        // held the PeerList read lock across a 20 ms-per-peer sleep loop (5643 ms with the ~280
+        // peers a seed node had accumulated), and both observed commands wait on exactly that
+        // lock — PING via InboundCommandProcessor.handlePing -> PeerList.contains, and
+        // FLASCHENPOST_PUT via GMParser.parse's peer-list/NodeStore read locks. Fixed in #293
+        // (TD026), pressure removed at the source in #294 (T86 peer-list bloat).
+        //
+        // The peer and the last successfully-parsed command byte are included (unsigned, since
+        // command bytes go up to 161 and print negative as a plain signed byte) so the event is
+        // self-explanatory without having to correlate timestamps against other log lines. Note
+        // peer.lastCommand reflects the last command parsed in this read batch, which is the
+        // stalling one only if a single command was processed; if several commands were parsed
+        // in one read(), an earlier one in the same batch may be the culprit.
         Log.sentry(
-            "command took over 5 seconds to parse: %d ms, last parsed command byte: %d, peer: %s"
+            ("read cycle took over 5 seconds: %d ms (socket read + decrypt + dispatch, includes"
+                    + " time blocked on locks), last parsed command byte: %d, peer: %s")
                 .formatted(diff, Byte.toUnsignedInt(peer.lastCommand), peer));
       }
 


### PR DESCRIPTION
Triage of backlog **T73** / Sentry **REDPANDAJ-2DQ** (2028 events since 2026-07-12, the noisiest issue in the project, twice written off as benign noise).

## What the counter measures

`ConnectionReaderThread.run()` times the whole `readConnection(peer)` call — socket read, buffer borrow, decrypt and the dispatch of every command in that read. That is wall-clock time and includes time **blocked on a lock**. The message said "command took over 5 seconds to parse", which is what sent two triage cycles looking for a slow parser on the ARM Raspi.

## Root cause of the 2028 events (already fixed, not by this PR)

Evidence from the live Sentry data (20 most recent events, 2026-07-29 10:31–10:49 UTC):

- Durations are 5007–5385 ms and never higher. A slow parse has a heavy tail; a bounded wait truncated at a 5000 ms threshold looks exactly like this.
- The bound is the peer-list read-lock hold measured in TD026 / #293: **5643 ms mean / 5653 ms max** with the ~280 peers a seed node had accumulated (T86). The RRWL is non-fair, so a queued writer blocks new readers too.
- Both command bytes seen in the events reach that lock:
  - `5` = PING → `InboundCommandProcessor.handlePing` → `PeerList.contains` (#293 measured this waiting up to **5316 ms**),
  - `141` = FLASCHENPOST_PUT → `GMParser.parse`, peer-list read lock (`GMParser.java:298`) and NodeStore read lock (`:345`).
- **Not ARM.** Events fire on all four testnet nodes; the x86 Hetzner nodes at the same magnitude as the Raspi.

Post-deploy check: the testnet moved to `7de285d`/`ae76d78` (#293 + #294) around 11:52–12:06 UTC. Zero occurrences since, on nodes that are otherwise fully busy (118 GM paths in 10 min on `46.224.156.238`), including one that restarted with 280 peers restored from disk.

## What this PR changes

Message text and the explaining comment. No behaviour change. The 5 s threshold is kept deliberately: with the lock waits gone, a >5 s read cycle is a genuine anomaly worth an event.

Side effect, intended: the new text re-groups the issue in Sentry. REDPANDAJ-2DQ is resolved as part of this triage, and a real recurrence should arrive as a new, correctly worded issue instead of reopening 2028 events of misleading history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm