### PR TITLE
fix(kademlia): enforce MAX_KEEP_TIME retention regardless of store size (T67)

### DIFF
--- a/src/main/java/im/redpanda/kademlia/KadStoreManager.java
+++ b/src/main/java/im/redpanda/kademlia/KadStoreManager.java
@@ -26,13 +26,24 @@ import java.util.concurrent.locks.ReentrantLock;
 public class KadStoreManager {
 
   /**
-   * Total stored content size (without keys) above which the periodic entry eviction sweep runs. A
-   * trailing {@code * 0} used to zero this out, so the sweep ran on every put once the store held
-   * anything at all, instead of only once it exceeds 10 MB.
+   * Total stored content size (without keys) above which the eviction sweep additionally applies
+   * the shorter, distance-based {@code keepTime} (space pressure). Below this threshold entries are
+   * kept for the full {@link #MAX_KEEP_TIME}: for a random id the XOR distance to our node is
+   * almost always ~160, which would collapse the distance-based retention to its 61-minute floor
+   * and effectively wipe small stores (the pre-L6 behavior, see PR #279). A trailing {@code * 0}
+   * used to zero this threshold out by accident.
+   *
+   * <p>T67 retention decision: expiry at {@code MAX_KEEP_TIME} is enforced on every node regardless
+   * of store size — by the periodic sweep in {@link #put(KadContent)} and lazily in {@link
+   * #get(KademliaId)} — so a node never serves or re-spreads a record that {@code put()} would
+   * reject as too old. Only the distance-based shortening stays gated on this size.
    */
   private static final int MIN_SIZE = 1024 * 1024 * 10;
 
-  /** How long a stored entry is kept before the eviction sweep may drop it: 14 days. */
+  /**
+   * Hard retention limit: 14 days. {@code put()} rejects anything older, the eviction sweep drops
+   * entries past this age even below {@link #MIN_SIZE}, and {@code get()} never returns them.
+   */
   private static final long MAX_KEEP_TIME = 1000L * 60L * 60L * 24L * 14L;
 
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
@@ -84,29 +95,36 @@ public class KadStoreManager {
       }
 
       // todo max size!
-      if (size > MIN_SIZE && currTime > lastCleanup + 1000L * 10L * 1L) {
+      // The sweep runs regardless of store size (throttled to ~10 s) so entries older than
+      // MAX_KEEP_TIME are evicted on every node, matching the put() age gate above (T67). The
+      // shorter distance-based keepTime only kicks in under space pressure (> MIN_SIZE).
+      if (currTime > lastCleanup + 1000L * 10L * 1L) {
         lastCleanup = currTime;
+        boolean spacePressure = size > MIN_SIZE;
 
         ArrayList<KademliaId> kademliaIds = new ArrayList<>();
 
         for (KadContent c : entries.values()) {
 
-          int distance = serverContext.getNonce().getDistance(c.getId());
+          long keepTime = MAX_KEEP_TIME;
 
-          // long keepTime = (long) Math.ceil(MAX_KEEP_TIME * (160 - distance) / 160);
-          long keepTime = (long) Math.ceil(1000L * 60L * 60L * 24L * (long) (160 - distance));
+          if (spacePressure) {
+            int distance = serverContext.getNonce().getDistance(c.getId());
 
-          keepTime =
-              Math.max(keepTime, 1000L * 60L * 61L); // at least 61 mins such that the maintenance
-          // routine can spread the entry
-          keepTime = Math.min(keepTime, MAX_KEEP_TIME); // max time
+            // long keepTime = (long) Math.ceil(MAX_KEEP_TIME * (160 - distance) / 160);
+            keepTime = (long) Math.ceil(1000L * 60L * 60L * 24L * (long) (160 - distance));
+
+            keepTime =
+                Math.max(keepTime, 1000L * 60L * 61L); // at least 61 mins such that the maintenance
+            // routine can spread the entry
+            keepTime = Math.min(keepTime, MAX_KEEP_TIME); // max time
+          }
 
           // System.out.println("keep time: " +
           // formatDuration(Duration.ofMillis(keepTime)) + " distance: " + distance);
           // System.out.println("id: " + Server.NONCE);
           // System.out.println("id: " + c.getId());
 
-          // todo: shorter times for key far away from our id
           if (c.getTimestamp() < currTime - keepTime) {
             kademliaIds.add(c.getId());
             // entries.remove(c.getId());
@@ -130,10 +148,25 @@ public class KadStoreManager {
     return get(KadContent.createKademliaId(node.getNodeId()));
   }
 
+  /**
+   * Returns the stored content for the given id, or {@code null} if there is none or it is older
+   * than {@link #MAX_KEEP_TIME}. Entries past that age are expired lazily here because the eviction
+   * sweep only runs from {@link #put(KadContent)} — a node that receives no puts must still never
+   * serve a record that {@code put()} would reject as too old (T67).
+   */
   public KadContent get(KademliaId id) {
     lock.lock();
     try {
-      return entries.get(id);
+      KadContent content = entries.get(id);
+      if (content == null) {
+        return null;
+      }
+      if (content.getTimestamp() < System.currentTimeMillis() - MAX_KEEP_TIME) {
+        entries.remove(id);
+        size -= content.getContent().length;
+        return null;
+      }
+      return content;
     } finally {
       lock.unlock();
     }
@@ -253,7 +286,13 @@ public class KadStoreManager {
   public static void maintain(ServerContext serverContext) {
     lock.lock();
     try {
+      long currTime = System.currentTimeMillis();
       for (KadContent kc : entries.values()) {
+        if (kc.getTimestamp() < currTime - MAX_KEEP_TIME) {
+          // do not re-spread entries every other node's put() would reject as too old (T67);
+          // the next sweep or get() will expire them
+          continue;
+        }
         new KademliaInsertJob(serverContext, kc).start();
       }
     } finally {

--- a/src/main/java/im/redpanda/kademlia/KadStoreManager.java
+++ b/src/main/java/im/redpanda/kademlia/KadStoreManager.java
@@ -18,6 +18,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.ScheduledFuture;
@@ -97,43 +98,46 @@ public class KadStoreManager {
       // todo max size!
       // The sweep runs regardless of store size (throttled to ~10 s) so entries older than
       // MAX_KEEP_TIME are evicted on every node, matching the put() age gate above (T67). The
-      // shorter distance-based keepTime only kicks in under space pressure (> MIN_SIZE).
+      // shorter distance-based keepTime only kicks in under space pressure (> MIN_SIZE),
+      // measured after the hard expiry pass so stale bulk cannot trigger it.
       if (currTime > lastCleanup + 1000L * 10L * 1L) {
         lastCleanup = currTime;
-        boolean spacePressure = size > MIN_SIZE;
 
-        ArrayList<KademliaId> kademliaIds = new ArrayList<>();
+        // pass 1: hard expiry at MAX_KEEP_TIME, independent of store size
+        expireEntriesOlderThan(currTime - MAX_KEEP_TIME);
 
-        for (KadContent c : entries.values()) {
+        // pass 2: distance-based shortening, only if the post-expiry store is still above
+        // MIN_SIZE
+        if (size > MIN_SIZE) {
+          ArrayList<KademliaId> kademliaIds = new ArrayList<>();
 
-          long keepTime = MAX_KEEP_TIME;
+          for (KadContent c : entries.values()) {
 
-          if (spacePressure) {
             int distance = serverContext.getNonce().getDistance(c.getId());
 
             // long keepTime = (long) Math.ceil(MAX_KEEP_TIME * (160 - distance) / 160);
-            keepTime = (long) Math.ceil(1000L * 60L * 60L * 24L * (long) (160 - distance));
+            long keepTime = (long) Math.ceil(1000L * 60L * 60L * 24L * (long) (160 - distance));
 
             keepTime =
                 Math.max(keepTime, 1000L * 60L * 61L); // at least 61 mins such that the maintenance
             // routine can spread the entry
             keepTime = Math.min(keepTime, MAX_KEEP_TIME); // max time
+
+            // System.out.println("keep time: " +
+            // formatDuration(Duration.ofMillis(keepTime)) + " distance: " + distance);
+            // System.out.println("id: " + Server.NONCE);
+            // System.out.println("id: " + c.getId());
+
+            if (c.getTimestamp() < currTime - keepTime) {
+              kademliaIds.add(c.getId());
+              // entries.remove(c.getId());
+              size -= c.getContent().length;
+            }
           }
 
-          // System.out.println("keep time: " +
-          // formatDuration(Duration.ofMillis(keepTime)) + " distance: " + distance);
-          // System.out.println("id: " + Server.NONCE);
-          // System.out.println("id: " + c.getId());
-
-          if (c.getTimestamp() < currTime - keepTime) {
-            kademliaIds.add(c.getId());
-            // entries.remove(c.getId());
-            size -= c.getContent().length;
+          for (KademliaId kadId : kademliaIds) {
+            entries.remove(kadId);
           }
-        }
-
-        for (KademliaId kadId : kademliaIds) {
-          entries.remove(kadId);
         }
       }
 
@@ -286,17 +290,29 @@ public class KadStoreManager {
   public static void maintain(ServerContext serverContext) {
     lock.lock();
     try {
-      long currTime = System.currentTimeMillis();
+      // expire instead of re-spreading entries every other node's put() would reject as too
+      // old (T67) — maintain() may be the only caller on a node that receives no puts
+      expireEntriesOlderThan(System.currentTimeMillis() - MAX_KEEP_TIME);
       for (KadContent kc : entries.values()) {
-        if (kc.getTimestamp() < currTime - MAX_KEEP_TIME) {
-          // do not re-spread entries every other node's put() would reject as too old (T67);
-          // the next sweep or get() will expire them
-          continue;
-        }
         new KademliaInsertJob(serverContext, kc).start();
       }
     } finally {
       lock.unlock();
+    }
+  }
+
+  /**
+   * Removes all entries with a timestamp older than the given cutoff and updates {@link #size}.
+   * Callers must hold {@link #lock}.
+   */
+  private static void expireEntriesOlderThan(long cutoff) {
+    Iterator<KadContent> iterator = entries.values().iterator();
+    while (iterator.hasNext()) {
+      KadContent c = iterator.next();
+      if (c.getTimestamp() < cutoff) {
+        size -= c.getContent().length;
+        iterator.remove();
+      }
     }
   }
 

--- a/src/test/java/im/redpanda/kademlia/KadStoreManagerMinSizeTest.java
+++ b/src/test/java/im/redpanda/kademlia/KadStoreManagerMinSizeTest.java
@@ -11,9 +11,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Regression test for L6 (bug hunt 2026-07-26): {@code MIN_SIZE} was declared as {@code 1024 * 1024
- * * 10 * 0}, so the periodic entry-eviction sweep was gated on {@code size > 0} and ran on every
- * put (throttled to ~10 s) instead of only once the store exceeds 10 MB.
+ * Regression tests for the {@code KadStoreManager} retention rules (L6 / bug hunt 2026-07-26 and
+ * the T67 follow-up):
+ *
+ * <ul>
+ *   <li>expiry at {@code MAX_KEEP_TIME} (14 days) is enforced regardless of store size — by the
+ *       periodic sweep in {@code put()} and lazily in {@code get()} — so a node never serves a
+ *       record that {@code put()} would reject as too old,
+ *   <li>the shorter, distance-based {@code keepTime} only applies above the 10 MB {@code MIN_SIZE}
+ *       gate (space pressure); below it, dropping the gate would collapse retention to the
+ *       61-minute floor for typical entries (XOR distance ~160) and wipe small stores.
+ * </ul>
  */
 class KadStoreManagerMinSizeTest {
 
@@ -34,25 +42,53 @@ class KadStoreManagerMinSizeTest {
     resetStore();
   }
 
-  /** Below the threshold the sweep must not run, so even a long-expired entry survives a put. */
+  /**
+   * Even below MIN_SIZE the sweep must drop entries older than MAX_KEEP_TIME: the map itself no
+   * longer contains the entry after a put (not just filtered by get()).
+   */
   @Test
-  void put_doesNotSweepWhileStoreIsBelowMinSize() throws Exception {
-    KadContent ancient = storeDirectly(100L * ONE_DAY_MS);
+  void put_evictsEntriesOlderThanMaxKeepTimeEvenBelowMinSize() throws Exception {
+    KadContent ancient = storeDirectly(100L * ONE_DAY_MS, null);
 
     assertThat(kadStoreManager.put(freshContent())).isTrue();
 
-    assertThat(kadStoreManager.get(ancient.getId())).isNotNull();
+    assertThat(rawEntries().containsKey(ancient.getId())).isFalse();
   }
 
-  /** Above the threshold the sweep runs and evicts entries past their keepTime. */
+  /**
+   * Below MIN_SIZE the distance-based shortening must NOT apply: a 2-day-old entry at the maximum
+   * XOR distance (keepTime would be the 61-minute floor under space pressure) survives the sweep.
+   */
   @Test
-  void put_sweepsOnceStoreExceedsMinSize() throws Exception {
-    KadContent ancient = storeDirectly(100L * ONE_DAY_MS);
+  void put_doesNotApplyDistanceBasedKeepTimeBelowMinSize() throws Exception {
+    KadContent recent = storeDirectly(2L * ONE_DAY_MS, idAtMaxDistanceFromUs());
+
+    assertThat(kadStoreManager.put(freshContent())).isTrue();
+
+    assertThat(kadStoreManager.get(recent.getId())).isNotNull();
+  }
+
+  /** Above MIN_SIZE the same 2-day-old, maximum-distance entry is evicted (keepTime 61 min). */
+  @Test
+  void put_appliesDistanceBasedKeepTimeAboveMinSize() throws Exception {
+    KadContent recent = storeDirectly(2L * ONE_DAY_MS, idAtMaxDistanceFromUs());
     setStaticField("size", 11 * 1024 * 1024);
 
     assertThat(kadStoreManager.put(freshContent())).isTrue();
 
+    assertThat(kadStoreManager.get(recent.getId())).isNull();
+  }
+
+  /**
+   * The sweep only runs from put(): a node receiving no puts must still never serve an entry older
+   * than MAX_KEEP_TIME — get() expires it lazily and removes it from the store.
+   */
+  @Test
+  void get_expiresEntriesOlderThanMaxKeepTime() throws Exception {
+    KadContent ancient = storeDirectly(100L * ONE_DAY_MS, null);
+
     assertThat(kadStoreManager.get(ancient.getId())).isNull();
+    assertThat(rawEntries().containsKey(ancient.getId())).isFalse();
   }
 
   private KadContent freshContent() {
@@ -60,17 +96,27 @@ class KadStoreManagerMinSizeTest {
   }
 
   /**
-   * Puts an entry straight into the backing map: {@code put()} itself rejects anything older than
-   * MAX_KEEP_TIME, and this entry has to be older than any possible keepTime.
+   * An id whose most significant bit differs from our node id: XOR distance 160, the worst case for
+   * the distance-based keepTime (clamped to the 61-minute floor).
    */
-  @SuppressWarnings("unchecked")
-  private KadContent storeDirectly(long ageMillis) throws Exception {
+  private KademliaId idAtMaxDistanceFromUs() {
+    byte[] bytes = serverContext.getNonce().getBytes().clone();
+    bytes[0] ^= (byte) 0x80;
+    return new KademliaId(bytes);
+  }
+
+  /**
+   * Puts an entry straight into the backing map: {@code put()} itself rejects anything older than
+   * MAX_KEEP_TIME. An optional forced id allows a deterministic XOR distance to our node id.
+   */
+  private KadContent storeDirectly(long ageMillis, KademliaId forcedId) throws Exception {
     KadContent content =
         new KadContent(System.currentTimeMillis() - ageMillis, randomKey(), new byte[16]);
+    if (forcedId != null) {
+      content.setId(forcedId);
+    }
 
-    Field entriesField = KadStoreManager.class.getDeclaredField("entries");
-    entriesField.setAccessible(true);
-    ((Map<KademliaId, KadContent>) entriesField.get(null)).put(content.getId(), content);
+    rawEntries().put(content.getId(), content);
     setStaticField("size", content.getContent().length);
 
     return content;
@@ -81,10 +127,14 @@ class KadStoreManagerMinSizeTest {
   }
 
   @SuppressWarnings("unchecked")
-  private static void resetStore() throws Exception {
+  private static Map<KademliaId, KadContent> rawEntries() throws Exception {
     Field entriesField = KadStoreManager.class.getDeclaredField("entries");
     entriesField.setAccessible(true);
-    ((Map<KademliaId, KadContent>) entriesField.get(null)).clear();
+    return (Map<KademliaId, KadContent>) entriesField.get(null);
+  }
+
+  private static void resetStore() throws Exception {
+    rawEntries().clear();
 
     setStaticField("size", 0);
     setStaticField("lastCleanup", 0L);

--- a/src/test/java/im/redpanda/kademlia/KadStoreManagerMinSizeTest.java
+++ b/src/test/java/im/redpanda/kademlia/KadStoreManagerMinSizeTest.java
@@ -80,6 +80,36 @@ class KadStoreManagerMinSizeTest {
   }
 
   /**
+   * Space pressure must be measured after the hard-expiry pass: if the store exceeds MIN_SIZE only
+   * because of stale (&gt;MAX_KEEP_TIME) bulk, the distance-based shortening must not fire and a
+   * 2-day-old, maximum-distance entry survives the sweep.
+   */
+  @Test
+  void put_ignoresStaleBulkWhenDecidingSpacePressure() throws Exception {
+    storeDirectly(100L * ONE_DAY_MS, null, new byte[11 * 1024 * 1024]);
+    KadContent recent = storeDirectly(2L * ONE_DAY_MS, idAtMaxDistanceFromUs());
+
+    assertThat(kadStoreManager.put(freshContent())).isTrue();
+
+    assertThat(kadStoreManager.get(recent.getId())).isNotNull();
+  }
+
+  /**
+   * maintain() may be the only regularly running entry point on a node that receives no puts and no
+   * gets: it must expire stale entries (map and size bookkeeping) instead of retaining them
+   * forever.
+   */
+  @Test
+  void maintain_expiresStaleEntriesInsteadOfRespreadingThem() throws Exception {
+    storeDirectly(100L * ONE_DAY_MS, null);
+
+    KadStoreManager.maintain(serverContext);
+
+    assertThat(rawEntries()).isEmpty();
+    assertThat(currentSize()).isZero();
+  }
+
+  /**
    * The sweep only runs from put(): a node receiving no puts must still never serve an entry older
    * than MAX_KEEP_TIME — get() expires it lazily and removes it from the store.
    */
@@ -105,21 +135,32 @@ class KadStoreManagerMinSizeTest {
     return new KademliaId(bytes);
   }
 
+  private KadContent storeDirectly(long ageMillis, KademliaId forcedId) throws Exception {
+    return storeDirectly(ageMillis, forcedId, new byte[16]);
+  }
+
   /**
    * Puts an entry straight into the backing map: {@code put()} itself rejects anything older than
    * MAX_KEEP_TIME. An optional forced id allows a deterministic XOR distance to our node id.
    */
-  private KadContent storeDirectly(long ageMillis, KademliaId forcedId) throws Exception {
+  private KadContent storeDirectly(long ageMillis, KademliaId forcedId, byte[] payload)
+      throws Exception {
     KadContent content =
-        new KadContent(System.currentTimeMillis() - ageMillis, randomKey(), new byte[16]);
+        new KadContent(System.currentTimeMillis() - ageMillis, randomKey(), payload);
     if (forcedId != null) {
       content.setId(forcedId);
     }
 
     rawEntries().put(content.getId(), content);
-    setStaticField("size", content.getContent().length);
+    setStaticField("size", currentSize() + payload.length);
 
     return content;
+  }
+
+  private static int currentSize() throws Exception {
+    Field field = KadStoreManager.class.getDeclaredField("size");
+    field.setAccessible(true);
+    return (int) field.get(null);
   }
 
   private static byte[] randomKey() {


### PR DESCRIPTION
Task **T67** — retention trade-off follow-up to the L6 fix (#279).

## Problem

With the restored 10 MB gate, a store below `MIN_SIZE` never evicts anything, and `get()` does not filter by age. A small node can therefore keep serving (and via `maintain()` keep re-spreading) records older than `MAX_KEEP_TIME` (14 days) — records its own `put()` rejects from the network. Asymmetric and inconsistent.

## Design decision (hybrid, KISS)

Neither pure option fits the code:

- **Dropping the size gate entirely** (option a) would re-introduce the pre-L6 wipe: for a random id the XOR distance to our node is almost always ~160, so the distance-based `keepTime` collapses to its 61-minute floor and a small store would evict virtually everything within an hour.
- **Keeping the behavior and only documenting it** (option b) leaves the put/get asymmetry in place.

So this PR enforces the **hard 14-day limit everywhere** while keeping the **distance-based shortening gated on space pressure**:

1. The throttled (~10 s) eviction sweep in `put()` now always runs; below `MIN_SIZE` it uses `keepTime = MAX_KEEP_TIME`, above it the existing distance-based shortening applies unchanged.
2. `get()` lazily expires entries older than `MAX_KEEP_TIME` (the sweep only runs from `put()`, so a node receiving no puts must still never serve stale records).
3. `maintain()` skips stale entries instead of re-spreading records every peer's `put()` would reject.

Result: `get()` can never return anything `put()` would reject, memory is bounded by time on every node, and small stores keep their full 14-day retention.

## Tests

`KadStoreManagerMinSizeTest` (rewritten, 4 tests, deterministic via a forced max-distance id):
- sweep evicts a 100-day entry below `MIN_SIZE` (regression for this PR)
- a 2-day, max-distance entry **survives** below the gate (no distance shortening)
- the same entry is **evicted** above the gate (distance shortening intact, L6 regression cover)
- `get()` lazily expires a 100-day entry without any put

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm
