### PR TITLE
fix(TD029): stop the peer-buffer reaper racing the selector's write path (REDPANDAJ-2EJ)

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -291,7 +291,11 @@ public class ConnectionHandler extends Thread {
     return false;
   }
 
-  private boolean handleKeyWriteable(SelectionKey key) {
+  /**
+   * Package-private rather than private so the buffer-gone path below can be driven directly from a
+   * test instead of through a real selector.
+   */
+  boolean handleKeyWriteable(SelectionKey key) {
     Peer peer = (Peer) key.attachment();
     peer.writeBufferLock.lock();
     try {
@@ -305,9 +309,25 @@ public class ConnectionHandler extends Thread {
        */
       peer.encrypteOutputdata();
 
-      peer.writeBufferCrypted.flip();
-      remainingBytes = peer.writeBufferCrypted.hasRemaining();
-      peer.writeBufferCrypted.compact();
+      // Re-read under the lock and null-check — the pattern every other writeBufferLock section
+      // uses (Peer.encrypteOutputdata(), Peer.sendPing(), InboundCommandProcessor:949); this was
+      // the only one dereferencing the field blind, on the thread where it hurts most.
+      //
+      // The buffers can already be gone when a key becomes writable: Peer.sendPing() sets
+      // connected=false when it finds a null writeBuffer but leaves the key registered and valid,
+      // and PeerJobs' reaper then frees the pair of such a peer without cancelling the key. The
+      // deref below threw on the selector thread for exactly that (REDPANDAJ-2EJ / TD029). A peer
+      // without buffers cannot send anything ever again, so tear it down instead of leaving a
+      // zombie key that re-fires OP_WRITE on every select().
+      ByteBuffer writeBufferCrypted = peer.writeBufferCrypted;
+      if (writeBufferCrypted == null) {
+        peer.disconnect("write buffer is gone");
+        return true;
+      }
+
+      writeBufferCrypted.flip();
+      remainingBytes = writeBufferCrypted.hasRemaining();
+      writeBufferCrypted.compact();
 
       // switch buffer for reading
       if (!remainingBytes) {

--- a/src/main/java/im/redpanda/core/PeerJobs.java
+++ b/src/main/java/im/redpanda/core/PeerJobs.java
@@ -147,8 +147,18 @@ public class PeerJobs extends Thread {
    * <p>The condition is re-tested under the lock because {@code setupConnectionForPeer()} holds
    * {@code writeBufferLock} across the whole connection swap: between the decision in the loop and
    * the acquisition here the peer can have reconnected and allocated fresh buffers, and nulling
-   * those would tear down a live connection. {@code connected} and {@code lastPongReceived} are
-   * plain fields, so the acquisition is also what gives this thread an up-to-date view of them.
+   * those would tear down a live connection. That swap sets {@code connected} and {@code
+   * lastPongReceived} under this same lock, so acquiring it is also what makes the re-test see the
+   * reconnect at all — the fields are plain, and the pre-lock checks in the loop can read an
+   * arbitrarily stale value. Note this only holds for the reconnect swap: other writers of those
+   * fields ({@code sendPing()}, {@code handlePong()}, {@code OutboundHandler}) take no lock, which
+   * does not matter here but should not be read as a general visibility guarantee.
+   *
+   * <p>The acquisition is an unbounded {@code lock()}, so this can park the chron thread for as
+   * long as a writeBufferLock section runs — worst case the {@code PEERLIST_LOCK_TIMEOUT_MS} of
+   * {@code ConnectionHandler.setupConnection()}. That is the same exposure the {@code
+   * peer.disconnect("timeout")} branch a few lines up already has, and the chron thread is the one
+   * thread in the system that can afford to wait.
    */
   private static void releaseWriteBuffers(Peer peer) {
     peer.writeBufferLock.lock();

--- a/src/main/java/im/redpanda/core/PeerJobs.java
+++ b/src/main/java/im/redpanda/core/PeerJobs.java
@@ -112,8 +112,7 @@ public class PeerJobs extends Thread {
 
           // todo: interrupt outbound thread?
         } else if (peer.getLastAnswered() > Settings.pingTimeout * 2) {
-          peer.writeBuffer = null;
-          peer.writeBufferCrypted = null;
+          releaseWriteBuffers(peer);
         }
 
       } else if (peer.isConnected()) {
@@ -128,6 +127,40 @@ public class PeerJobs extends Thread {
           }
         }
       }
+    }
+  }
+
+  /**
+   * Frees the 2 × 300 KiB write buffers of a peer that has been silent for twice the ping timeout.
+   *
+   * <p>TD029 (REDPANDAJ-2EJ): both fields belong to {@link Peer#writeBufferLock} — {@link
+   * Peer#disconnect(String)}, {@link Peer#setupConnectionForPeer(PeerInHandshake)} and {@code
+   * ConnectionHandler.handleKeyWriteable()} all touch them under it. Nulling them here without the
+   * lock let the selector thread watch the pair disappear in the middle of its own locked section
+   * and NPE on {@code writeBufferCrypted.flip()}.
+   *
+   * <p>Lock order (documented on {@link PeerList}): {@code writeBufferLock} is the outermost of the
+   * three, and {@link #runOnce()} released the peer list read lock right after taking its snapshot,
+   * so nothing can be inverted here — the same loop already calls {@link Peer#disconnect(String)},
+   * which takes exactly this lock.
+   *
+   * <p>The condition is re-tested under the lock because {@code setupConnectionForPeer()} holds
+   * {@code writeBufferLock} across the whole connection swap: between the decision in the loop and
+   * the acquisition here the peer can have reconnected and allocated fresh buffers, and nulling
+   * those would tear down a live connection. {@code connected} and {@code lastPongReceived} are
+   * plain fields, so the acquisition is also what gives this thread an up-to-date view of them.
+   */
+  private static void releaseWriteBuffers(Peer peer) {
+    peer.writeBufferLock.lock();
+    try {
+      if (!peer.isConnected()
+          && !peer.isConnecting
+          && peer.getLastAnswered() > Settings.pingTimeout * 2) {
+        peer.writeBuffer = null;
+        peer.writeBufferCrypted = null;
+      }
+    } finally {
+      peer.writeBufferLock.unlock();
     }
   }
 

--- a/src/test/java/im/redpanda/core/ConnectionHandlerWriteBufferGoneTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerWriteBufferGoneTest.java
@@ -1,0 +1,86 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.channels.SelectableChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import org.junit.Test;
+
+/**
+ * Second half of TD029 (REDPANDAJ-2EJ): {@code handleKeyWriteable()} dereferenced {@code
+ * peer.writeBufferCrypted} without a null check, on the selector thread.
+ *
+ * <p>Locking the reaper in {@code PeerJobs} closes the race, but not this: a peer can reach a
+ * writable key with its buffers already gone. {@link Peer#sendPing()} sets {@code connected=false}
+ * when it finds a null {@code writeBuffer} (Peer.java:284-286) and leaves the {@link SelectionKey}
+ * registered and valid, and the reaper then frees the pair of such a peer without cancelling that
+ * key. Every other {@code writeBufferLock} section in the tree re-reads and null-checks these
+ * fields; this one did not, and the NPE it threw was swallowed by the {@code catch (Exception)} in
+ * {@code handleSelectionKey()}, which cancels the key — so the connection died either way, only
+ * silently and with a Sentry event.
+ */
+public class ConnectionHandlerWriteBufferGoneTest {
+
+  @Test
+  public void writableKeyOfAPeerWithoutBuffersIsTornDownInsteadOfThrowing() {
+    ByteBufferPool.init();
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    ConnectionHandler connectionHandler = new ConnectionHandler(serverContext, false);
+
+    Peer peer = new Peer("46.224.156.238", 59558, NodeId.generateWithSimpleKey());
+    peer.setConnected(true);
+    // exactly the state PeerJobs' reaper leaves behind: no buffers, key still valid
+    peer.writeBuffer = null;
+    peer.writeBufferCrypted = null;
+
+    SelectionKey key = new StubSelectionKey();
+    key.attach(peer);
+    peer.setSelectionKey(key);
+
+    boolean handled = connectionHandler.handleKeyWriteable(key);
+
+    assertThat(handled)
+        .as("a peer whose write buffers are gone must be torn down, not dereferenced")
+        .isTrue();
+    assertThat(peer.isConnected()).isFalse();
+  }
+
+  /** Minimal valid {@link SelectionKey}: only {@code attach}/{@code isValid}/{@code cancel} run. */
+  private static final class StubSelectionKey extends SelectionKey {
+    @Override
+    public SelectableChannel channel() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Selector selector() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isValid() {
+      return true;
+    }
+
+    @Override
+    public void cancel() {
+      // no-op
+    }
+
+    @Override
+    public int interestOps() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SelectionKey interestOps(int ops) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int readyOps() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/src/test/java/im/redpanda/core/PeerJobsWriteBufferReapTest.java
+++ b/src/test/java/im/redpanda/core/PeerJobsWriteBufferReapTest.java
@@ -1,0 +1,96 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Regression test for TD029 (REDPANDAJ-2EJ), seen on a public seed node 76 s after the deploy of
+ * 226ab3a: {@code NullPointerException: Cannot invoke "java.nio.ByteBuffer.flip()" because
+ * "peer.writeBufferCrypted" is null} on the NIO selector thread.
+ *
+ * <p>{@code PeerJobs.runOnce()} frees the write buffers of a long-silent peer. It did so without
+ * holding {@link Peer#writeBufferLock}, the lock that owns both fields everywhere else — {@link
+ * Peer#disconnect(String)}, {@link Peer#setupConnectionForPeer(PeerInHandshake)} and {@code
+ * ConnectionHandler.handleKeyWriteable()}. The selector reads {@code writeBufferCrypted} inside its
+ * own {@code writeBufferLock} section, so the reaper could null it between the acquisition and the
+ * deref.
+ *
+ * <p>The assertion is one-sided and therefore not timing-flaky (see {@link
+ * ConcurrencyTestSupport}): a slow machine only gives the reaper more time to do the thing it must
+ * not do.
+ */
+public class PeerJobsWriteBufferReapTest {
+
+  @After
+  public void tearDown() {
+    ConnectionHandler.peerInHandshakes.clear();
+  }
+
+  private ServerContext context() {
+    ServerContext serverContext = ServerContext.buildDefaultServerContext();
+    serverContext.setConnectionHandler(new ConnectionHandler(serverContext, false));
+    ConnectionHandler.peerInHandshakes.clear();
+    return serverContext;
+  }
+
+  /**
+   * A dialable peer that is neither connected nor connecting and never answered — i.e. exactly the
+   * {@code lastAnswered > pingTimeout * 2} branch, and dialable so the T86 eviction keeps it.
+   */
+  private static Peer silentPeer() {
+    Peer peer = new Peer("46.224.156.238", 59558, NodeId.generateWithSimpleKey());
+    peer.writeBuffer = ByteBuffer.allocate(1024);
+    peer.writeBufferCrypted = ByteBuffer.allocate(1024);
+    return peer;
+  }
+
+  @Test
+  public void runOnce_freesTheWriteBuffersOnlyUnderTheWriteBufferLock() throws Exception {
+    ServerContext ctx = context();
+    Peer peer = silentPeer();
+    ctx.getPeerList().add(peer);
+    PeerJobs peerJobs = new PeerJobs(ctx);
+
+    // Holding writeBufferLock is what ConnectionHandler.handleKeyWriteable() does for the whole
+    // encrypt/flip/write section. While it is held, nothing may take these buffers away.
+    ConcurrencyTestSupport.assertBlockedWhileHeld(peer.getWriteBufferLock(), peerJobs::runOnce);
+
+    // ...and once the lock is free the reap must actually happen, so the test above cannot pass
+    // vacuously by blocking somewhere else.
+    assertThat(peer.writeBuffer).as("the reap must still run once the lock is released").isNull();
+    assertThat(peer.writeBufferCrypted).isNull();
+  }
+
+  /**
+   * {@code setupConnectionForPeer()} holds {@code writeBufferLock} across the entire connection
+   * swap, so a reaper that decided to free the buffers can end up queued behind it and acquire the
+   * lock only after the peer has reconnected and allocated fresh ones. Freeing those would tear
+   * down a live connection, so the condition is re-tested under the lock.
+   */
+  @Test
+  public void runOnce_doesNotFreeTheBuffersOfAPeerThatReconnectedInTheMeantime() {
+    ServerContext ctx = context();
+    Peer peer =
+        new Peer("46.224.156.238", 59558, NodeId.generateWithSimpleKey()) {
+          @Override
+          public boolean isConnected() {
+            // The loop's own checks run before the lock is taken and must see the stale state
+            // that makes runOnce() decide to reap; the check inside the lock sees the reconnect.
+            return getWriteBufferLock().isHeldByCurrentThread();
+          }
+        };
+    peer.writeBuffer = ByteBuffer.allocate(1024);
+    peer.writeBufferCrypted = ByteBuffer.allocate(1024);
+    ctx.getPeerList().add(peer);
+
+    new PeerJobs(ctx).runOnce();
+
+    assertThat(peer.writeBuffer)
+        .as("a peer that reconnected while the reaper waited for the lock must keep its buffers")
+        .isNotNull();
+    assertThat(peer.writeBufferCrypted).isNotNull();
+  }
+}


### PR DESCRIPTION
## The defect (TD029 / REDPANDAJ-2EJ)

Seen once on a public seed node 76 s after the deploy of 226ab3a, on the NIO selector thread:

```
NullPointerException: Cannot invoke "java.nio.ByteBuffer.flip()" because "peer.writeBufferCrypted" is null
```

`peer.writeBuffer` and `peer.writeBufferCrypted` are owned by `Peer.writeBufferLock`. Every place
that allocates or frees them takes it — `Peer.disconnect()` (Peer.java:215/251-252),
`Peer.setupConnectionForPeer()` (Peer.java:522/534-535), `InboundCommandProcessor` (:151) — with one
exception: `PeerJobs.runOnce()` nulled the pair unlocked (PeerJobs.java:115-116) in the
`lastAnswered > pingTimeout * 2` reaper branch.

`ConnectionHandler.handleKeyWriteable()` reads `writeBufferCrypted` **under** that lock
(ConnectionHandler.java:296 → :308) and, uniquely in this tree, without a null check. So the reaper
could null the field between the selector's `lock()` and its `flip()`.

It was armed rather than introduced by the last two merges: #294 (eviction of undialable peers) and
#297 (ip+port map removal fix) both raised disconnect/reconnect churn on exactly this path, which is
why Sentry saw it for the first time in ~2.5 weeks and right after the deploy. Contained by the
`catch (Exception)` in `handleSelectionKey()` (ConnectionHandler.java:273): one connection lost, node
healthy. A defect, not an outage.

## Fix

Both sides, because neither alone is sufficient.

**1. `PeerJobs.releaseWriteBuffers()` — take `writeBufferLock`.** Restores the field's documented
ownership; the reaper can no longer null the pair inside somebody else's critical section.

**Lock order is not violated.** `PeerList`'s javadoc pins `writeBufferLock -> NodeStore -> PeerList`
(#295). `writeBufferLock` is the *outermost* of the three, and `runOnce()` releases the peer list read
lock immediately after snapshotting (PeerJobs.java:78-84), so nothing is held when the reaper branch
runs — the same loop already calls `peer.disconnect()` two lines up, which takes exactly this lock.
No inversion is possible here, and `PeerListLockOrderTest` stays green.

The condition is re-tested under the lock. `setupConnectionForPeer()` holds `writeBufferLock` across
the whole connection swap, so between the loop's decision and the acquisition the peer can have
reconnected and allocated fresh buffers; freeing *those* would silently kill a live connection. This
is not hypothetical hardening — `connected` and `lastPongReceived` are plain (non-volatile) fields, and
before this change the reaper had no happens-before with the selector at all, so it could act on an
arbitrarily stale view of both.

**2. `ConnectionHandler.handleKeyWriteable()` — snapshot and null-check.** The lock alone does not fix
the reported crash: it makes the two nulls atomic but does not stop the selector from *entering* its
locked section with the buffers already gone. That state is reachable independently of the race —
`Peer.sendPing()` sets `connected = false` when it finds a null `writeBuffer` (Peer.java:284-286) and
leaves the `SelectionKey` registered and valid, and the reaper then frees the pair of such a peer
without cancelling that key. The null check follows the pattern of every other `writeBufferLock`
section (`Peer.encrypteOutputdata()`, `Peer.sendPing()`, `InboundCommandProcessor:949-951`); this was
the only blind deref, on the thread where it is most expensive. A peer with no buffers can never send
again, so it is disconnected rather than left as a zombie key that re-fires `OP_WRITE` on every
`select()`.

`handleKeyWriteable` goes from `private` to package-private so that path can be driven from a test
without a real selector.

## Tests

Two deterministic regression tests, no sleep-and-hope.

- `PeerJobsWriteBufferReapTest.runOnce_freesTheWriteBuffersOnlyUnderTheWriteBufferLock` — uses the
  existing `ConcurrencyTestSupport.assertBlockedWhileHeld`: holds `writeBufferLock` (what the selector
  does), asserts `runOnce()` cannot complete, then asserts the reap does happen once released, so it
  cannot pass vacuously. One-sided: a slower machine only makes the observation more reliable.
- `PeerJobsWriteBufferReapTest.runOnce_doesNotFreeTheBuffersOfAPeerThatReconnectedInTheMeantime` —
  drives the reconnect-during-acquisition interleaving explicitly via an `isConnected()` override
  keyed on `isHeldByCurrentThread()`.
- `ConnectionHandlerWriteBufferGoneTest` — a valid, writable key on a peer whose buffers are gone.

**Negative control.** Production change reverted, tests re-run:

| test | without the fix |
| --- | --- |
| `runOnce_freesTheWriteBuffersOnlyUnderTheWriteBufferLock` | `AssertionError: action completed while the conflicting lock was held — it does not take the lock` |
| `runOnce_doesNotFreeTheBuffersOfAPeerThatReconnectedInTheMeantime` | `AssertionError: a peer that reconnected while the reaper waited for the lock must keep its buffers` |
| `writableKeyOfAPeerWithoutBuffersIsTornDownInsteadOfThrowing` | `NullPointerException: Cannot invoke "java.nio.ByteBuffer.flip()" because "peer.writeBufferCrypted" is null` at `ConnectionHandler.handleKeyWriteable` — the Sentry message verbatim |

Restored: `mvn verify` green, **494 tests, 0 failures, 1 skipped**.

## Audited nearby, deliberately not touched

`PeerJobs.java:115-116` was the **only** unlocked write to these fields in the tree. But seven sites do
hold `writeBufferLock` and then dereference `writeBuffer` with no null check — the same latent NPE this
PR removes from the selector path, on reader/job threads:
`InboundCommandProcessor:489`, `:552-554`, `:614-618` (also reads the field before taking the lock),
`RequestPeerListJob:26`, `OutboundService:640-642`, `GarlicRouter:362-364`, `GMParser:446-448`.
Out of scope here; reported to the coordinator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm
