### PR TITLE
fix: reject a malformed handshake public key instead of throwing (REDPANDAJ-2EH)

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -714,7 +714,23 @@ public class ConnectionHandler extends Thread {
         byte[] bytesPublicKey = new byte[NodeId.PUBLIC_KEYLEN];
         buffer.get(bytesPublicKey);
 
-        NodeId nodeId = NodeId.importPublic(bytesPublicKey);
+        NodeId nodeId;
+        try {
+          nodeId = NodeId.importPublic(bytesPublicKey);
+        } catch (IllegalArgumentException e) {
+          /**
+           * REDPANDAJ-2EH: these 64 bytes are unauthenticated remote input, and BouncyCastle
+           * rejects a malformed Ed25519 encoding (non-canonical or small-order point) with an
+           * IllegalArgumentException. That is hostile-network noise, not an application bug —
+           * reject it exactly like the KademliaId mismatch right below instead of letting the
+           * exception escape into the generic handler (error-level Sentry event, socket left
+           * half-open until the handshake reaper).
+           */
+          Log.put("Malformed public key from peer, closing connection...", 20);
+          peerInHandshake.setStatus(2);
+          peerInHandshake.getSocketChannel().close();
+          return false;
+        }
 
         Log.put("new nodeid from peer: " + nodeId.getKademliaId(), 20);
 

--- a/src/test/java/im/redpanda/core/ConnectionHandlerMalformedPublicKeyTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerMalformedPublicKeyTest.java
@@ -59,6 +59,45 @@ public class ConnectionHandlerMalformedPublicKeyTest {
     }
   }
 
+  /**
+   * A malformed key that arrives split across two reads goes through the REDPANDAJ-2FA carry-over
+   * (stash + prepend) before it reaches the import — the reassembled key must hit the exact same
+   * quiet rejection as a contiguous one.
+   */
+  @Test
+  public void malformedPublicKeySplitAcrossTwoReadsIsStillRejectedQuietly() throws Exception {
+    withHandshakeAwaitingPublicKey(
+        (connectionHandler, peerInHandshake, peerIdentity, accepted) -> {
+          byte[] malformedKey = new byte[NodeId.PUBLIC_KEYLEN]; // all-zero, see test above
+          int firstChunk = 40;
+
+          ByteBuffer head = ByteBuffer.allocate(1 + firstChunk);
+          head.put(Command.SEND_PUBLIC_KEY);
+          head.put(malformedKey, 0, firstChunk);
+          head.flip();
+
+          assertTrue(
+              "incomplete command must wait for more bytes",
+              invokeParse(connectionHandler, peerInHandshake, head));
+          assertEquals(
+              "the incomplete command must be stashed",
+              1 + firstChunk,
+              peerInHandshake.plaintextHandshakeCarryLength());
+          assertTrue("the connection must stay open while waiting", accepted.isOpen());
+
+          ByteBuffer tail = ByteBuffer.allocate(NodeId.PUBLIC_KEYLEN - firstChunk);
+          tail.put(malformedKey, firstChunk, NodeId.PUBLIC_KEYLEN - firstChunk);
+          tail.flip();
+          ByteBuffer reassembled = peerInHandshake.prependPlaintextHandshakeCarry(tail);
+
+          boolean keepProcessing = invokeParse(connectionHandler, peerInHandshake, reassembled);
+
+          assertFalse("the read event must not be processed further", keepProcessing);
+          assertEquals("disconnect status must be set", 2, peerInHandshake.getStatus());
+          assertFalse("the socket must be closed", accepted.isOpen());
+        });
+  }
+
   /** Interop guard: a conforming peer's public key still completes this handshake step. */
   @Test
   public void validPublicKeyStillCompletesTheHandshakeStep() throws Exception {

--- a/src/test/java/im/redpanda/core/ConnectionHandlerMalformedPublicKeyTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerMalformedPublicKeyTest.java
@@ -1,0 +1,172 @@
+package im.redpanda.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.Arrays;
+import org.junit.Test;
+
+/**
+ * REDPANDAJ-2EH regression: the 64 bytes following a plaintext SEND_PUBLIC_KEY are unauthenticated
+ * remote input, and BouncyCastle rejects a malformed Ed25519 encoding (non-canonical or small-order
+ * point) with {@code IllegalArgumentException: invalid public key}. That exception used to escape
+ * {@code parsePlaintextHandshakeCommands} into the generic handler in {@code
+ * handlePeerInHandshake}: an error-level Sentry event per hostile packet, the key cancelled but the
+ * socket left half-open until {@code PeerJobs.reapStaleHandshakes} closed it. A malformed key must
+ * instead be a quiet per-connection rejection, exactly like the KademliaId-mismatch case right
+ * below it.
+ */
+public class ConnectionHandlerMalformedPublicKeyTest {
+
+  static {
+    java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+  }
+
+  @Test
+  public void malformedPublicKeyIsRejectedQuietlyAndClosesTheConnection() throws Exception {
+    // Verified empirically against BouncyCastle 1.84: both encodings below make
+    // Ed25519PublicKeyParameters throw "invalid public key" — all-zero decodes to a small-order
+    // point (rejected), all-0xFF has y >= p with the sign bit set (non-canonical).
+    byte[] allZero = new byte[NodeId.PUBLIC_KEYLEN];
+    byte[] allFf = new byte[NodeId.PUBLIC_KEYLEN];
+    Arrays.fill(allFf, (byte) 0xFF);
+
+    for (byte[] malformedKey : new byte[][] {allZero, allFf}) {
+      withHandshakeAwaitingPublicKey(
+          (connectionHandler, peerInHandshake, peerIdentity, accepted) -> {
+            ByteBuffer buffer = ByteBuffer.allocate(1 + NodeId.PUBLIC_KEYLEN);
+            buffer.put(Command.SEND_PUBLIC_KEY);
+            buffer.put(malformedKey);
+            buffer.flip();
+
+            // Invokes the parser directly: without the fix the IllegalArgumentException from
+            // NodeId.importPublic escapes here (unwrapped by invokeParse), with the fix the
+            // rejection is handled like the KademliaId mismatch.
+            boolean keepProcessing = invokeParse(connectionHandler, peerInHandshake, buffer);
+
+            assertFalse("the read event must not be processed further", keepProcessing);
+            assertEquals("disconnect status must be set", 2, peerInHandshake.getStatus());
+            assertFalse(
+                "the socket must be closed exactly like the mismatch path", accepted.isOpen());
+          });
+    }
+  }
+
+  /** Interop guard: a conforming peer's public key still completes this handshake step. */
+  @Test
+  public void validPublicKeyStillCompletesTheHandshakeStep() throws Exception {
+    withHandshakeAwaitingPublicKey(
+        (connectionHandler, peerInHandshake, peerIdentity, accepted) -> {
+          ByteBuffer buffer = ByteBuffer.allocate(1 + NodeId.PUBLIC_KEYLEN);
+          buffer.put(Command.SEND_PUBLIC_KEY);
+          buffer.put(peerIdentity.exportPublic());
+          buffer.flip();
+
+          boolean keepProcessing = invokeParse(connectionHandler, peerInHandshake, buffer);
+
+          assertTrue("a valid key must not tear down the connection", keepProcessing);
+          assertEquals(
+              "status must advance to awaiting encryption", -1, peerInHandshake.getStatus());
+          assertNotNull(peerInHandshake.getNodeId());
+          assertNotNull(peerInHandshake.getPeer().getNodeId());
+          assertTrue("the connection must stay open", accepted.isOpen());
+        });
+  }
+
+  /** The pre-existing semantic rejection must be unchanged by the malformed-key guard. */
+  @Test
+  public void kademliaIdMismatchStillClosesTheConnection() throws Exception {
+    withHandshakeAwaitingPublicKey(
+        (connectionHandler, peerInHandshake, peerIdentity, accepted) -> {
+          // A perfectly well-formed key pair — just not the one the peer identified itself with.
+          byte[] otherExport = NodeId.generateWithSimpleKey().exportPublic();
+          ByteBuffer buffer = ByteBuffer.allocate(1 + NodeId.PUBLIC_KEYLEN);
+          buffer.put(Command.SEND_PUBLIC_KEY);
+          buffer.put(otherExport);
+          buffer.flip();
+
+          boolean keepProcessing = invokeParse(connectionHandler, peerInHandshake, buffer);
+
+          assertFalse("the read event must not be processed further", keepProcessing);
+          assertEquals("disconnect status must be set", 2, peerInHandshake.getStatus());
+          assertFalse("the socket must be closed", accepted.isOpen());
+        });
+  }
+
+  private interface HandshakeScenario {
+    void run(
+        ConnectionHandler connectionHandler,
+        PeerInHandshake peerInHandshake,
+        NodeId peerIdentity,
+        SocketChannel accepted)
+        throws Exception;
+  }
+
+  /**
+   * Sets up the state right after parseHandshake(): the peer's identity (KademliaId) is known from
+   * the 30-byte handshake, we asked for its public key (status 1) and are waiting for it — over a
+   * real accepted socket so closing is observable.
+   */
+  private static void withHandshakeAwaitingPublicKey(HandshakeScenario scenario) throws Exception {
+    ByteBufferPool.init();
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    ConnectionHandler connectionHandler = new ConnectionHandler(serverContext, false);
+
+    try (ServerSocketChannel serverSocketChannel = ServerSocketChannel.open()) {
+      serverSocketChannel.configureBlocking(false);
+      serverSocketChannel.bind(new InetSocketAddress("127.0.0.1", 0));
+      int port = serverSocketChannel.socket().getLocalPort();
+
+      try (SocketChannel client = SocketChannel.open(new InetSocketAddress("127.0.0.1", port))) {
+        SocketChannel accepted;
+        do {
+          accepted = serverSocketChannel.accept();
+        } while (accepted == null);
+        accepted.configureBlocking(false);
+
+        NodeId peerIdentity = NodeId.generateWithSimpleKey();
+        PeerInHandshake peerInHandshake = new PeerInHandshake("127.0.0.1", accepted);
+        peerInHandshake.setPeer(new Peer("127.0.0.1", 0));
+        peerInHandshake.setProtocolVersion(23);
+        peerInHandshake.setLightClient(true);
+        peerInHandshake.setIdentity(peerIdentity.getKademliaId());
+        peerInHandshake.setStatus(1);
+
+        try {
+          scenario.run(connectionHandler, peerInHandshake, peerIdentity, accepted);
+        } finally {
+          accepted.close();
+        }
+      }
+    }
+  }
+
+  /**
+   * Calls the private parser and unwraps reflection's InvocationTargetException, so a leaking
+   * IllegalArgumentException fails the test as itself (the REDPANDAJ-2EH symptom), not as a
+   * reflection wrapper.
+   */
+  private static boolean invokeParse(
+      ConnectionHandler connectionHandler, PeerInHandshake peerInHandshake, ByteBuffer buffer)
+      throws Exception {
+    Method parse =
+        ConnectionHandler.class.getDeclaredMethod(
+            "parsePlaintextHandshakeCommands", PeerInHandshake.class, ByteBuffer.class);
+    parse.setAccessible(true);
+    try {
+      return (boolean) parse.invoke(connectionHandler, peerInHandshake, buffer);
+    } catch (java.lang.reflect.InvocationTargetException e) {
+      if (e.getCause() instanceof Exception cause) {
+        throw cause;
+      }
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Sentry REDPANDAJ-2EH: `IllegalArgumentException: invalid public key` from `Ed25519PublicKeyParameters.parse`, thrown on the `IncomingHandler` thread.

The 64 bytes following a plaintext `SEND_PUBLIC_KEY` are unauthenticated remote input: any party that completes the 30-byte handshake magic can send `SEND_PUBLIC_KEY` + 64 arbitrary bytes. `NodeId.importPublic` checks only the length, then hands the bytes to BouncyCastle, which rejects a malformed Ed25519 encoding (non-canonical or small-order point) with `IllegalArgumentException`. The exception escaped `parsePlaintextHandshakeCommands` into the generic `catch (Exception)` in `handlePeerInHandshake`, which:

- reports an **error-level Sentry event** per hostile packet (`Log.sentry`), and
- cancels the selection key but **does not close the socket** and does not remove the `PeerInHandshake` — the half-open connection lingers until `PeerJobs.reapStaleHandshakes` closes it after the 10 s handshake timeout.

So each malformed-key packet costs one Sentry error plus a file descriptor held for up to 10 s. The selector thread itself survives (the catch is per-key), so this is bounded noise + a short-lived FD leak, not a crash — but it is remotely triggerable at will.

## Fix

Catch the `IllegalArgumentException` narrowly at the `NodeId.importPublic` call site in `parsePlaintextHandshakeCommands` and reject the connection exactly like the `KademliaId`-mismatch case directly below it: low-level log, `setStatus(2)`, close the channel, stop processing the read event.

This is the same guard style already used for the two other remote-input `importPublic` call sites (`InboundCommandProcessor.handleSendPeerList`, `KadContent.verify`), and it keeps `NodeId.importPublic`'s throwing contract intact for the local/trusted callers (`Updater`, jobs). A malformed key is never treated as valid; the rejection path is byte-for-byte the mismatch path.

`NodeId.importWithPrivate` was checked as well: it is only fed from the local `privateSigningKey.txt` (release tooling), so it keeps its throwing contract.

## Tests

New `ConnectionHandlerMalformedPublicKeyTest` (same socket-pair + reflection harness as the other `ConnectionHandler*Test` classes):

- `malformedPublicKeyIsRejectedQuietlyAndClosesTheConnection` — all-zero and all-0xFF 64-byte keys (both verified empirically to make BouncyCastle 1.84 throw `invalid public key`: all-zero decodes to a small-order point, all-0xFF is non-canonical). Asserts no exception escapes, status 2, socket closed.
- `validPublicKeyStillCompletesTheHandshakeStep` — a conforming peer's key still advances the handshake to status -1.
- `kademliaIdMismatchStillClosesTheConnection` — the pre-existing semantic rejection is unchanged.

Negative control: with the production change reverted, the malformed-key test fails with exactly `java.lang.IllegalArgumentException: invalid public key`.

Full `mvn verify` green locally.

Fixes REDPANDAJ-2EH

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm
