### PR TITLE
T66: inbound accept budget against socket-exhaustion floods

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -454,10 +454,11 @@ public class ConnectionHandler extends Thread {
       // MAX_CONNECTIONS. Soft-eviction was rejected: picking and disconnecting a victim on the
       // selector thread touches peer write locks (the T87 lock-order hazard) for a state that only
       // an attack reaches. Returning with success == false lets the finally close the channel.
-      if (selector.keys().size() >= Settings.MAX_INBOUND_CONNECTIONS) {
+      int registeredSockets = selector.keys().size();
+      if (registeredSockets >= Settings.MAX_INBOUND_CONNECTIONS) {
         Log.put(
             "inbound connection rejected: socket budget exhausted ("
-                + selector.keys().size()
+                + registeredSockets
                 + " selector keys >= "
                 + Settings.MAX_INBOUND_CONNECTIONS
                 + ")",

--- a/src/main/java/im/redpanda/core/ConnectionHandler.java
+++ b/src/main/java/im/redpanda/core/ConnectionHandler.java
@@ -444,6 +444,27 @@ public class ConnectionHandler extends Thread {
     PeerInHandshake peerInHandshake = null;
     boolean success = false;
     try {
+      // T66: hard inbound budget. Light clients only identify themselves in the handshake, so an
+      // accept-time check cannot special-case them — capping here at MAX_CONNECTIONS would turn
+      // away legitimate mobile clients on a busy node (the reason redpandaj#278 added no such
+      // check). Instead we stop accepting only at a generous global socket budget: the selector
+      // key count covers every socket this layer owns, which is exactly the resource an accept
+      // flood exhausts. The node recovers below the ceiling on its own — PeerJobs reaps stale
+      // handshakes after HANDSHAKE_TIMEOUT_MS and the outbound loop trims connected peers toward
+      // MAX_CONNECTIONS. Soft-eviction was rejected: picking and disconnecting a victim on the
+      // selector thread touches peer write locks (the T87 lock-order hazard) for a state that only
+      // an attack reaches. Returning with success == false lets the finally close the channel.
+      if (selector.keys().size() >= Settings.MAX_INBOUND_CONNECTIONS) {
+        Log.put(
+            "inbound connection rejected: socket budget exhausted ("
+                + selector.keys().size()
+                + " selector keys >= "
+                + Settings.MAX_INBOUND_CONNECTIONS
+                + ")",
+            50);
+        return;
+      }
+
       socketChannel.configureBlocking(false);
 
       // null if the peer already reset the connection — routine for scanners, so handle it as a

--- a/src/main/java/im/redpanda/core/Settings.java
+++ b/src/main/java/im/redpanda/core/Settings.java
@@ -11,6 +11,19 @@ public class Settings {
   public static int STD_PORT = 59558;
   public static int MIN_CONNECTIONS = 20;
   public static int MAX_CONNECTIONS = 50;
+
+  /**
+   * Hard ceiling for accepting inbound connections (T66), enforced in {@code
+   * ConnectionHandler.setupAcceptedChannel} against the number of keys registered with the
+   * selector, i.e. every socket the networking layer owns. Deliberately far above {@link
+   * #MAX_CONNECTIONS} (4x): a light client is only recognizable once its handshake arrives, so an
+   * accept-time check cannot tell a mobile client from a flood — a cap at {@code MAX_CONNECTIONS}
+   * would reject legitimate clients on a busy node. Below this ceiling nothing is refused; at the
+   * ceiling new accepts are closed immediately, which bounds the file descriptors and handshake
+   * state an accept flood can pin.
+   */
+  public static int MAX_INBOUND_CONNECTIONS = 200;
+
   public static long pingTimeout = 65L * 1000L; // time in ms
   public static int pingDelay = 1000; // time in ms
   public static int peerListRequestDelay = 60 * 60; // time in sec

--- a/src/test/java/im/redpanda/core/ConnectionHandlerInboundCapTest.java
+++ b/src/test/java/im/redpanda/core/ConnectionHandlerInboundCapTest.java
@@ -1,0 +1,95 @@
+package im.redpanda.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetSocketAddress;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for the inbound accept budget (T66): {@code setupAcceptedChannel} must close a
+ * freshly accepted channel once the selector's socket budget ({@link
+ * Settings#MAX_INBOUND_CONNECTIONS}) is exhausted, and must keep accepting below it. The budget is
+ * measured against {@code ConnectionHandler.selector.keys().size()}, so the tests derive their
+ * thresholds from the current key count instead of assuming an empty selector — other test classes
+ * share the static selector.
+ */
+class ConnectionHandlerInboundCapTest {
+
+  private ConnectionHandler handler;
+  private int originalMaxInbound;
+
+  @BeforeEach
+  void setUp() {
+    ByteBufferPool.init();
+    handler = new ConnectionHandler(ServerContext.buildDefaultServerContext(), false);
+    originalMaxInbound = Settings.MAX_INBOUND_CONNECTIONS;
+  }
+
+  @AfterEach
+  void tearDown() {
+    Settings.MAX_INBOUND_CONNECTIONS = originalMaxInbound;
+    ConnectionHandler.peerInHandshakes.clear();
+  }
+
+  /** At the budget, the accepted channel is closed and no handshake state is created. */
+  @Test
+  void setupAcceptedChannel_rejectsWhenSocketBudgetExhausted() throws Exception {
+    try (ServerSocketChannel serverChannel = ServerSocketChannel.open();
+        SocketChannel client = SocketChannel.open()) {
+      serverChannel.bind(new InetSocketAddress("127.0.0.1", 0));
+      client.connect(serverChannel.getLocalAddress());
+
+      SocketChannel accepted = serverChannel.accept();
+      try {
+        int handshakesBefore = ConnectionHandler.peerInHandshakes.size();
+        // the budget is already used up by whatever is registered right now
+        Settings.MAX_INBOUND_CONNECTIONS = ConnectionHandler.selector.keys().size();
+
+        handler.setupAcceptedChannel(accepted);
+
+        assertThat(accepted.isOpen()).isFalse();
+        assertThat(ConnectionHandler.peerInHandshakes).hasSize(handshakesBefore);
+      } finally {
+        accepted.close();
+      }
+    }
+  }
+
+  /** One below the budget, the same channel is accepted and enters the handshake. */
+  @Test
+  void setupAcceptedChannel_acceptsBelowSocketBudget() throws Exception {
+    try (ServerSocketChannel serverChannel = ServerSocketChannel.open();
+        SocketChannel client = SocketChannel.open()) {
+      serverChannel.bind(new InetSocketAddress("127.0.0.1", 0));
+      client.connect(serverChannel.getLocalAddress());
+
+      SocketChannel accepted = serverChannel.accept();
+      PeerInHandshake createdHandshake = null;
+      try {
+        int handshakesBefore = ConnectionHandler.peerInHandshakes.size();
+        // exactly one accept still fits into the budget
+        Settings.MAX_INBOUND_CONNECTIONS = ConnectionHandler.selector.keys().size() + 1;
+
+        handler.setupAcceptedChannel(accepted);
+
+        assertThat(accepted.isOpen()).isTrue();
+        assertThat(ConnectionHandler.peerInHandshakes).hasSize(handshakesBefore + 1);
+        createdHandshake = ConnectionHandler.peerInHandshakes.get(handshakesBefore);
+      } finally {
+        if (createdHandshake != null) {
+          SelectionKey key = createdHandshake.getKey();
+          if (key != null) {
+            key.cancel();
+          }
+          handler.removePeerInHandshake(createdHandshake);
+        }
+        accepted.close();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## T66: Inbound-accept connection cap

### Design note (decision taken here, please carry into the backlog)

**Chosen: a separate, generous hard inbound budget — `Settings.MAX_INBOUND_CONNECTIONS = 200` (4x `MAX_CONNECTIONS`) — enforced at accept time against `selector.keys().size()`. Reject (close the accepted channel) only at that ceiling. No cap at `MAX_CONNECTIONS`, no soft-eviction.**

Reasoning:

1. **Light clients are only recognizable after the handshake.** `ConnectionReaderThread` sets the `lightClient` flag from the handshake magic, so at accept time a mobile client and a flood connection look identical. Any accept-time cap therefore has to be generous enough that legitimate clients never hit it — which is exactly why the H3 fix (#278) added no `MAX_CONNECTIONS` check on this path. That property is preserved: below the ceiling, nothing is refused.
2. **The selector key count is the right metric.** It counts every socket the networking layer owns (pending handshakes + established peers, inbound and outbound, plus the server socket) — precisely the resource an accept flood exhausts (file descriptors + handshake state). It is O(1), lock-free, and read on the selector thread itself, avoiding any peer-list locking in `keyAccept`/`setupAcceptedChannel` (T87: the selector thread must not park on the peer list).
3. **The node recovers below the ceiling on its own.** `PeerJobs` already reaps stale `PeerInHandshake`s after `HANDSHAKE_TIMEOUT_MS`, and the outbound loop trims connected peers toward `MAX_CONNECTIONS`. So the hard reject only ever fires while an active flood (or a genuine 200-socket overload) is in progress.
4. **Soft-eviction rejected.** Picking and disconnecting a victim from the selector thread touches peer write-buffer locks — the exact T87 lock-order hazard that wedged a seed node — and adds victim-selection policy for a state that in practice only an attack reaches. A hard reject at 4x normal capacity cannot hit legitimate clients under normal operation and is one comparison.

### Implementation

- `Settings.MAX_INBOUND_CONNECTIONS = 200` (mutable static, documented, overridable by tests like `MAX_CONNECTIONS`).
- `ConnectionHandler.setupAcceptedChannel`: budget check at the top of the existing try block; over budget → log + return, the existing `success == false` finally closes the channel. Placing it inside the try also keeps the established invariant that every failure path closes the accepted channel (H3), including a closed/broken selector.
- `Settings.NAT_OPEN` is still set in `keyAccept` before the check — an accepted TCP connection proves the NAT is open regardless of whether we keep it.

### Regression test

`ConnectionHandlerInboundCapTest` proves both sides of the boundary with real connected socket pairs:
- at the budget (`MAX_INBOUND_CONNECTIONS == current selector key count`): accepted channel closed, no `PeerInHandshake` created;
- one below the budget: same channel is accepted and enters the handshake.

Thresholds are derived from the live selector key count since the static selector is shared across test classes.

### Tests

- `mvn verify` green locally (full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm
