### PR TITLE
obs(TD022): make record-store protocol-size skew loud instead of a debug one-liner

### DIFF
--- a/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
+++ b/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
@@ -336,10 +336,11 @@ public final class GarlicRouter {
    * senders and stay at DEBUG to avoid a remote-triggerable log flood.
    */
   private static void logDroppedRecordStore(
-      ChannelDht.RecordValidation validation, KadContent record, long nowMs) {
+      ChannelDht.RecordValidation validation, KadContent droppedRecord, long nowMs) {
     switch (validation) {
       case WRONG_SIZE -> {
-        int actualSize = record.getContent() == null ? -1 : record.getContent().length;
+        int actualSize =
+            droppedRecord.getContent() == null ? -1 : droppedRecord.getContent().length;
         if (tryAcquireSizeMismatchWarn(nowMs)) {
           log.warn(
               "flaschenpost v2 record store dropped: record size {} != expected {} — client and"

--- a/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
+++ b/src/main/java/im/redpanda/flaschenpost/GarlicRouter.java
@@ -16,6 +16,7 @@ import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -53,6 +54,16 @@ public final class GarlicRouter {
           RecordStoreRateLimiter.DEFAULT_CAPACITY,
           RecordStoreRateLimiter.DEFAULT_REFILL_INTERVAL_MS,
           System.currentTimeMillis());
+
+  /** Minimum interval between two size-mismatch WARN lines (see {@link #logDroppedRecordStore}). */
+  static final long SIZE_MISMATCH_WARN_INTERVAL_MS = 1000L * 60 * 10;
+
+  /**
+   * Timestamp of the last size-mismatch WARN. {@link Long#MIN_VALUE} = never warned yet (kept as an
+   * explicit sentinel so the interval subtraction in {@link #tryAcquireSizeMismatchWarn} cannot
+   * overflow).
+   */
+  private static final AtomicLong lastSizeMismatchWarnMs = new AtomicLong(Long.MIN_VALUE);
 
   /**
    * Own bucket for inbound channel-rendezvous record lookups (T46). A lookup triggers a Kademlia
@@ -298,8 +309,9 @@ public final class GarlicRouter {
             storeMsg.getPublicKey().toByteArray(),
             storeMsg.getContent().toByteArray(),
             storeMsg.getSignature().toByteArray());
-    if (!ChannelDht.isValidRecord(record, now)) {
-      log.debug("flaschenpost v2 record store record invalid (sig/size/ttl), dropping");
+    ChannelDht.RecordValidation validation = ChannelDht.validateRecord(record, now);
+    if (validation != ChannelDht.RecordValidation.VALID) {
+      logDroppedRecordStore(validation, record, now);
       return;
     }
     // Store locally first so the record is immediately resolvable on this node. Only replicate if
@@ -307,6 +319,70 @@ public final class GarlicRouter {
     // and replicating a record we ourselves won't keep would be pointless.
     if (serverContext.getKadStoreManager().put(record)) {
       new KademliaInsertJob(serverContext, record).start();
+    }
+  }
+
+  /**
+   * Logs a dropped {@code CMD_RECORD_STORE} with the concrete validation reason (TD022 — the old
+   * single "sig/size/ttl" line hid a breaking-protocol size skew behind routine garbage drops).
+   *
+   * <p>{@link ChannelDht.RecordValidation#WRONG_SIZE} means the publishing client uses a different
+   * {@link ChannelDht#RECORD_SIZE_BYTES} bucket — a deployment/version error (the constant is a
+   * breaking protocol change), not routine input validation, so it is lifted to WARN. Because
+   * stores are anonymous and the size check runs before the signature check, anyone can trigger
+   * this branch with cheap garbage — the WARN is therefore throttled to one line per {@link
+   * #SIZE_MISMATCH_WARN_INTERVAL_MS}; suppressed occurrences fall back to DEBUG. All other reasons
+   * (bad signature, expired, future-dated, missing content) are expected garbage from arbitrary
+   * senders and stay at DEBUG to avoid a remote-triggerable log flood.
+   */
+  private static void logDroppedRecordStore(
+      ChannelDht.RecordValidation validation, KadContent record, long nowMs) {
+    switch (validation) {
+      case WRONG_SIZE -> {
+        int actualSize = record.getContent() == null ? -1 : record.getContent().length;
+        if (tryAcquireSizeMismatchWarn(nowMs)) {
+          log.warn(
+              "flaschenpost v2 record store dropped: record size {} != expected {} — client and"
+                  + " node disagree on ChannelDht.RECORD_SIZE_BYTES (protocol version skew, check"
+                  + " deployment order); repeat occurrences logged at debug for the next {} min",
+              actualSize,
+              ChannelDht.RECORD_SIZE_BYTES,
+              SIZE_MISMATCH_WARN_INTERVAL_MS / 60_000);
+        } else {
+          log.debug(
+              "flaschenpost v2 record store record size {} != expected {} (version skew, warn"
+                  + " throttled), dropping",
+              actualSize,
+              ChannelDht.RECORD_SIZE_BYTES);
+        }
+      }
+      case BAD_SIGNATURE ->
+          log.debug("flaschenpost v2 record store record signature invalid, dropping");
+      case EXPIRED -> log.debug("flaschenpost v2 record store record older than ttl, dropping");
+      case FUTURE_DATED ->
+          log.debug("flaschenpost v2 record store record too far in the future, dropping");
+      case MISSING_CONTENT ->
+          log.debug("flaschenpost v2 record store record has no content, dropping");
+      case VALID -> {
+        // not a drop; nothing to log
+      }
+    }
+  }
+
+  /**
+   * Returns {@code true} if a size-mismatch WARN may be emitted now, and claims the slot (at most
+   * one winner per {@link #SIZE_MISMATCH_WARN_INTERVAL_MS}, race-free via CAS). Package-private for
+   * tests.
+   */
+  static boolean tryAcquireSizeMismatchWarn(long nowMs) {
+    while (true) {
+      long last = lastSizeMismatchWarnMs.get();
+      if (last != Long.MIN_VALUE && nowMs - last < SIZE_MISMATCH_WARN_INTERVAL_MS) {
+        return false;
+      }
+      if (lastSizeMismatchWarnMs.compareAndSet(last, nowMs)) {
+        return true;
+      }
     }
   }
 

--- a/src/main/java/im/redpanda/outbound/ChannelDht.java
+++ b/src/main/java/im/redpanda/outbound/ChannelDht.java
@@ -134,26 +134,60 @@ public final class ChannelDht {
   }
 
   /**
+   * Distinct outcomes of {@link #validateRecord}. Callers that drop invalid records should log the
+   * reasons separately: {@link #WRONG_SIZE} indicates a client publishing a different {@link
+   * #RECORD_SIZE_BYTES} bucket — i.e. protocol-version skew between client and node (TD022), a
+   * deployment error worth surfacing — whereas the other reasons are routine input validation that
+   * any anonymous sender can trigger and must stay quiet.
+   */
+  public enum RecordValidation {
+    VALID,
+    /** No record or no content bytes at all (malformed input). */
+    MISSING_CONTENT,
+    /**
+     * Content is not exactly {@link #RECORD_SIZE_BYTES}: the sender speaks a different record
+     * format version (the size is a breaking protocol constant, see {@link #RECORD_SIZE_BYTES}).
+     * Checked before the signature, so this outcome is cheap for anyone to trigger.
+     */
+    WRONG_SIZE,
+    /** Older than {@link #MAX_RECORD_AGE_MS}. */
+    EXPIRED,
+    /** Dated further than {@link #MAX_FUTURE_SKEW_MS} ahead of now. */
+    FUTURE_DATED,
+    /** Signature does not verify against the embedded pubkey. */
+    BAD_SIGNATURE
+  }
+
+  /**
    * Validates a single record as accepted for storage / serving: signed by the embedded pubkey
    * (self-certifying — the pubkey pins the Kademlia key), exactly the fixed bucket size (uniformity
    * is part of the anti-profiling contract), not older than {@link #MAX_RECORD_AGE_MS} and not
    * further than {@link #MAX_FUTURE_SKEW_MS} in the future. The content stays opaque — the node
    * deliberately cannot tell which channel it belongs to.
+   *
+   * @return {@link RecordValidation#VALID}, or the first failed check in the order missing content
+   *     → size → age → future skew → signature (cheap checks first; the signature check is the only
+   *     expensive one)
    */
-  public static boolean isValidRecord(KadContent content, long nowMs) {
+  public static RecordValidation validateRecord(KadContent content, long nowMs) {
     if (content == null || content.getContent() == null) {
-      return false;
+      return RecordValidation.MISSING_CONTENT;
     }
     if (content.getContent().length != RECORD_SIZE_BYTES) {
-      return false;
+      return RecordValidation.WRONG_SIZE;
     }
     if (nowMs - content.getTimestamp() > MAX_RECORD_AGE_MS) {
-      return false;
+      return RecordValidation.EXPIRED;
     }
     if (content.getTimestamp() - nowMs > MAX_FUTURE_SKEW_MS) {
-      return false;
+      return RecordValidation.FUTURE_DATED;
     }
-    return content.verify();
+    return content.verify() ? RecordValidation.VALID : RecordValidation.BAD_SIGNATURE;
+  }
+
+  /** Boolean convenience over {@link #validateRecord} for callers that don't need the reason. */
+  public static boolean isValidRecord(KadContent content, long nowMs) {
+    return validateRecord(content, nowMs) == RecordValidation.VALID;
   }
 
   /**

--- a/src/test/java/im/redpanda/flaschenpost/RecordDhtRouterTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/RecordDhtRouterTest.java
@@ -216,4 +216,30 @@ public class RecordDhtRouterTest {
         .as("an invalid (wrong-size) record must not be stored")
         .isNull();
   }
+
+  @Test
+  public void sizeMismatchWarn_isThrottledToOnePerInterval() {
+    // TD022: the size-mismatch drop is the one validation failure logged at WARN (protocol version
+    // skew), and since anyone can send cheap wrong-size garbage the WARN must be bounded. The
+    // throttle state is a process-global singleton, so probe it with synthetic timestamps far in
+    // the future — no other test reaches this region of the clock.
+    long base = System.currentTimeMillis() + 1000L * 60 * 60 * 24 * 365;
+
+    assertThat(GarlicRouter.tryAcquireSizeMismatchWarn(base))
+        .as("first size mismatch in the window warns")
+        .isTrue();
+    assertThat(GarlicRouter.tryAcquireSizeMismatchWarn(base + 1))
+        .as("immediate repeat is suppressed")
+        .isFalse();
+    assertThat(
+            GarlicRouter.tryAcquireSizeMismatchWarn(
+                base + GarlicRouter.SIZE_MISMATCH_WARN_INTERVAL_MS - 1))
+        .as("still inside the throttle interval")
+        .isFalse();
+    assertThat(
+            GarlicRouter.tryAcquireSizeMismatchWarn(
+                base + GarlicRouter.SIZE_MISMATCH_WARN_INTERVAL_MS))
+        .as("interval elapsed, next warn is admitted")
+        .isTrue();
+  }
 }

--- a/src/test/java/im/redpanda/outbound/ChannelDhtTest.java
+++ b/src/test/java/im/redpanda/outbound/ChannelDhtTest.java
@@ -190,6 +190,84 @@ public class ChannelDhtTest {
         .isFalse();
   }
 
+  // --- Validation reasons (TD022: each failure cause maps to its own distinct outcome, so the
+  // record-store drop log can tell a protocol-size skew apart from routine garbage) ---
+
+  @Test
+  public void validateRecord_reportsValidForFreshSignedFixedSizeRecord() {
+    long now = System.currentTimeMillis();
+    KadContent content =
+        ChannelDht.buildRecordContent(randomChannelSecret(), randomRecordContent(), now);
+
+    assertThat(ChannelDht.validateRecord(content, now))
+        .isEqualTo(ChannelDht.RecordValidation.VALID);
+  }
+
+  @Test
+  public void validateRecord_reportsMissingContent() {
+    long now = System.currentTimeMillis();
+
+    assertThat(ChannelDht.validateRecord(null, now))
+        .isEqualTo(ChannelDht.RecordValidation.MISSING_CONTENT);
+
+    KadContent noBytes =
+        new KadContent(
+            now,
+            ChannelDht.deriveRecordNodeId(randomChannelSecret()).exportPublic(),
+            null,
+            new byte[64]);
+    assertThat(ChannelDht.validateRecord(noBytes, now))
+        .isEqualTo(ChannelDht.RecordValidation.MISSING_CONTENT);
+  }
+
+  @Test
+  public void validateRecord_reportsWrongSizeEvenWhenCorrectlySigned() {
+    // A correctly signed record of the wrong bucket size is exactly the TD022 version-skew case
+    // (e.g. a client still publishing the old 512-byte bucket): the size verdict must win over
+    // the signature so the drop log can name the deployment error.
+    byte[] secret = randomChannelSecret();
+    long now = System.currentTimeMillis();
+    NodeId recordNodeId = ChannelDht.deriveRecordNodeId(secret);
+    KadContent content = new KadContent(now, recordNodeId.exportPublic(), randomBytes(512));
+    content.signWith(recordNodeId);
+
+    assertThat(ChannelDht.validateRecord(content, now))
+        .isEqualTo(ChannelDht.RecordValidation.WRONG_SIZE);
+  }
+
+  @Test
+  public void validateRecord_reportsExpired() {
+    long now = System.currentTimeMillis();
+    long published = now - ChannelDht.MAX_RECORD_AGE_MS - 1000;
+    KadContent content =
+        ChannelDht.buildRecordContent(randomChannelSecret(), randomRecordContent(), published);
+
+    assertThat(ChannelDht.validateRecord(content, now))
+        .isEqualTo(ChannelDht.RecordValidation.EXPIRED);
+  }
+
+  @Test
+  public void validateRecord_reportsFutureDated() {
+    long now = System.currentTimeMillis();
+    long published = now + ChannelDht.MAX_FUTURE_SKEW_MS + 60_000;
+    KadContent content =
+        ChannelDht.buildRecordContent(randomChannelSecret(), randomRecordContent(), published);
+
+    assertThat(ChannelDht.validateRecord(content, now))
+        .isEqualTo(ChannelDht.RecordValidation.FUTURE_DATED);
+  }
+
+  @Test
+  public void validateRecord_reportsBadSignature() {
+    long now = System.currentTimeMillis();
+    KadContent content =
+        ChannelDht.buildRecordContent(randomChannelSecret(), randomRecordContent(), now);
+    content.getContent()[0] ^= 0xFF;
+
+    assertThat(ChannelDht.validateRecord(content, now))
+        .isEqualTo(ChannelDht.RecordValidation.BAD_SIGNATURE);
+  }
+
   // --- Result selection (newest-wins, foreign-record rejection) ---
 
   @Test


### PR DESCRIPTION
## Problem

`ChannelDht.RECORD_SIZE_BYTES` is a breaking protocol constant (512 -> 1024 in #289, `5d4d87a`), but a skewed deployment is invisible today:

- the node drops every mismatching `record_store` with one DEBUG line that lumps **three different causes** into `"record invalid (sig/size/ttl)"`,
- the publishing client hears nothing (`record_store` is fire-and-forget),
- the looking-up client gets a well-formed `found=false` and retries forever.

In practice this made an e2e run against a 1024-byte node with a 512-byte-publishing client read as a timing flake ("Bob never recovered Alice's OH from the rendezvous record") instead of as a deployment skew.

## Change (observability only — no wire or validation-behavior change)

- `ChannelDht.validateRecord(...)` now returns a `RecordValidation` reason. The real failure set is **five** causes, not the three the old message claimed: `MISSING_CONTENT`, `WRONG_SIZE`, `EXPIRED`, `FUTURE_DATED`, `BAD_SIGNATURE`. `isValidRecord` stays as the boolean wrapper, so `extractNewest` and all existing callers are untouched.
- `GarlicRouter.handleRecordStore` logs each drop reason distinctly:
  - **`WRONG_SIZE` -> WARN** with actual vs expected size and a pointer at deployment order. Rationale: a size mismatch is a version/deployment error operators must see; INFO is routinely filtered out in production configs.
  - Everything else (bad signature, expired, future-dated, missing content) stays **DEBUG** — routine input validation any anonymous sender can trigger.
- Flood safety: the size check runs *before* the (expensive) signature check, so anyone can hit the WARN branch with cheap unsigned garbage. The WARN is therefore throttled to **one line per 10 minutes** via a CAS slot (`tryAcquireSizeMismatchWarn`); suppressed occurrences fall back to DEBUG. The existing global `RecordStoreRateLimiter` still bounds the overall store rate in front of all of this.

## Tests

- `ChannelDhtTest`: one test per validation reason plus the valid case (6 new), including that a *correctly signed* wrong-size record reports `WRONG_SIZE` — exactly the TD022 skew shape.
- `RecordDhtRouterTest`: throttle window semantics (first warn admitted, repeats suppressed, next warn after the interval).

Out of scope by design (TD022 fix direction (a) only): a wire-level record-format version and a CI pin of the mobile constant against the backend constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm