### PR TITLE
T93: consolidate logging on log4j2 (Log shim + slf4j routing)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
 
-        <logback.version>1.4.14</logback.version>
         <bcprov.version>1.84</bcprov.version>
         <commons-text.version>1.15.0</commons-text.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
@@ -132,10 +131,11 @@
         </dependency>
 
 
+        <!-- Route slf4j to log4j-core so log4j2.xml governs all logging output -->
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.25.4</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/im/redpanda/core/Log.java
+++ b/src/main/java/im/redpanda/core/Log.java
@@ -18,7 +18,13 @@ public class Log {
 
   private static final Logger logger = LogManager.getLogger();
 
+  /**
+   * Legacy verbosity level, no longer consulted by {@link #put(String, int)} and {@link
+   * #putStd(String)} — log output is governed by log4j2.xml. Kept for compatibility (e.g. {@link
+   * ListenConsole}).
+   */
   public static int LEVEL = 10;
+
   private static AtomicInteger rating;
 
   public static void init(ServerContext serverContext) {
@@ -45,18 +51,24 @@ public class Log {
     }.start();
   }
 
+  /**
+   * Shim onto log4j: the legacy numeric level is mapped to log4j levels ({@code <= 50} to info,
+   * {@code <= 150} to debug, everything else to trace). Filtering is done exclusively by
+   * log4j2.xml, the legacy {@link #LEVEL} field is no longer consulted.
+   */
   public static void put(String msg, int level) {
-    if (level > LEVEL) {
-      return;
+    if (level <= 50) {
+      logger.info(msg);
+    } else if (level <= 150) {
+      logger.debug(msg);
+    } else {
+      logger.trace(msg);
     }
-    System.out.println("Log: " + msg);
   }
 
+  /** Shim onto log4j: standard messages are logged at info level. */
   public static void putStd(String msg) {
-    if (20 > LEVEL) {
-      return;
-    }
-    System.out.println("Log: " + msg);
+    logger.info(msg);
   }
 
   public static void putCritical(Throwable e) {

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -26,7 +26,7 @@
 
     <Loggers>
 
-        <Logger name="im.redpanda" level="all" additivity="false">
+        <Logger name="im.redpanda" level="info" additivity="false">
             <AppenderRef ref="Console"/>
             <AppenderRef ref="FileAppenderRolling"/>
         </Logger>

--- a/src/test/java/im/redpanda/core/LogShimTest.java
+++ b/src/test/java/im/redpanda/core/LogShimTest.java
@@ -1,0 +1,115 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the {@link Log#put(String, int)} / {@link Log#putStd(String)} shim maps the legacy
+ * numeric levels onto the intended log4j levels.
+ */
+class LogShimTest {
+
+  /** Logger name used by {@link Log}'s class-level {@code LogManager.getLogger()}. */
+  private static final String LOG_LOGGER_NAME = Log.class.getName();
+
+  private final List<LogEvent> events = new CopyOnWriteArrayList<>();
+  private LoggerContext context;
+  private CapturingAppender appender;
+
+  private final class CapturingAppender extends AbstractAppender {
+    private CapturingAppender() {
+      super("LogShimTestAppender", null, null, true, Property.EMPTY_ARRAY);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      events.add(event.toImmutable());
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    context = (LoggerContext) LogManager.getContext(false);
+    appender = new CapturingAppender();
+    appender.start();
+    Configuration configuration = context.getConfiguration();
+    LoggerConfig loggerConfig = new LoggerConfig(LOG_LOGGER_NAME, Level.ALL, false);
+    loggerConfig.addAppender(appender, Level.ALL, null);
+    configuration.addLogger(LOG_LOGGER_NAME, loggerConfig);
+    context.updateLoggers();
+  }
+
+  @AfterEach
+  void tearDown() {
+    context.getConfiguration().removeLogger(LOG_LOGGER_NAME);
+    context.updateLoggers();
+    appender.stop();
+  }
+
+  private Level levelOfSingleEvent() {
+    assertThat(events).hasSize(1);
+    return events.get(0).getLevel();
+  }
+
+  @Test
+  void t86EvictionLevel40MapsToInfo() {
+    // PeerJobs eviction messages use legacy level 40 and must be visible on info
+    Log.put("removed peer due to inactivity", 40);
+    assertThat(levelOfSingleEvent()).isEqualTo(Level.INFO);
+  }
+
+  @Test
+  void level50BoundaryMapsToInfo() {
+    Log.put("boundary", 50);
+    assertThat(levelOfSingleEvent()).isEqualTo(Level.INFO);
+  }
+
+  @Test
+  void level51MapsToDebug() {
+    Log.put("just above info boundary", 51);
+    assertThat(levelOfSingleEvent()).isEqualTo(Level.DEBUG);
+  }
+
+  @Test
+  void level150BoundaryMapsToDebug() {
+    Log.put("boundary", 150);
+    assertThat(levelOfSingleEvent()).isEqualTo(Level.DEBUG);
+  }
+
+  @Test
+  void level151MapsToTrace() {
+    Log.put("per-connection chatter", 151);
+    assertThat(levelOfSingleEvent()).isEqualTo(Level.TRACE);
+  }
+
+  @Test
+  void putStdMapsToInfo() {
+    Log.putStd("standard message");
+    assertThat(levelOfSingleEvent()).isEqualTo(Level.INFO);
+  }
+
+  @Test
+  void legacyLevelFieldNoLongerSuppressesOutput() {
+    int previous = Log.LEVEL;
+    try {
+      Log.LEVEL = 10;
+      Log.put("suppressed under the legacy gate, visible now", 40);
+      assertThat(levelOfSingleEvent()).isEqualTo(Level.INFO);
+    } finally {
+      Log.LEVEL = previous;
+    }
+  }
+}


### PR DESCRIPTION
## T93 (TD028+TD030): Consolidate logging on log4j2

The node log was simultaneously flooded and silent: ~76 of the 84 `Log.put`/`Log.putStd` call sites were dead in prod (`Log.LEVEL = 10` gate), including operationally valuable lines (T86 eviction, permanent-peer removal, handshake failures, garlic auth failures, DHT rejects). At the same time, 5 slf4j classes bound to logback without any logback.xml (root DEBUG default), while log4j2.xml set `im.redpanda` to `all`.

### Changes

1. **pom.xml**: drop `logback-classic`, add `log4j-slf4j2-impl:2.25.4` — slf4j now routes to log4j-core, so the bundled log4j2.xml governs all output. `dependency:tree` confirms logback is gone and there is exactly one slf4j binding.
2. **log4j2.xml**: `im.redpanda` logger `all` -> `info` (no more debug-default-on in prod on the log4j side).
3. **Log.java**: `Log.put`/`putStd` are now thin shims onto the existing log4j logger with a level map: `<= 50` -> info, `<= 150` -> debug, else trace; `putStd` -> info. All 84 call sites untouched. The legacy `LEVEL` field is no longer consulted by the shims (kept for `ListenConsole` compatibility).

### Verification

- New `LogShimTest` covers the level map incl. boundaries and verifies the T86 eviction level (40) lands on info, and that the legacy `LEVEL` gate no longer suppresses output.
- `mvn verify` green locally.
- Exactly one config file (log4j2.xml) now governs the entire node output.

Part of the agent-loop tech-debt triage (TD028 + TD030).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm
