### PR TITLE
fix(TD027): key the ip+port map by the address, not by a hash of it

### DIFF
--- a/src/main/java/im/redpanda/core/PeerList.java
+++ b/src/main/java/im/redpanda/core/PeerList.java
@@ -63,8 +63,29 @@ public class PeerList {
   /** We store each Peer in a hashmap for fast get operations via KademliaId */
   private final HashMap<KademliaId, Peer> peerHashMap = new HashMap<>();
 
-  /** We store each Peer in a hashmap for fast get operations via Ip and Port */
-  private final HashMap<Integer, Peer> peerlistIpPort = new HashMap<>();
+  /**
+   * We store each Peer in a hashmap for fast get operations via Ip and Port.
+   *
+   * <p>The key is the address itself ({@code ip + ":" + port}, see {@link #ipPortKey}), not a hash
+   * of it. It used to be {@code ip.hashCode() + port}, i.e. an {@code int} that two
+   * <em>different</em> addresses can share: {@code "10.0.0.11":59558} and {@code "10.0.0.21":59527}
+   * collide, and so does every pair whose ip hashes differ by exactly the port difference. A
+   * colliding peer took over the slot of a live one, which made {@link #addLocked} answer with the
+   * wrong peer (and, for a peer without a {@link NodeId}, refuse to register the new one at all)
+   * and let {@link #removeIpPort} cascade a full removal onto an innocent peer at a completely
+   * different address (TD027).
+   *
+   * <p>Only peers that have an ip are in here — see {@link #addPeer}. Peers without connection
+   * details are explicitly allowed in the peer list, and there is no address to key them by.
+   *
+   * <p>Note what this map still cannot distinguish, because it is not a collision but genuine key
+   * equality: every inbound light client from the same ip announces port 0 (it has no listening
+   * socket, {@code ConnectionReaderThread:151}), so they all share the key {@code "127.0.0.1:0"}
+   * and the last one to be added owns it. That is a lookup ambiguity, not corruption — every
+   * mutation of this map is value-checked ({@link #removeIpPortMapping}), so a removal can only
+   * ever drop the mapping it actually owns.
+   */
+  private final HashMap<String, Peer> peerlistIpPort = new HashMap<>();
 
   /** Blacklist of ips via HashMap */
   private final HashMap<String, Peer> blacklistIp = new HashMap<>();
@@ -168,7 +189,7 @@ public class PeerList {
      * Peers without (ip,port) here.
      */
     if (peer.getIp() != null) {
-      oldPeer = peerlistIpPort.get(getIpPortHash(peer));
+      oldPeer = peerlistIpPort.get(ipPortKey(peer));
       if (oldPeer != null) {
         // Peer with same Ip+Port exists already
 
@@ -195,7 +216,12 @@ public class PeerList {
       if (peer.getKademliaId() != null) {
         oldPeer = peerHashMap.put(peer.getKademliaId(), peer);
       }
-      peerlistIpPort.put(getIpPortHash(peer), peer);
+      // Only keyable peers go into the address map. A peer without an ip has no address, and
+      // addLocked's javadoc explicitly allows such peers in the list (clearConnectionDetails
+      // produces them). Keying them anyway would put every one of them into one shared bucket.
+      if (peer.getIp() != null) {
+        peerlistIpPort.put(ipPortKey(peer), peer);
+      }
       peerArrayList.add(peer);
     } finally {
       readWriteLock.writeLock().unlock();
@@ -204,18 +230,25 @@ public class PeerList {
   }
 
   /**
-   * Hash method for the peerlistIpPort list.
+   * Key method for the {@link #peerlistIpPort} map.
    *
-   * @param peer
-   * @return hash value
+   * @param peer a peer with an ip
+   * @return the address key of that peer
    */
-  private Integer getIpPortHash(Peer peer) {
-    return getIpPortHash(peer.getIp(), peer.getPort());
+  private static String ipPortKey(Peer peer) {
+    return ipPortKey(peer.getIp(), peer.getPort());
   }
 
-  private static Integer getIpPortHash(String ip, int port) {
-    // ToDo: we need later a better method
-    return ip.hashCode() + port;
+  /**
+   * The address itself, so that two different addresses can never share a key.
+   *
+   * <p>Was {@code ip.hashCode() + port} — a hash used as if it were a key. Distinct addresses whose
+   * ip hashes differ by exactly the port difference mapped to the same slot ({@code
+   * "10.0.0.11":59558} vs {@code "10.0.0.21":59527}), and since peers announce their own ip and
+   * port in the gossiped peer list, the colliding entry was remote-controllable (TD027).
+   */
+  private static String ipPortKey(String ip, int port) {
+    return ip + ":" + port;
   }
 
   /**
@@ -233,15 +266,17 @@ public class PeerList {
    * on every retry, forever (T88; the S4 airplane-mode gate hung on it after T86/#294 started
    * evicting undialable peers and thus made this removal path reachable at all).
    *
-   * <p>The value-checked removal matters because {@link #getIpPortHash} is {@code ip.hashCode() +
-   * port}: every loopback light client shares the key {@code "127.0.0.1".hashCode()}, so an
-   * unconditional {@code remove(key)} would evict a different, live peer's mapping.
+   * <p>The value-checked removal matters because an address is not unique per peer: every inbound
+   * light client from the same ip announces port 0, so they all share the key {@code "127.0.0.1:0"}
+   * and only the last one added owns it. An unconditional {@code remove(key)} would evict a
+   * different, live peer's mapping. This is the single mutation point for removals from {@link
+   * #peerlistIpPort}, so that invariant holds for every path (TD027).
    */
-  private void removeIpPortMapping(Peer peer) {
+  private boolean removeIpPortMapping(Peer peer) {
     if (peer.getIp() == null) {
-      return;
+      return false;
     }
-    peerlistIpPort.remove(getIpPortHash(peer), peer);
+    return peerlistIpPort.remove(ipPortKey(peer), peer);
   }
 
   /**
@@ -283,9 +318,12 @@ public class PeerList {
    * @return
    */
   public boolean removeIpPort(String ip, int port) {
+    if (ip == null) {
+      return false;
+    }
     readWriteLock.writeLock().lock();
     try {
-      Peer peer = peerlistIpPort.remove(getIpPortHash(ip, port));
+      Peer peer = peerlistIpPort.remove(ipPortKey(ip, port));
       if (peer == null) {
         return false;
       }
@@ -298,18 +336,22 @@ public class PeerList {
   }
 
   /**
-   * Removes the Peer from the IpPortList, peer is still in the other lists. Use this only for
+   * Removes this peer from the IpPortList, the peer is still in the other lists. Use this only for
    * ip,port changes.
    *
-   * @param ip
-   * @param port
-   * @return
+   * <p>Takes the {@link Peer} rather than an ip and a port so that the removal can be
+   * value-checked: an address does not identify a peer (see {@link #peerlistIpPort}), so removing
+   * by address alone evicted whichever peer happened to own that key — the very mistake the other
+   * two removal paths were fixed for in T88, left behind on this one (TD027). Its caller {@link
+   * #clearConnectionDetails} always has the peer.
+   *
+   * @param peer the peer whose address mapping should go
+   * @return true if this peer's own mapping was removed, false if it did not own one
    */
-  public boolean removeIpPortOnly(String ip, int port) {
+  public boolean removeIpPortOnly(Peer peer) {
     readWriteLock.writeLock().lock();
     try {
-      Peer peer = peerlistIpPort.remove(getIpPortHash(ip, port));
-      return peer != null;
+      return removeIpPortMapping(peer);
     } finally {
       readWriteLock.writeLock().unlock();
     }
@@ -437,7 +479,7 @@ public class PeerList {
 
   public void clearConnectionDetails(Peer peer) {
     Log.put("clearing peer: " + peer.getIp() + ":" + peer.getPort(), 50);
-    removeIpPortOnly(peer.getIp(), peer.getPort());
+    removeIpPortOnly(peer);
     peer.removeIpAndPort();
   }
 

--- a/src/test/java/im/redpanda/core/PeerListIpPortConsistencyTest.java
+++ b/src/test/java/im/redpanda/core/PeerListIpPortConsistencyTest.java
@@ -19,6 +19,12 @@ import org.junit.Test;
  * <p>The path only became reachable with T86/#294, which is the first code that ever removes an
  * undialable (port-0) peer; before that they simply leaked. It surfaced as the S4 airplane-mode
  * gate failing with 154 consecutive "duplicate parallel connection from the same identity" lines.
+ *
+ * <p>The second half (TD027, tests at the bottom) is what the map was keyed by: {@code
+ * ip.hashCode() + port} is a hash, not a key, so two <em>different</em> addresses could share a
+ * slot. The key is the address itself now, and the last removal path that still removed by key
+ * instead of by peer ({@code removeIpPortOnly}, used by {@code clearConnectionDetails}) is
+ * value-checked like the other two.
  */
 public class PeerListIpPortConsistencyTest {
 
@@ -70,10 +76,10 @@ public class PeerListIpPortConsistencyTest {
   }
 
   /**
-   * {@code getIpPortHash} is {@code ip.hashCode() + port}, so every loopback light client shares
-   * one key and the last {@code add} owns the mapping. Removing an earlier peer must not evict the
-   * mapping of the peer that owns it now — which is why the removal is value-checked rather than a
-   * plain {@code remove(key)}.
+   * Every inbound light client from the same ip announces port 0, so they all share the key {@code
+   * "127.0.0.1:0"} and the last {@code add} owns the mapping. Removing an earlier peer must not
+   * evict the mapping of the peer that owns it now — which is why the removal is value-checked
+   * rather than a plain {@code remove(key)}.
    */
   @Test
   public void removalDoesNotStealAColocatedPeersIpPortEntry() {
@@ -108,5 +114,143 @@ public class PeerListIpPortConsistencyTest {
     Peer reconnect = new Peer("46.224.156.238", 59558, new NodeId(identity.getKademliaId()));
     assertThat(peerList.add(reconnect)).isNull();
     assertThat(peerList.get(identity.getKademliaId())).isSameAs(reconnect);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // TD027: the ip+port map used to be keyed by ip.hashCode() + port — a hash, not a key.
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Two addresses that collided under the old {@code ip.hashCode() + port} key.
+   *
+   * <p>{@code "10.0.0.11".hashCode()} and {@code "10.0.0.21".hashCode()} differ by exactly 31 (one
+   * character, one position from the end), so the two addresses below produced the same {@code
+   * int}. {@link String#hashCode()} is specified, so this pair is stable forever; {@link
+   * #theTwoAddressesReallyCollideUnderTheOldHashKey} asserts it rather than trusting the comment.
+   */
+  private static final String COLLIDING_IP_A = "10.0.0.11";
+
+  private static final int COLLIDING_PORT_A = 59558;
+  private static final String COLLIDING_IP_B = "10.0.0.21";
+  private static final int COLLIDING_PORT_B = 59527;
+
+  /** Guards the premise of the two tests below: without a collision they would prove nothing. */
+  @Test
+  public void theTwoAddressesReallyCollideUnderTheOldHashKey() {
+    assertThat(COLLIDING_IP_A.hashCode() + COLLIDING_PORT_A)
+        .as("the old key was ip.hashCode() + port and these two addresses shared it")
+        .isEqualTo(COLLIDING_IP_B.hashCode() + COLLIDING_PORT_B);
+    assertThat(COLLIDING_IP_A).isNotEqualTo(COLLIDING_IP_B);
+  }
+
+  /**
+   * TD027(a): two peers at different addresses that hashed to the same old key must both keep their
+   * own mapping.
+   *
+   * <p>Both are ordinary dialable nodes, the kind a gossiped peer list carries — and since a peer
+   * announces its own ip and port there, the colliding entry was remote-controllable. Under the old
+   * key, adding {@code b} silently took over {@code a}'s slot, so the map answered every question
+   * about {@code a}'s address with {@code b}: {@code add()} refused to register a new peer for
+   * {@code a}'s address (it returned {@code b} as the pre-existing one), and {@code removeIpPort}
+   * on {@code a}'s address cascaded a full removal onto {@code b}, a live peer at an entirely
+   * different address.
+   */
+  @Test
+  public void twoPeersWithCollidingAddressHashesKeepTheirOwnMapping() {
+    PeerList peerList = ServerContext.buildDefaultServerContext().getPeerList();
+
+    Peer a = new Peer(COLLIDING_IP_A, COLLIDING_PORT_A, NodeId.generateWithSimpleKey());
+    Peer b = new Peer(COLLIDING_IP_B, COLLIDING_PORT_B, NodeId.generateWithSimpleKey());
+    peerList.add(a);
+    peerList.add(b);
+
+    // add() of a peer without an identity resolves purely through the address map and returns
+    // whoever is registered at that address, without registering the newcomer. It must be the peer
+    // that actually lives there.
+    assertThat(peerList.add(new Peer(COLLIDING_IP_A, COLLIDING_PORT_A)))
+        .as("a's address must resolve to a, not to the peer that merely hashed to the same key")
+        .isSameAs(a);
+
+    // removeIpPort cascades: it drops whatever the address map points at from all three
+    // structures. Removing a must therefore leave b completely untouched.
+    assertThat(peerList.removeIpPort(COLLIDING_IP_A, COLLIDING_PORT_A)).isTrue();
+    assertThat(peerList.get(a.getKademliaId())).isNull();
+    assertThat(peerList.get(b.getKademliaId()))
+        .as("removing a must not evict b, which only shared the old hash key")
+        .isSameAs(b);
+    assertThat(peerList.removeIpPort(COLLIDING_IP_B, COLLIDING_PORT_B))
+        .as("b must still be reachable through its own address")
+        .isTrue();
+  }
+
+  /**
+   * TD027(b): {@code clearConnectionDetails} — the "the client wiped its data" path in {@code
+   * ConnectionReaderThread:230} — must not evict a live neighbour's mapping.
+   *
+   * <p>T88 made the two peer-based removal paths value-checked but left {@code removeIpPortOnly} on
+   * an unconditional {@code remove(key)}. Alice and Bob are two inbound light clients from the same
+   * ip, so they genuinely share the key {@code "127.0.0.1:0"} and Bob, added last, owns it. Wiping
+   * Alice's connection details used to drop Bob's mapping instead.
+   */
+  @Test
+  public void clearingConnectionDetailsDoesNotStealAColocatedPeersIpPortEntry() {
+    PeerList peerList = ServerContext.buildDefaultServerContext().getPeerList();
+
+    Peer alice = inboundLightClient("127.0.0.1", NodeId.generateWithSimpleKey());
+    Peer bob = inboundLightClient("127.0.0.1", NodeId.generateWithSimpleKey());
+    peerList.add(alice);
+    peerList.add(bob); // same address: bob now owns the mapping
+
+    peerList.clearConnectionDetails(alice);
+
+    assertThat(alice.getIp()).as("alice's own details are still cleared").isNull();
+    // removeIpPort resolves through the address map and cascades to whoever it points at — so if it
+    // still finds and drops bob, alice's clearConnectionDetails left his entry alone.
+    assertThat(peerList.removeIpPort("127.0.0.1", 0))
+        .as("bob's ip+port mapping must survive alice's clearConnectionDetails")
+        .isTrue();
+    assertThat(peerList.get(bob.getKademliaId())).isNull();
+  }
+
+  /** {@code removeIpPortOnly} reports whether it removed <em>this</em> peer's mapping. */
+  @Test
+  public void removeIpPortOnlyOnlyRemovesTheMappingThePeerOwns() {
+    PeerList peerList = ServerContext.buildDefaultServerContext().getPeerList();
+
+    Peer alice = inboundLightClient("127.0.0.1", NodeId.generateWithSimpleKey());
+    Peer bob = inboundLightClient("127.0.0.1", NodeId.generateWithSimpleKey());
+    peerList.add(alice);
+    peerList.add(bob);
+
+    assertThat(peerList.removeIpPortOnly(alice))
+        .as("alice never owned the mapping, so there is nothing for her to remove")
+        .isFalse();
+    assertThat(peerList.removeIpPortOnly(bob)).as("bob owns it").isTrue();
+    assertThat(peerList.removeIpPortOnly(bob)).as("and only once").isFalse();
+    assertThat(peerList.size()).as("both peers are still in the list itself").isEqualTo(2);
+  }
+
+  /**
+   * A peer without connection details is explicitly allowed in the peer list (see {@code
+   * addLocked}'s javadoc), and there is no address to key it by — so it must simply stay out of the
+   * address map instead of landing in a shared {@code "null:0"} bucket.
+   */
+  @Test
+  public void peersWithoutConnectionDetailsStayOutOfTheAddressMap() {
+    PeerList peerList = ServerContext.buildDefaultServerContext().getPeerList();
+
+    Peer wiped = inboundLightClient("127.0.0.1", NodeId.generateWithSimpleKey());
+    peerList.add(wiped);
+    peerList.clearConnectionDetails(wiped);
+
+    // Before the composite key this threw an NPE inside addPeer (ip.hashCode() on a null ip); a
+    // "null:0" key would be no better, it would make every address-less peer collide with every
+    // other one.
+    Peer alsoWiped = new Peer(null, 0, NodeId.generateWithSimpleKey());
+    assertThat(peerList.add(alsoWiped))
+        .as("an address-less peer is registered on its identity alone")
+        .isNull();
+    assertThat(peerList.get(alsoWiped.getKademliaId())).isSameAs(alsoWiped);
+    assertThat(peerList.get(wiped.getKademliaId())).isSameAs(wiped);
   }
 }

--- a/src/test/java/im/redpanda/core/PeerListTest.java
+++ b/src/test/java/im/redpanda/core/PeerListTest.java
@@ -123,8 +123,9 @@ public class PeerListTest {
     ServerContext serverContext = ServerContext.buildDefaultServerContext();
 
     PeerList peerList = serverContext.getPeerList();
-    peerList.add(new Peer("127.0.0.1", 50558));
-    peerList.removeIpPortOnly("127.0.0.1", 50558);
+    Peer peer = new Peer("127.0.0.1", 50558);
+    peerList.add(peer);
+    assertTrue(peerList.removeIpPortOnly(peer));
     assertEquals(1, peerList.size());
   }
 


### PR DESCRIPTION
## The defect

`PeerList` keeps `peerlistIpPort` keyed by `ip.hashCode() + port`. That is a hash used as if it were a key, so two **different** addresses can share one slot. It is not theoretical and not rare: `"10.0.0.11".hashCode()` and `"10.0.0.21".hashCode()` differ by exactly 31 (one character, one position from the end), so `10.0.0.11:59558` and `10.0.0.21:59527` are one entry — and so is every pair whose ip hashes differ by exactly the port difference. Peers announce their own ip and port in the gossiped peer list, so *which* entries collide is remote-controllable.

What a collision does today:

| reader | effect |
|---|---|
| `addLocked` | For a peer **without** a `NodeId` it returns the colliding peer as "already known at this address" and does **not** register the newcomer. A legitimately new peer — a seed from `OutboundHandler`, a gossiped peer from `InboundCommandProcessor`, a restored peer from `Server` — silently never enters the list. |
| `removeIpPort(ip, port)` | Drops whatever the map points at from **all three** structures. On a collision it cascades a full removal onto a live peer at a completely different address. |
| `removeIpPortOnly(ip, port)` | Unconditional `remove(key)` — evicts a different, live peer's mapping. |

`addLocked`'s other branch (peer *with* a `NodeId`) is unaffected: it only returns `oldPeer` when the NodeIds are equal, which a collision never produces. That is why `ConnectionHandler.setupConnection`'s TD020 invariant ("`add()` only ever returns an `oldPeer` whose NodeId equals ours") still held.

#297 (T88, one day old) fixed the half with teeth — the two peer-based removal paths now use a value-checked `Map.remove(key, value)`. `removeIpPortOnly` was left behind: it is the "the client wiped its data" path (`clearConnectionDetails`, from `ConnectionReaderThread:230`), and with several inbound light clients on one ip it evicts a different, live client's mapping.

## Fix

The key is the address itself, `ip + ":" + port`. Distinct addresses can no longer share a slot. Two things follow from having a real key:

- **`addPeer` only inserts peers that have an ip.** A peer without connection details is explicitly allowed in the peer list (`addLocked`'s own javadoc says so; `clearConnectionDetails` produces them) and has no address to be keyed by. The old code called `ip.hashCode()` on it and threw `NullPointerException`; a `"null:0"` key would be no better, it would put every address-less peer into one shared bucket. `addLocked` already guards its lookup with `getIp() != null`, so nothing looks for them.
- **`removeIpPortOnly` takes the `Peer`** instead of an ip and a port, and delegates to the value-checked `removeIpPortMapping` #297 introduced. `removeIpPortMapping` is now the single mutation point for removals from the map, so the "only drop the mapping you own" invariant holds on every path. Its only production caller, `clearConnectionDetails(Peer)`, always has the peer.

## The design question, answered

The obvious alternative — *port-0 peers should never enter that map in the first place* — was considered and **rejected**.

Port-0 sharing is **not a collision**. Every inbound light client from the same ip really is at `<ip>:0`: the handshake carries the sender's *listening* port and a light client has none, so it announces 0 (`ConnectionReaderThread:151`). A composite key cannot and should not separate them. Excluding them would:

- change which peers `add()` can match — for an address-less newcomer, `add(new Peer(ip, 0))` (`ConnectionReaderThread:231`) would stop resolving to the light client already at that ip and create a fresh anonymous peer instead;
- **hollow out the T88 regressions.** `removalDoesNotStealAColocatedPeersIpPortEntry` asserts `removeIpPort("127.0.0.1", 0)` is `true` after alice's removal; with port-0 excluded it becomes `false` and the test has to be rewritten to assert the opposite. `reconnectAfterEvictionIsRegisteredInsteadOfDroppedAsDuplicate` would pass vacuously. Those tests cost a nine-minute client lockout to learn.

…for a consequence the map's only real reader rates as mild. With every mutation value-checked, what remains is a *lookup ambiguity* (the last light client on an ip owns the slot), not corruption. That is documented on the field, so the next reader does not have to re-derive it.

No lock usage changed — the T87 lock order (`writeBufferLock -> NodeStore -> PeerList`) is untouched, and `PeerListLockOrderTest` stays green.

## Tests

`PeerListIpPortConsistencyTest` gains four cases (plus one that asserts the collision pair really *did* collide under the old key, so the premise cannot rot):

- `twoPeersWithCollidingAddressHashesKeepTheirOwnMapping` — both readers: `add()` resolves `10.0.0.11:59558` to its own peer, and `removeIpPort` on it leaves the peer at `10.0.0.21:59527` completely alone.
- `clearingConnectionDetailsDoesNotStealAColocatedPeersIpPortEntry` — the production path.
- `removeIpPortOnlyOnlyRemovesTheMappingThePeerOwns` — the ownership contract of the new signature.
- `peersWithoutConnectionDetailsStayOutOfTheAddressMap` — the address-less peer.

**Negative controls**, each with only the one relevant piece reverted:

| reverted | result |
|---|---|
| hash key (`String.valueOf(ip.hashCode() + port)`) | `twoPeersWithCollidingAddressHashesKeepTheirOwnMapping` fails: `Expecting actual: Peer{ip='10.0.0.21', port=59527} and: Peer{ip='10.0.0.11', port=59558} to refer to the same object` |
| value check in `removeIpPortOnly` | `clearingConnectionDetailsDoesNotStealAColocatedPeersIpPortEntry` fails on *"bob's ip+port mapping must survive alice's clearConnectionDetails"*, `removeIpPortOnlyOnlyRemovesTheMappingThePeerOwns` fails on *"alice never owned the mapping"* |
| `addPeer` ip guard + hash key (i.e. `main` verbatim) | `peersWithoutConnectionDetailsStayOutOfTheAddressMap` errors with `NullPointerException: Cannot invoke "String.hashCode()" because "ip" is null` at `PeerList.addPeer` |

Full suite: **496 tests, 0 failures**, including `ConnectionHandlerDuplicateConnectionTest` (TD020/T88) and `PeerListLockOrderTest` (T87).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm
