### PR TITLE
TD021: silence ByteBufferPool per-allocation log flood (trace + guard)

### DIFF
--- a/src/main/java/im/redpanda/core/ByteBufferPool.java
+++ b/src/main/java/im/redpanda/core/ByteBufferPool.java
@@ -82,27 +82,34 @@ public class ByteBufferPool {
             } else {
               pool.setMaxTotalPerKey(400);
             }
-            log.info(
-                "Generating new ByteBuffer for pool. Free memory (MB): {} Idle: {} Active: {} Waiters: {}",
-                (Runtime.getRuntime().freeMemory() / 1024. / 1024.),
-                pool.getNumIdle(),
-                pool.getNumActive(),
-                pool.getNumWaiters());
+            // TD021: this runs on every buffer allocation, so it must stay below the
+            // effective log level (slf4j binds to logback here, whose default root level
+            // is DEBUG because no logback.xml is shipped). The guard also keeps the
+            // listAllObjects() walk and the StringBuilder off the hot path entirely
+            // unless trace is explicitly enabled.
+            if (log.isTraceEnabled()) {
+              log.trace(
+                  "Generating new ByteBuffer for pool. Free memory (MB): {} Idle: {} Active: {} Waiters: {}",
+                  (Runtime.getRuntime().freeMemory() / 1024. / 1024.),
+                  pool.getNumIdle(),
+                  pool.getNumActive(),
+                  pool.getNumWaiters());
 
-            Map<String, List<DefaultPooledObjectInfo>> stringListMap = pool.listAllObjects();
+              Map<String, List<DefaultPooledObjectInfo>> stringListMap = pool.listAllObjects();
 
-            StringBuilder out = new StringBuilder();
+              StringBuilder out = new StringBuilder();
 
-            for (Map.Entry<String, List<DefaultPooledObjectInfo>> entry :
-                stringListMap.entrySet()) {
-              out.append("key: ")
-                  .append(entry.getKey())
-                  .append(" size: ")
-                  .append(entry.getValue().size())
-                  .append("\n");
+              for (Map.Entry<String, List<DefaultPooledObjectInfo>> entry :
+                  stringListMap.entrySet()) {
+                out.append("key: ")
+                    .append(entry.getKey())
+                    .append(" size: ")
+                    .append(entry.getValue().size())
+                    .append("\n");
+              }
+
+              log.trace("\n\nList of Pool: \n{}\n\n", out);
             }
-
-            log.info("\n\nList of Pool: \n{}\n\n", out);
 
             return allocate;
           }


### PR DESCRIPTION
## TD021 — ByteBufferPool per-allocation log flood

`ByteBufferPool`'s pooled-object factory wrote two records on **every buffer allocation**: the "Generating new ByteBuffer" stats line and a full pool dump built with `listAllObjects()` + a `StringBuilder`. This is per-operation, not per-incident: in one mobile CI job the node lines were 659 KB of the 876 KB total log, with 250 `ByteBufferPool` records / 125 pool dumps in a single run — enough stdout volume to put the (since-fixed) client-side pipe reader under backpressure.

### Chosen route: `trace` + `isTraceEnabled()` guard

The obvious "demote to debug" route **does not work in this codebase, and I verified that empirically**: `ByteBufferPool` logs via slf4j, slf4j binds to logback (the only provider on the classpath), and no `logback.xml` is shipped — so the effective root level is logback's default **DEBUG**. A debug demotion left every line in the test-suite output (14/14 occurrences, unchanged). Both records are therefore `trace`, and the whole block sits behind `log.isTraceEnabled()`, so the `listAllObjects()` walk and the `StringBuilder` are never executed on the hot path unless trace is explicitly enabled via a logback config. The diagnostics stay reachable for real pool debugging.

The existing log4j2.xml files do not govern these lines (they configure log4j-core, used by `Log.java`'s `LogManager` loggers only). The logback/log4j2 split-brain itself is out of scope here; worth a tech-debt entry.

### Measured effect (full `mvn verify` output, same machine)

| | before (main) | after |
|---|---|---|
| "Generating new ByteBuffer" lines | 14 | **0** |
| "List of Pool" dumps | 14 | **0** |
| `ByteBufferPool` log records | 46 | 0 (18 residual mentions are ArchUnit class-import noise + pre-existing SpotBugs report entries) |

Tests: 491 run, 0 failures, 0 errors, 1 skipped — green before and after. No test asserts on these log lines.

Other logging in the class checked: `validateObject`'s per-call `log.debug` is already guarded and never fires in practice (pool has no test-on-borrow/test-while-idle), the invalid-buffer paths are per-incident Sentry reports — all left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm
