### PR TITLE
build(T92): align maven-failsafe-plugin to 3.5.6 in e2e profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -530,7 +530,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.22.2</version>
+                        <version>3.5.6</version>
                         <executions>
                             <execution>
                                 <goals>
@@ -543,6 +543,14 @@
                             <includes>
                                 <include>**/*IT.java</include>
                             </includes>
+                            <!-- The assembly fat jar (appendAssemblyId=false) replaces the main
+                                 artifact and bundles jgrapht-core's module-info.class, so failsafe
+                                 3.x would treat target/redpanda.jar as module org.jgrapht.core,
+                                 put it on the module path and collide with the real
+                                 jgrapht-core jar, collecting 0 tests. Force the plain classpath
+                                 and run ITs against the classes directory instead of the jar. -->
+                            <useModulePath>false</useModulePath>
+                            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## Summary

Aligns `maven-failsafe-plugin` in the `e2e` profile from 2.22.2 to 3.5.6, matching the surefire version (T92, from tech-debt entry TD024).

## Root cause of the earlier failed bump

The assembly plugin builds a fat jar with `appendAssemblyId=false`, which **replaces the main artifact** (`target/redpanda.jar`). That jar bundles jgrapht-core's `module-info.class`, so failsafe 3.x auto-detected the fat jar as module `org.jgrapht.core`, put it on the **module path**, collided with the real `jgrapht-core-1.5.1.jar` (`Module 'org.jgrapht.core' is already on the module path!`) and collected **0 tests**.

## Fix

In the e2e failsafe configuration:
- `<useModulePath>false</useModulePath>` — force the plain classpath
- `<classesDirectory>${project.build.outputDirectory}</classesDirectory>` — run ITs against the classes directory instead of the (fat) main artifact jar

No junit-platform provider or JUnit 5 deps added — the project is pure JUnit 4 and failsafe's auto-detected `JUnit4Provider` is correct.

## Local test results

`mvn verify -Pe2e` (failsafe 3.5.6):
```
[INFO] Running im.redpanda.e2e.HandshakeVersionsE2EIT
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.32 s -- in im.redpanda.e2e.HandshakeVersionsE2EIT
[INFO] Running im.redpanda.e2e.TwoNodesE2EIT
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.352 s -- in im.redpanda.e2e.TwoNodesE2EIT
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

`mvn verify` (unchanged path, surefire):
```
[INFO] Tests run: 491, Failures: 0, Errors: 0, Skipped: 1
[INFO] BUILD SUCCESS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm