### PR TITLE
fix(T88): keep the ip+port map in sync on removal, so a light client can reconnect

### DIFF
--- a/src/main/java/im/redpanda/core/PeerList.java
+++ b/src/main/java/im/redpanda/core/PeerList.java
@@ -219,6 +219,32 @@ public class PeerList {
   }
 
   /**
+   * Drops this peer's {@link #peerlistIpPort} entry, but only while that entry still points at this
+   * very peer.
+   *
+   * <p>{@link #addPeer} inserts <em>every</em> peer into that map, so every removal has to take it
+   * out again. The two removal paths used to skip it for {@code port == 0}, which desynchronised
+   * the maps for exactly the peers an inbound light client produces: the handshake carries the
+   * sender's listening port and a light client has none, so it announces 0 ({@code
+   * ConnectionReaderThread:151}). The entry then survived in {@code peerlistIpPort} while the
+   * {@link KademliaId} key was gone, and {@link #addLocked}'s ip+port branch handed that ghost back
+   * as {@code oldPeer} on the next connection of the same identity — so the reconnecting peer was
+   * never registered and {@code ConnectionHandler.setupConnection} dropped it as a TD020 duplicate,
+   * on every retry, forever (T88; the S4 airplane-mode gate hung on it after T86/#294 started
+   * evicting undialable peers and thus made this removal path reachable at all).
+   *
+   * <p>The value-checked removal matters because {@link #getIpPortHash} is {@code ip.hashCode() +
+   * port}: every loopback light client shares the key {@code "127.0.0.1".hashCode()}, so an
+   * unconditional {@code remove(key)} would evict a different, live peer's mapping.
+   */
+  private void removeIpPortMapping(Peer peer) {
+    if (peer.getIp() == null) {
+      return;
+    }
+    peerlistIpPort.remove(getIpPortHash(peer), peer);
+  }
+
+  /**
    * Removes a {@link Peer} from the PeerList. Removes the Peer from both Hashmaps and the ArrayList
    *
    * @param peer
@@ -242,9 +268,7 @@ public class PeerList {
       if (!removed) {
         return false;
       }
-      if (peer.getIp() != null && peer.getPort() != 0) {
-        peerlistIpPort.remove(getIpPortHash(peer));
-      }
+      removeIpPortMapping(peer);
       return true;
     } finally {
       readWriteLock.writeLock().unlock();
@@ -306,9 +330,7 @@ public class PeerList {
         return false;
       }
       removedOnePeer = peerArrayList.remove(remove);
-      if (remove.getIp() != null && remove.getPort() != 0) {
-        peerlistIpPort.remove(getIpPortHash(remove));
-      }
+      removeIpPortMapping(remove);
     } finally {
       readWriteLock.writeLock().unlock();
     }

--- a/src/test/java/im/redpanda/core/ConnectionHandlerDuplicateConnectionTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerDuplicateConnectionTest.java
@@ -128,6 +128,59 @@ public class ConnectionHandlerDuplicateConnectionTest {
   }
 
   /**
+   * T88: a light client that was evicted from the peer list while it was away reconnects. Nothing
+   * is registered for its identity any more, so {@code parseHandshake} builds a fresh {@link Peer}
+   * — {@code setupConnection} must register it, not mistake it for the losing half of a parallel
+   * handshake.
+   *
+   * <p>It did, before the fix: {@code PeerList.remove} skipped the ip+port map for {@code port ==
+   * 0}, so the evicted peer stayed reachable through {@code add()}'s ip+port branch and came back
+   * as {@code oldPeer != peerOrigin} — the TD020 signature. Every reconnect was dropped, on every
+   * retry, which is what wedged the S4 airplane-mode scenario (154 duplicate lines, no delivery).
+   */
+  @Test
+  public void reconnectAfterEvictionIsRegisteredInsteadOfDroppedAsDuplicate() throws Exception {
+    ByteBufferPool.init();
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    ConnectionHandler connectionHandler = new ConnectionHandler(serverContext, false);
+    PeerList peerList = serverContext.getPeerList();
+
+    NodeId identity = NodeId.generateWithSimpleKey();
+
+    // The connection before the outage, and its eviction while the client was unreachable (T86:
+    // PeerJobs drops peers that are neither connected nor dialable, and a light client is both).
+    Peer beforeTheOutage = new Peer("127.0.0.1", 0, identity);
+    peerList.add(beforeTheOutage);
+    peerList.remove(beforeTheOutage);
+    assertThat(peerList.get(identity.getKademliaId()))
+        .as("precondition: the identity is gone from the peer list")
+        .isNull();
+
+    // The reconnect: a fresh Peer, exactly as ConnectionReaderThread.parseHandshake builds it when
+    // peerList.get(identity) returns null.
+    Peer reconnect = new Peer("127.0.0.1", 0, new NodeId(identity.getKademliaId()));
+    try (SocketChannel channel = SocketChannel.open()) {
+      PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", channel);
+      peerInHandshake.setPeer(reconnect);
+      peerInHandshake.setLightClient(true); // skip the Node/DB lookups in setupConnection
+      peerInHandshake.setIdentity(identity.getKademliaId());
+      peerInHandshake.setNodeId(identity);
+      peerInHandshake.setKey(new NoopSelectionKey());
+      connectionHandler.addPeerInHandshake(peerInHandshake);
+
+      connectionHandler.setupConnection(reconnect, peerInHandshake);
+
+      assertThat(peerList.get(identity.getKademliaId()))
+          .as("the reconnecting light client must be registered")
+          .isSameAs(reconnect);
+      assertThat(reconnect.isConnected())
+          .as("the reconnect must not be torn down as a TD020 duplicate")
+          .isTrue();
+      assertThat(channel.isOpen()).as("the reconnect's socket must stay open").isTrue();
+    }
+  }
+
+  /**
    * Minimal {@link SelectionKey} stub: {@code setupConnection} calls the final {@code attach}, and
    * (on the TD020 disconnect path) {@code Peer.disconnect} calls {@code cancel}.
    */

--- a/src/test/java/im/redpanda/core/PeerListIpPortConsistencyTest.java
+++ b/src/test/java/im/redpanda/core/PeerListIpPortConsistencyTest.java
@@ -1,0 +1,112 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Pins the ip+port map against the {@link KademliaId} map (T88).
+ *
+ * <p>{@code PeerList.addPeer} inserts every peer into <em>both</em> maps, but the two removal paths
+ * used to skip {@code peerlistIpPort} whenever {@code port == 0} — i.e. for exactly the entries an
+ * inbound light client creates, because the handshake carries the sender's listening port and a
+ * light client has none ({@code ConnectionReaderThread:151}). The removed peer therefore stayed
+ * reachable through the ip+port branch of {@code add()} while its identity key was gone, and that
+ * ghost was handed back as {@code oldPeer} for the next connection of the same identity, so the
+ * reconnecting peer was never registered and {@code ConnectionHandler.setupConnection} dropped it
+ * as a TD020 duplicate — on every retry, with no way out.
+ *
+ * <p>The path only became reachable with T86/#294, which is the first code that ever removes an
+ * undialable (port-0) peer; before that they simply leaked. It surfaced as the S4 airplane-mode
+ * gate failing with 154 consecutive "duplicate parallel connection from the same identity" lines.
+ */
+public class PeerListIpPortConsistencyTest {
+
+  /** An inbound light client as {@code ConnectionHandler.setupConnection} builds it: port 0. */
+  private static Peer inboundLightClient(String ip, NodeId identity) {
+    Peer peer = new Peer(ip, 0);
+    peer.setNodeId(identity);
+    return peer;
+  }
+
+  @Test
+  public void removingAnUndialablePeerAlsoDropsItsIpPortEntry() {
+    PeerList peerList = ServerContext.buildDefaultServerContext().getPeerList();
+
+    NodeId identity = NodeId.generateWithSimpleKey();
+    Peer first = inboundLightClient("127.0.0.1", identity);
+    peerList.add(first);
+
+    assertThat(peerList.remove(first)).isTrue();
+
+    // The reconnect: parseHandshake found nothing for this identity and built a fresh Peer.
+    Peer reconnect = inboundLightClient("127.0.0.1", new NodeId(identity.getKademliaId()));
+
+    assertThat(peerList.add(reconnect))
+        .as("a removed peer must not come back as oldPeer through the ip+port map")
+        .isNull();
+    assertThat(peerList.get(identity.getKademliaId()))
+        .as("the reconnecting peer must be the registered one")
+        .isSameAs(reconnect);
+  }
+
+  /**
+   * The same for {@code removeByObject}, the path a peer without a {@link KademliaId} takes. {@code
+   * removeIpPort} is the observation: it resolves through the ip+port map, so it can only still
+   * find something if the removal left the entry behind.
+   */
+  @Test
+  public void removingAnUndialablePeerWithoutIdentityAlsoDropsItsIpPortEntry() {
+    PeerList peerList = ServerContext.buildDefaultServerContext().getPeerList();
+
+    Peer anonymous = new Peer("127.0.0.1", 0);
+    peerList.add(anonymous);
+
+    assertThat(peerList.remove(anonymous)).isTrue();
+
+    assertThat(peerList.removeIpPort("127.0.0.1", 0))
+        .as("removeByObject must take the ip+port entry with it")
+        .isFalse();
+  }
+
+  /**
+   * {@code getIpPortHash} is {@code ip.hashCode() + port}, so every loopback light client shares
+   * one key and the last {@code add} owns the mapping. Removing an earlier peer must not evict the
+   * mapping of the peer that owns it now — which is why the removal is value-checked rather than a
+   * plain {@code remove(key)}.
+   */
+  @Test
+  public void removalDoesNotStealAColocatedPeersIpPortEntry() {
+    PeerList peerList = ServerContext.buildDefaultServerContext().getPeerList();
+
+    Peer alice = inboundLightClient("127.0.0.1", NodeId.generateWithSimpleKey());
+    Peer bob = inboundLightClient("127.0.0.1", NodeId.generateWithSimpleKey());
+    peerList.add(alice);
+    peerList.add(bob); // same ip+port hash: bob now owns the mapping
+
+    peerList.remove(alice);
+
+    // removeIpPort resolves through that mapping and cascades to whoever it points at — so if it
+    // still finds and drops bob, alice's removal left his entry alone.
+    assertThat(peerList.removeIpPort("127.0.0.1", 0))
+        .as("bob's ip+port mapping must survive alice's removal")
+        .isTrue();
+    assertThat(peerList.get(bob.getKademliaId())).isNull();
+  }
+
+  /** A dialable peer keeps behaving as before — the guard removal must not change that. */
+  @Test
+  public void removingADialablePeerStillDropsItsIpPortEntry() {
+    PeerList peerList = ServerContext.buildDefaultServerContext().getPeerList();
+
+    NodeId identity = NodeId.generateWithSimpleKey();
+    Peer node = new Peer("46.224.156.238", 59558, identity);
+    peerList.add(node);
+
+    assertThat(peerList.remove(node)).isTrue();
+
+    Peer reconnect = new Peer("46.224.156.238", 59558, new NodeId(identity.getKademliaId()));
+    assertThat(peerList.add(reconnect)).isNull();
+    assertThat(peerList.get(identity.getKademliaId())).isSameAs(reconnect);
+  }
+}


### PR DESCRIPTION
## What broke

The deploy gate for release `ec038ab` failed at **S4 (airplane-mode reconnect)**. After Bob's radio came back the node logged, at ~3 s intervals for nine minutes, 154×

```
duplicate parallel connection from the same identity (KadId: 31AHH7Df51); disconnecting the unregistered duplicate
```

one per reconnect attempt, and the message never arrived. The client side matched: `fetchMessages(): host node ... not connected` 171×, never a successful connection again.

**Not a regression from #295.** A control gate run on `ae76d78` — the merge directly before #295 — reproduces the identical signature (36 duplicate lines, same identity, no `Connected successfully` afterwards). #295 does not change `PeerList.add`'s semantics at all; `addLocked` is a pure extraction of the old body.

## Root cause

`PeerList` keeps two maps and `addPeer()` puts every peer into **both**: `peerHashMap` (by `KademliaId`) and `peerlistIpPort` (by `ip.hashCode() + port`). But `remove(KademliaId)` and `removeByObject()` dropped the `peerlistIpPort` entry only `if (peer.getPort() != 0)`.

An inbound light client is exactly the port-0 case — the handshake carries the sender's *listening* port and a light client has none, so it announces 0 (`ConnectionReaderThread:151`). Removing such a peer left its ip+port entry behind, pointing at an object that is no longer in the list.

On the next connection of the same identity:

| step | what happens |
|---|---|
| `ConnectionReaderThread.parseHandshake` | `peerList.get(identity)` → `null`, so it builds a **fresh** `Peer` and re-requests the public key |
| `ConnectionHandler.setupConnection` | `peerList.add(fresh)`: `KademliaId` miss, then the ip+port branch finds the **ghost** with an equal `NodeId` and returns it *without registering the fresh peer* |
| result | `oldPeer != peerOrigin` — the TD020 signature — so the connection that just completed is disconnected as a "duplicate". Every retry repeats it, forever. |

The path only became **reachable** with T86/#294, which is the first code that ever removes an undialable (port-0) peer (`PeerJobs.evictUndialableDisconnectedPeers`). Before that they leaked instead, so the `port != 0` guard never mattered. That is why a latent inconsistency surfaced on the first gate run after #294.

The node log shows the transition directly. The reconnect at `15:23:37` still printed `peer status for handshake: -1` — `get(identity)` found the registered peer with its key, half-open swap, `Connected successfully`. Every attempt from `15:24:37` on printed `written bytes to REQUEST_PUBLIC_KEY: 1` again: the identity key was gone while the ip+port entry was not.

## Fix

One `removeIpPortMapping()` used by both removal paths. It drops the entry whenever the peer has an ip, and it is **value-checked** (`Map.remove(key, value)`): `getIpPortHash` is `ip.hashCode() + port`, so every loopback light client shares one key and an unconditional `remove(key)` would evict whichever live peer owns the mapping now.

## Tests

- `PeerListIpPortConsistencyTest` (new): both removal paths, the colocated-peer case (removal must not steal a neighbour's mapping), and the dialable case as a no-behaviour-change check.
- `ConnectionHandlerDuplicateConnectionTest.reconnectAfterEvictionIsRegisteredInsteadOfDroppedAsDuplicate` (new): the end-to-end shape — an evicted light client reconnects and must end up registered and connected, not torn down as a TD020 duplicate.
- **Negative control:** with `PeerList.java` reverted, `removingAnUndialablePeerAlsoDropsItsIpPortEntry` fails with `expected:<null> but was:<Peer{ip='127.0.0.1', port=0}>` and the `ConnectionHandler` test fails on "the reconnecting light client must be registered". The two existing TD020/TD019 tests stay green both ways.
- Full suite: **491 tests, 0 failures**, including `PeerListLockOrderTest` — the T87 deadlock fix is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm