### PR TITLE
fix: drop a crypto-invalid nodeinfo entry-point key instead of throwing (TD032)

### DIFF
--- a/src/main/java/im/redpanda/flaschenpost/GMParser.java
+++ b/src/main/java/im/redpanda/flaschenpost/GMParser.java
@@ -276,10 +276,11 @@ public class GMParser {
           Collections.shuffle(entryPoints);
 
           for (GMEntryPointModel entryPoint : entryPoints) {
-            // REDPANDAJ-2EH/TD032: NodeIdTypeAdapter returns a null nodeId for an entry point whose
+            // REDPANDAJ-2EH/TD032: the JSON is attacker-controlled, so the array may contain null
+            // elements, and NodeIdTypeAdapter returns a null nodeId for an entry point whose
             // Base58 string decoded to a crypto-invalid public key (dropped, siblings kept). Skip
-            // it here instead of dereferencing null.
-            if (entryPoint.getNodeId() == null) {
+            // both here instead of dereferencing null.
+            if (entryPoint == null || entryPoint.getNodeId() == null) {
               continue;
             }
             Peer peer = serverContext.getPeerList().get(entryPoint.getNodeId().getKademliaId());

--- a/src/main/java/im/redpanda/flaschenpost/GMParser.java
+++ b/src/main/java/im/redpanda/flaschenpost/GMParser.java
@@ -276,6 +276,12 @@ public class GMParser {
           Collections.shuffle(entryPoints);
 
           for (GMEntryPointModel entryPoint : entryPoints) {
+            // REDPANDAJ-2EH/TD032: NodeIdTypeAdapter returns a null nodeId for an entry point whose
+            // Base58 string decoded to a crypto-invalid public key (dropped, siblings kept). Skip
+            // it here instead of dereferencing null.
+            if (entryPoint.getNodeId() == null) {
+              continue;
+            }
             Peer peer = serverContext.getPeerList().get(entryPoint.getNodeId().getKademliaId());
             if (peer == null || !peer.isConnected()) {
               Node.addNodeIfNotPresent(

--- a/src/main/java/im/redpanda/kademlia/nodeinfo/NodeIdTypeAdapter.java
+++ b/src/main/java/im/redpanda/kademlia/nodeinfo/NodeIdTypeAdapter.java
@@ -3,6 +3,7 @@ package im.redpanda.kademlia.nodeinfo;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import im.redpanda.core.Log;
 import im.redpanda.core.NodeId;
 import im.redpanda.crypt.AddressFormatException;
 import im.redpanda.crypt.Base58;
@@ -20,9 +21,24 @@ public class NodeIdTypeAdapter extends TypeAdapter<NodeId> {
     String s = jsonReader.nextString();
     try {
       return NodeId.importPublic(Base58.decode(s));
-    } catch (AddressFormatException e) {
-      e.printStackTrace();
-      throw new IOException("public node id string could not be parsed");
+    } catch (AddressFormatException | IllegalArgumentException e) {
+      /*
+       * REDPANDAJ-2EH (second occurrence, TD032): this Base58 string is unauthenticated remote
+       * input carried inside a self-signed nodeinfo KadContent. A valid Base58 string can still
+       * decode to 64 bytes that BouncyCastle rejects as a non-canonical / small-order Ed25519
+       * point with IllegalArgumentException("invalid public key") — the same rejection #299 fixed
+       * at the handshake site. Left unhandled it escaped Gson out of NodeInfoModel.importFromString
+       * and unwound the whole relay path (Sentry event per relay attempt, remaining commands in
+       * the read dropped), and because the poisoned nodeinfo record is persisted in KadStoreManager
+       * it was re-thrown on every later relay to that destination.
+       *
+       * Drop only this one entry point (return null) and keep its siblings instead of aborting the
+       * entire nodeinfo parse. NodeId.importPublic keeps its throwing contract for local callers;
+       * only this network-facing adapter is lenient. Consumers must skip a null nodeId — see
+       * GMParser.sendGarlicMessageToPeer.
+       */
+      Log.put("dropping nodeinfo entry with unparseable node id: " + e.getMessage(), 50);
+      return null;
     }
   }
 }

--- a/src/main/java/im/redpanda/kademlia/nodeinfo/NodeIdTypeAdapter.java
+++ b/src/main/java/im/redpanda/kademlia/nodeinfo/NodeIdTypeAdapter.java
@@ -2,6 +2,7 @@ package im.redpanda.kademlia.nodeinfo;
 
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import im.redpanda.core.Log;
 import im.redpanda.core.NodeId;
@@ -18,6 +19,15 @@ public class NodeIdTypeAdapter extends TypeAdapter<NodeId> {
 
   @Override
   public NodeId read(JsonReader jsonReader) throws IOException {
+    if (jsonReader.peek() != JsonToken.STRING) {
+      // Copilot review follow-up: the JSON is attacker-controlled, so the nodeId value may be any
+      // token (null, number, object, ...). nextString() would throw IllegalStateException before
+      // reaching the catch below and abort the whole nodeinfo parse — consume the token and treat
+      // it like an unparseable node id instead.
+      Log.put("dropping nodeinfo entry with non-string node id token", 50);
+      jsonReader.skipValue();
+      return null;
+    }
     String s = jsonReader.nextString();
     try {
       return NodeId.importPublic(Base58.decode(s));

--- a/src/test/java/im/redpanda/kademlia/nodeinfo/NodeIdTypeAdapterPoisonTest.java
+++ b/src/test/java/im/redpanda/kademlia/nodeinfo/NodeIdTypeAdapterPoisonTest.java
@@ -1,0 +1,103 @@
+package im.redpanda.kademlia.nodeinfo;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import im.redpanda.core.NodeId;
+import im.redpanda.crypt.Base58;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * REDPANDAJ-2EH (second occurrence, TD032): a nodeinfo KadContent is self-signed, so its JSON is
+ * fully attacker-controlled. A Base58-valid entry-point node id string can decode to 64 bytes that
+ * BouncyCastle rejects as a non-canonical / small-order Ed25519 point with {@code
+ * IllegalArgumentException: invalid public key} — the same rejection #299 fixed at the handshake.
+ * Before the fix that exception escaped {@link NodeInfoModel#importFromString} out of Gson and
+ * unwound the whole relay path; here we pin that a poisoned entry is dropped while its siblings
+ * survive.
+ */
+class NodeIdTypeAdapterPoisonTest {
+
+  /** 64 bytes of 0xFF: the first 32 (Ed25519 verify key) are a non-canonical, rejected encoding. */
+  private static String poisonNodeIdString() {
+    byte[] poison = new byte[NodeId.PUBLIC_KEYLEN];
+    Arrays.fill(poison, (byte) 0xFF);
+    return Base58.encode(poison);
+  }
+
+  private static String validNodeIdString() {
+    return Base58.encode(new NodeId().exportPublic());
+  }
+
+  /**
+   * A single JSON entry point whose node id decodes to a crypto-invalid key must not blow up the
+   * whole parse — it is dropped (null node id) and the model is returned.
+   */
+  @Test
+  void poisonedEntryIsDroppedNotThrown() {
+    String json =
+        "{\"entryPoints\":[{\"nodeId\":\""
+            + poisonNodeIdString()
+            + "\",\"ip\":\"1.2.3.4\",\"port\":1234}],\"services\":[]}";
+
+    NodeInfoModel model = assertDoesNotThrow(() -> NodeInfoModel.importFromString(json));
+    assertNotNull(model);
+    assertEquals(1, model.getEntryPoints().size());
+    assertNull(model.getEntryPoints().getFirst().getNodeId(), "poisoned node id must be dropped");
+  }
+
+  /**
+   * The core acceptance test: one poisoned entry point must not drop its valid siblings. Before the
+   * fix Gson aborted the entire {@code entryPoints} array on the first crypto-invalid key, losing
+   * every valid sibling in the same record.
+   */
+  @Test
+  void poisonedEntryDoesNotDropItsSiblings() {
+    String validA = validNodeIdString();
+    String validB = validNodeIdString();
+
+    String json =
+        "{\"entryPoints\":["
+            + "{\"nodeId\":\""
+            + validA
+            + "\",\"ip\":\"1.1.1.1\",\"port\":1},"
+            + "{\"nodeId\":\""
+            + poisonNodeIdString()
+            + "\",\"ip\":\"2.2.2.2\",\"port\":2},"
+            + "{\"nodeId\":\""
+            + validB
+            + "\",\"ip\":\"3.3.3.3\",\"port\":3}"
+            + "],\"services\":[]}";
+
+    NodeInfoModel model = assertDoesNotThrow(() -> NodeInfoModel.importFromString(json));
+    assertNotNull(model);
+
+    List<GMEntryPointModel> entryPoints = model.getEntryPoints();
+    assertEquals(3, entryPoints.size(), "all three array elements must survive");
+
+    // Both valid siblings keep their node id; only the poisoned middle entry is nulled out.
+    assertNotNull(entryPoints.get(0).getNodeId(), "first valid sibling must survive");
+    assertNull(entryPoints.get(1).getNodeId(), "poisoned entry must be dropped");
+    assertNotNull(entryPoints.get(2).getNodeId(), "second valid sibling must survive");
+
+    assertEquals("1.1.1.1", entryPoints.get(0).getIp());
+    assertEquals("3.3.3.3", entryPoints.get(2).getIp());
+  }
+
+  /** A well-formed record must still round-trip unchanged (no regression). */
+  @Test
+  void validRecordStillParses() {
+    NodeId nodeId = new NodeId();
+    NodeInfoModel source = new NodeInfoModel();
+    source.addEntryPoint(new GMEntryPointModel(NodeId.importPublic(nodeId.exportPublic())));
+
+    NodeInfoModel imported = NodeInfoModel.importFromString(source.export());
+
+    assertEquals(1, imported.getEntryPoints().size());
+    assertNotNull(imported.getEntryPoints().getFirst().getNodeId());
+  }
+}

--- a/src/test/java/im/redpanda/kademlia/nodeinfo/NodeIdTypeAdapterPoisonTest.java
+++ b/src/test/java/im/redpanda/kademlia/nodeinfo/NodeIdTypeAdapterPoisonTest.java
@@ -88,6 +88,45 @@ class NodeIdTypeAdapterPoisonTest {
     assertEquals("3.3.3.3", entryPoints.get(2).getIp());
   }
 
+  /**
+   * Copilot review follow-up: a non-string {@code nodeId} token (JSON null, number, object) used to
+   * throw {@code IllegalStateException} from {@code nextString()} before the catch, aborting the
+   * whole nodeinfo parse. It must be consumed and dropped like an unparseable node id.
+   */
+  @Test
+  void nonStringNodeIdTokenIsDroppedNotThrown() {
+    String valid = validNodeIdString();
+    String json =
+        "{\"entryPoints\":["
+            + "{\"nodeId\":null,\"ip\":\"1.1.1.1\",\"port\":1},"
+            + "{\"nodeId\":123,\"ip\":\"2.2.2.2\",\"port\":2},"
+            + "{\"nodeId\":{\"a\":1},\"ip\":\"3.3.3.3\",\"port\":3},"
+            + ("{\"nodeId\":\"" + valid + "\",\"ip\":\"4.4.4.4\",\"port\":4}")
+            + "],\"services\":[]}";
+
+    NodeInfoModel model = assertDoesNotThrow(() -> NodeInfoModel.importFromString(json));
+    assertNotNull(model);
+    assertEquals(4, model.getEntryPoints().size());
+    assertNull(model.getEntryPoints().get(0).getNodeId());
+    assertNull(model.getEntryPoints().get(1).getNodeId());
+    assertNull(model.getEntryPoints().get(2).getNodeId());
+    assertNotNull(model.getEntryPoints().get(3).getNodeId(), "valid sibling must survive");
+  }
+
+  /**
+   * Copilot review follow-up: the {@code entryPoints} array itself may contain null elements — they
+   * must parse into null list entries without blowing up (the consumer skips them).
+   */
+  @Test
+  void nullArrayElementIsKept() {
+    String json = "{\"entryPoints\":[null],\"services\":[]}";
+
+    NodeInfoModel model = assertDoesNotThrow(() -> NodeInfoModel.importFromString(json));
+    assertNotNull(model);
+    assertEquals(1, model.getEntryPoints().size());
+    assertNull(model.getEntryPoints().getFirst());
+  }
+
   /** A well-formed record must still round-trip unchanged (no regression). */
   @Test
   void validRecordStillParses() {


### PR DESCRIPTION
## Summary

T90 / TD032: the REDPANDAJ-2EH defect (PR #299, handshake site) exists a second time on the nodeinfo path. `NodeIdTypeAdapter.read` only caught `AddressFormatException`; a Base58-valid string decoding to 64 crypto-invalid bytes made BouncyCastle throw `IllegalArgumentException: invalid public key` out of Gson. The nodeinfo `KadContent` is self-signed, so this JSON is fully attacker-controlled remote input.

## Blast radius (analysis result)

- **Where the IAE lands:** it escapes `NodeInfoModel.importFromString` at `GMParser.sendGarlicMessageToPeer` (`GMParser.java:274`, no local catch), unwinds `GMParser.parse` (`GMParser.java:165`) → `InboundCommandProcessor.handleFlaschenpostPut` (`InboundCommandProcessor.java:1254`) → `loopCommands` (`InboundCommandProcessor.java:371-382`, aborts the remaining commands of that read; `finally` still compacts the buffer) → up to `ConnectionReaderThread.run`'s `catch (Throwable)` (`ConnectionReaderThread.java:686-688`): one Sentry error event per relay attempt, peer stays connected. Second landing site: a nested GM inside a garlic message targeted to us, `GarlicMessage.parseContent` (`GarlicMessage.java:229`) — its catches (`InvalidKeyException`/`AEADBadTagException`/`GeneralSecurityException`) do not cover `RuntimeException`.
- **Sibling loss / DoS:** yes, worse than #299 in effect — one poisoned entry point aborts the whole Gson array parse, so ALL valid sibling entry points of that nodeinfo record are lost and neither the entry-point relay nor the fallback routing below (`GMParser.java:292+`) ever runs: the garlic message is not forwarded at all.
- **Persistence:** the poisoned record sits in `KadStoreManager.entries` (in-memory `HashMap`, `KadStoreManager.java:40`), kept up to `MAX_KEEP_TIME` = 14 days (`KadStoreManager.java:36`), replaced only by a newer timestamp (`KadStoreManager.java:76`). Every later relay toward that destination re-parses it and re-throws — a single injection poisons the relay path for up to 14 days. It is not persisted to disk and never reaches `NodeStore` (entry-point `Node`s are only added after a successful parse). Because `KadContent.verify` binds the record to its signer, an attacker can only poison the nodeinfo of a `NodeId` they control — but any relay node parsing it is affected.

## Fix (same shape as #299)

- `NodeIdTypeAdapter.read`: narrow catch of `IllegalArgumentException` (and the pre-existing `AddressFormatException`) at the parse site — drop only that one entry point by returning a null `nodeId`, keep its siblings, log at low level. `NodeId.importPublic` keeps its throwing contract for local callers.
- `GMParser.sendGarlicMessageToPeer`: skip entry points with a null `nodeId` instead of dereferencing them.
- Call-site audit: `GMParser.sendGarlicMessageToPeer` (`GMParser.java:274`) is the only remote-reachable consumer of this adapter (`NodeInfoModel.importFromString` has no other production caller; `NodeInfoSetRefreshJob` only uses the export/write side).

## Tests

- `NodeIdTypeAdapterPoisonTest`: poisoned entry is dropped not thrown; **one poisoned record does not drop its siblings** (3-element array, middle poisoned, both neighbors survive); valid-record round-trip regression check.
- Negative control run: with the fix stashed, both poison tests fail with `IllegalArgumentException: invalid public key` (the exact 2EH symptom).
- Local `mvn verify` green: 514 tests, 0 failures, 0 errors, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm