### PR TITLE
test: harden update-install test against Surefire fork CWD races (T70)

### DIFF
--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -214,12 +214,14 @@ public class InboundCommandProcessor {
   }
 
   /**
-   * Staging file a jar update is written to before being moved to {@link #updateInstallPath()}.
-   * Kept a sibling of the install destination so the {@code Files.move} never crosses a filesystem
-   * boundary (and so a test override relocates both files together).
+   * Staging file a jar update is written to before being moved to the given install destination.
+   * Derived as a sibling of that destination so the {@code Files.move} never crosses a filesystem
+   * boundary (and so a test override relocates both files together). Takes the already-resolved
+   * install path instead of re-reading the system property, so a property change mid-install (e.g.
+   * a test cleaning up after a timeout) cannot make the tmp file and the move destination diverge.
    */
-  static Path updateInstallTmpPath() {
-    return updateInstallPath().resolveSibling("tmp_redpanda.jar");
+  static Path updateInstallTmpPath(Path installPath) {
+    return installPath.resolveSibling("tmp_redpanda.jar");
   }
 
   /**
@@ -809,7 +811,10 @@ public class InboundCommandProcessor {
    */
   private void installJarUpdate(long othersTimestamp, byte[] signatureBytes, byte[] data) {
     installThreadHookForTests.accept(Thread.currentThread());
-    Path tmpPath = updateInstallTmpPath();
+    // Resolve the install path exactly once and derive the tmp path from it, so both stay
+    // consistent even if the overriding system property changes while the install is running.
+    Path installPath = updateInstallPath();
+    Path tmpPath = updateInstallTmpPath(installPath);
     try (FileOutputStream fos = new FileOutputStream(tmpPath.toFile())) {
       fos.write(data);
     } catch (IOException e) {
@@ -820,7 +825,7 @@ public class InboundCommandProcessor {
     try {
       // Install the update
       // Save to 'update' file so the shell script can pick it up and restart
-      Files.move(tmpPath, updateInstallPath(), StandardCopyOption.REPLACE_EXISTING);
+      Files.move(tmpPath, installPath, StandardCopyOption.REPLACE_EXISTING);
 
       // Update local settings
       serverContext.getLocalSettings().setUpdateTimestamp(othersTimestamp);
@@ -828,7 +833,10 @@ public class InboundCommandProcessor {
       serverContext.getLocalSettings().save(serverContext.getPort());
 
       System.out.println(
-          "Update successfully verified and saved to 'update'. New timestamp: " + othersTimestamp);
+          "Update successfully verified and saved to '"
+              + installPath
+              + "'. New timestamp: "
+              + othersTimestamp);
       System.out.println("Stopping server to apply update...");
 
       // Exit asynchronously to allow current method to return and log to be written

--- a/src/main/java/im/redpanda/core/InboundCommandProcessor.java
+++ b/src/main/java/im/redpanda/core/InboundCommandProcessor.java
@@ -169,6 +169,11 @@ public class InboundCommandProcessor {
   private static final String APK_PATH_PROPERTY = "redpanda.update.apk.path";
 
   /**
+   * System property overriding {@link #updateInstallPath()}; used by tests to avoid CWD sharing.
+   */
+  private static final String INSTALL_PATH_PROPERTY = "redpanda.update.install.path";
+
+  /**
    * Path of the local redpanda.jar that gets uploaded to peers requesting it. Defaults to the usual
    * seed-node vs. client layout, overridable via {@value #JAR_PATH_PROPERTY} (tests only, so
    * Surefire forks sharing the working directory don't collide).
@@ -192,6 +197,29 @@ public class InboundCommandProcessor {
       return override;
     }
     return Path.of(ConnectionReaderThread.ANDROID_UPDATE_FILE);
+  }
+
+  /**
+   * Destination a received-and-verified jar update is installed to (the {@code update} file the
+   * restart shell script picks up). Defaults to the CWD-relative {@code update} file, overridable
+   * via {@value #INSTALL_PATH_PROPERTY} (tests only, so Surefire forks sharing the working
+   * directory don't collide).
+   */
+  static Path updateInstallPath() {
+    Path override = pathOverride(INSTALL_PATH_PROPERTY);
+    if (override != null) {
+      return override;
+    }
+    return Path.of("update");
+  }
+
+  /**
+   * Staging file a jar update is written to before being moved to {@link #updateInstallPath()}.
+   * Kept a sibling of the install destination so the {@code Files.move} never crosses a filesystem
+   * boundary (and so a test override relocates both files together).
+   */
+  static Path updateInstallTmpPath() {
+    return updateInstallPath().resolveSibling("tmp_redpanda.jar");
   }
 
   /**
@@ -781,7 +809,8 @@ public class InboundCommandProcessor {
    */
   private void installJarUpdate(long othersTimestamp, byte[] signatureBytes, byte[] data) {
     installThreadHookForTests.accept(Thread.currentThread());
-    try (FileOutputStream fos = new FileOutputStream("tmp_redpanda.jar")) {
+    Path tmpPath = updateInstallTmpPath();
+    try (FileOutputStream fos = new FileOutputStream(tmpPath.toFile())) {
       fos.write(data);
     } catch (IOException e) {
       Log.sentry(e);
@@ -791,8 +820,7 @@ public class InboundCommandProcessor {
     try {
       // Install the update
       // Save to 'update' file so the shell script can pick it up and restart
-      Files.move(
-          Path.of("tmp_redpanda.jar"), Path.of("update"), StandardCopyOption.REPLACE_EXISTING);
+      Files.move(tmpPath, updateInstallPath(), StandardCopyOption.REPLACE_EXISTING);
 
       // Update local settings
       serverContext.getLocalSettings().setUpdateTimestamp(othersTimestamp);

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorUpdateHardeningTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorUpdateHardeningTest.java
@@ -3,34 +3,64 @@ package im.redpanda.core;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Covers the T10 (updater option B) hardening added to the UPDATE_ANSWER_CONTENT handler: rollback
  * protection via a build-time floor, a future-timestamp skew guard, and fail-closed behaviour when
  * no updater key is configured. See PLAN-updater-option-b.md, PR 1.
+ *
+ * <p>All update file paths are redirected into a per-test {@link TempDir} via the {@code
+ * redpanda.update.*.path} system properties (the PR #246 pattern): Surefire runs 8 forks sharing
+ * one working directory, and other classes (InboundCommandProcessorAsyncUpdatesTest,
+ * InboundCommandProcessorMoreCoverageTest) delete CWD-relative {@code tmp_redpanda.jar} in their
+ * cleanup, which could race this class's write/move window in another fork (T70 flakiness).
  */
 class InboundCommandProcessorUpdateHardeningTest {
 
   private static final int TEST_PORT = 49781;
+
+  private static final String INSTALL_PATH_PROPERTY = "redpanda.update.install.path";
+  private static final String APK_PATH_PROPERTY = "redpanda.update.apk.path";
+
+  @TempDir File tempDir;
+
+  /** Redirected install destination (CWD-relative {@code update} in production). */
+  private File updateFile;
+
+  /** Redirected staging file, always a sibling of {@link #updateFile}. */
+  private File tmpJarFile;
+
+  /** Redirected apk destination ({@link ConnectionReaderThread#ANDROID_UPDATE_FILE} in prod). */
+  private File apkFile;
 
   private ServerContext ctx;
   private InboundCommandProcessor proc;
 
   @BeforeEach
   void setup() {
+    updateFile = new File(tempDir, "update");
+    tmpJarFile = new File(tempDir, "tmp_redpanda.jar");
+    apkFile = new File(tempDir, "android.apk");
+    System.setProperty(INSTALL_PATH_PROPERTY, updateFile.getAbsolutePath());
+    System.setProperty(APK_PATH_PROPERTY, apkFile.getAbsolutePath());
+
     ctx = ServerContext.buildDefaultServerContext();
     ctx.setPort(TEST_PORT);
     proc = new InboundCommandProcessor(ctx);
@@ -41,12 +71,15 @@ class InboundCommandProcessorUpdateHardeningTest {
 
   @AfterEach
   void cleanup() {
+    System.clearProperty(INSTALL_PATH_PROPERTY);
+    System.clearProperty(APK_PATH_PROPERTY);
     Updater.resetPublicUpdaterKeyForTests();
-    InboundCommandProcessor.restartAction = () -> System.exit(0);
+    // Deliberately a no-op, NOT the production default System.exit(0): the positive-path tests
+    // wait for their delayed restart trigger, but if such a test fails/times out before the
+    // 2s-delayed background thread fires, restoring System.exit(0) here would let that straggler
+    // thread kill the whole Surefire fork mid-suite.
+    InboundCommandProcessor.restartAction = () -> {};
     InboundCommandProcessor.installThreadHookForTests = t -> {};
-    new File("tmp_redpanda.jar").delete();
-    new File("update").delete();
-    new File(ConnectionReaderThread.ANDROID_UPDATE_FILE).delete();
     new File(Settings.SAVE_DIR + "/localSettings" + TEST_PORT + ".dat").delete();
   }
 
@@ -88,8 +121,8 @@ class InboundCommandProcessorUpdateHardeningTest {
     int consumed = proc.parseCommand(Command.UPDATE_ANSWER_CONTENT, in, newPeer(8801));
 
     assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
-    assertFalse(new File("tmp_redpanda.jar").exists(), "tmp file must not be written");
-    assertFalse(new File("update").exists(), "update file must not be written");
+    assertFalse(tmpJarFile.exists(), "tmp file must not be written");
+    assertFalse(updateFile.exists(), "update file must not be written");
     assertEquals(localTs, ctx.getLocalSettings().getUpdateTimestamp());
   }
 
@@ -114,8 +147,8 @@ class InboundCommandProcessorUpdateHardeningTest {
     int consumed = proc.parseCommand(Command.UPDATE_ANSWER_CONTENT, in, newPeer(8802));
 
     assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
-    assertFalse(new File("tmp_redpanda.jar").exists(), "tmp file must not be written");
-    assertFalse(new File("update").exists(), "update file must not be written");
+    assertFalse(tmpJarFile.exists(), "tmp file must not be written");
+    assertFalse(updateFile.exists(), "update file must not be written");
     assertEquals(-1L, ctx.getLocalSettings().getUpdateTimestamp());
   }
 
@@ -133,8 +166,8 @@ class InboundCommandProcessorUpdateHardeningTest {
         1 + 8 + 4 + sig.length + data.length,
         consumed,
         "handler must report exactly the consumed byte length or the parser desyncs");
-    assertFalse(new File("tmp_redpanda.jar").exists(), "tmp file must not be written");
-    assertFalse(new File("update").exists(), "update file must not be written");
+    assertFalse(tmpJarFile.exists(), "tmp file must not be written");
+    assertFalse(updateFile.exists(), "update file must not be written");
   }
 
   @Test
@@ -152,8 +185,8 @@ class InboundCommandProcessorUpdateHardeningTest {
     int consumed = proc.parseCommand(Command.UPDATE_ANSWER_CONTENT, in, newPeer(8804));
 
     assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
-    assertFalse(new File("tmp_redpanda.jar").exists(), "tmp file must not be written");
-    assertFalse(new File("update").exists(), "update file must not be written");
+    assertFalse(tmpJarFile.exists(), "tmp file must not be written");
+    assertFalse(updateFile.exists(), "update file must not be written");
     assertEquals(-1L, ctx.getLocalSettings().getUpdateTimestamp());
   }
 
@@ -162,8 +195,17 @@ class InboundCommandProcessorUpdateHardeningTest {
     NodeId testKey = new NodeId();
     Updater.setPublicUpdaterKeyForTests(testKey);
 
+    // The restart trigger is the last step of the install (fired 2s after the jar is moved into
+    // place and the settings are saved), so it is the one deterministic "install finished" signal:
+    // once the latch opens, all other side effects are visible and can be asserted directly
+    // instead of being polled for.
     AtomicInteger restartCount = new AtomicInteger();
-    InboundCommandProcessor.restartAction = restartCount::incrementAndGet;
+    CountDownLatch restartLatch = new CountDownLatch(1);
+    InboundCommandProcessor.restartAction =
+        () -> {
+          restartCount.incrementAndGet();
+          restartLatch.countDown();
+        };
 
     byte[] data = "fake-jar-bytes".getBytes();
     long othersTs = Updater.MIN_UPDATE_TIMESTAMP_MS + 1_000_000L;
@@ -177,19 +219,17 @@ class InboundCommandProcessorUpdateHardeningTest {
     int consumed = proc.parseCommand(Command.UPDATE_ANSWER_CONTENT, in, newPeer(8805));
     assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
 
-    File updateFile = new File("update");
-    awaitCondition(updateFile::exists, 5000);
+    // Waiting for the restart also guarantees the 2s-delayed background thread does not outlive
+    // this test method (in the success path) and fire into a later test.
+    assertTrue(restartLatch.await(10, TimeUnit.SECONDS), "restart action not invoked within 10 s");
+    assertEquals(1, restartCount.get());
+
+    assertTrue(updateFile.exists(), "update file must exist after the install completed");
     assertTrue(
         java.util.Arrays.equals(data, Files.readAllBytes(updateFile.toPath())),
         "installed update file must contain the received data");
-
     assertEquals(othersTs, ctx.getLocalSettings().getUpdateTimestamp());
     assertTrue(java.util.Arrays.equals(sig, ctx.getLocalSettings().getUpdateSignature()));
-
-    // The restart happens 2s after installing, asynchronously; wait for it and make sure the
-    // JVM (this test process) is still alive to observe it.
-    awaitCondition(() -> restartCount.get() == 1, 5000);
-    assertEquals(1, restartCount.get());
   }
 
   @Test
@@ -201,17 +241,17 @@ class InboundCommandProcessorUpdateHardeningTest {
     NodeId testKey = new NodeId();
     Updater.setPublicUpdaterKeyForTests(testKey);
 
-    // Must not fall through to the default restartAction (System.exit(0)) — this test's install
-    // really does succeed and reach the restart trigger 2s later, on a background thread that
-    // outlives this test method. If we returned before it fires, @After's cleanup() would already
-    // have reset restartAction back to the System.exit(0) default by the time it does, killing the
-    // Surefire fork mid-suite — so, like validUpdate_installs_andInvokesRestartAction, we must wait
-    // for it here instead of just no-op-ing and returning early.
+    // Deterministic "install finished" signal, same as validUpdate_installs_andInvokesRestartAction
+    // (see comment there): await the restart latch, then assert all side effects directly.
     AtomicInteger restartCount = new AtomicInteger();
-    InboundCommandProcessor.restartAction = restartCount::incrementAndGet;
+    CountDownLatch restartLatch = new CountDownLatch(1);
+    InboundCommandProcessor.restartAction =
+        () -> {
+          restartCount.incrementAndGet();
+          restartLatch.countDown();
+        };
 
-    java.util.concurrent.atomic.AtomicReference<Thread> writerThread =
-        new java.util.concurrent.atomic.AtomicReference<>();
+    AtomicReference<Thread> writerThread = new AtomicReference<>();
     InboundCommandProcessor.installThreadHookForTests = writerThread::set;
 
     byte[] data = "fake-jar-bytes-for-offload-check".getBytes();
@@ -227,18 +267,15 @@ class InboundCommandProcessorUpdateHardeningTest {
     int consumed = proc.parseCommand(Command.UPDATE_ANSWER_CONTENT, in, newPeer(8814));
     assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
 
-    File updateFile = new File("update");
-    awaitCondition(updateFile::exists, 5000);
-    awaitCondition(() -> writerThread.get() != null, 5000);
+    assertTrue(restartLatch.await(10, TimeUnit.SECONDS), "restart action not invoked within 10 s");
+    assertEquals(1, restartCount.get());
 
+    assertTrue(updateFile.exists(), "update file must exist after the install completed");
+    assertNotNull(writerThread.get(), "install thread hook must have fired before the restart");
     assertNotEquals(
         callingThread,
         writerThread.get(),
         "the jar write/install must not run on the calling (reader) thread");
-
-    // Wait for the delayed restart trigger too (see comment above) so cleanup() doesn't race it.
-    awaitCondition(() -> restartCount.get() == 1, 5000);
-    assertEquals(1, restartCount.get());
   }
 
   @Test
@@ -261,13 +298,14 @@ class InboundCommandProcessorUpdateHardeningTest {
     int consumed = proc.parseCommand(Command.ANDROID_UPDATE_ANSWER_CONTENT, in, newPeer(8815));
     assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
 
-    File apkFile = new File(ConnectionReaderThread.ANDROID_UPDATE_FILE);
-    awaitCondition(apkFile::exists, 5000);
+    // There is no restart trigger on the android path, so the last observable install step is the
+    // settings timestamp (set after the apk write); once it lands, apk file and signature are
+    // stable and can be asserted directly.
+    awaitCondition(() -> ctx.getLocalSettings().getUpdateAndroidTimestamp() == othersTs, 10_000);
+    assertTrue(apkFile.exists(), "apk file must exist after the install completed");
     assertTrue(
         java.util.Arrays.equals(data, Files.readAllBytes(apkFile.toPath())),
         "installed apk file must contain the received data");
-
-    awaitCondition(() -> ctx.getLocalSettings().getUpdateAndroidTimestamp() == othersTs, 5000);
     assertTrue(java.util.Arrays.equals(sig, ctx.getLocalSettings().getUpdateAndroidSignature()));
   }
 
@@ -284,7 +322,7 @@ class InboundCommandProcessorUpdateHardeningTest {
 
     assertEquals(0, consumed);
     assertFalse(peer.isConnected(), "peer must be disconnected on negative content length");
-    assertFalse(new File("tmp_redpanda.jar").exists(), "tmp file must not be written");
+    assertFalse(tmpJarFile.exists(), "tmp file must not be written");
   }
 
   @Test
@@ -300,9 +338,7 @@ class InboundCommandProcessorUpdateHardeningTest {
 
     assertEquals(0, consumed);
     assertFalse(peer.isConnected(), "peer must be disconnected on negative android content length");
-    assertFalse(
-        new File(ConnectionReaderThread.ANDROID_UPDATE_FILE).exists(),
-        "apk file must not be written");
+    assertFalse(apkFile.exists(), "apk file must not be written");
   }
 
   @Test
@@ -316,9 +352,7 @@ class InboundCommandProcessorUpdateHardeningTest {
     int consumed = proc.parseCommand(Command.ANDROID_UPDATE_ANSWER_CONTENT, in, newPeer(8808));
 
     assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
-    assertFalse(
-        new File(ConnectionReaderThread.ANDROID_UPDATE_FILE).exists(),
-        "apk file must not be written");
+    assertFalse(apkFile.exists(), "apk file must not be written");
   }
 
   @Test
@@ -331,9 +365,7 @@ class InboundCommandProcessorUpdateHardeningTest {
     int consumed = proc.parseCommand(Command.ANDROID_UPDATE_ANSWER_CONTENT, in, newPeer(8809));
 
     assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
-    assertFalse(
-        new File(ConnectionReaderThread.ANDROID_UPDATE_FILE).exists(),
-        "apk file must not be written");
+    assertFalse(apkFile.exists(), "apk file must not be written");
     assertEquals(0L, ctx.getLocalSettings().getUpdateAndroidTimestamp());
   }
 

--- a/src/test/java/im/redpanda/core/InboundCommandProcessorUpdateHardeningTest.java
+++ b/src/test/java/im/redpanda/core/InboundCommandProcessorUpdateHardeningTest.java
@@ -298,15 +298,18 @@ class InboundCommandProcessorUpdateHardeningTest {
     int consumed = proc.parseCommand(Command.ANDROID_UPDATE_ANSWER_CONTENT, in, newPeer(8815));
     assertEquals(1 + 8 + 4 + sig.length + data.length, consumed);
 
-    // There is no restart trigger on the android path, so the last observable install step is the
-    // settings timestamp (set after the apk write); once it lands, apk file and signature are
-    // stable and can be asserted directly.
-    awaitCondition(() -> ctx.getLocalSettings().getUpdateAndroidTimestamp() == othersTs, 10_000);
+    // There is no restart trigger on the android path, so poll for the last observable install
+    // step instead: installApkUpdate writes the apk, then sets the timestamp, then the signature
+    // (Copilot review: waiting on the timestamp alone could pass before the signature is set).
+    // Once the signature matches, timestamp and apk file are stable and can be asserted directly.
+    awaitCondition(
+        () -> java.util.Arrays.equals(sig, ctx.getLocalSettings().getUpdateAndroidSignature()),
+        10_000);
+    assertEquals(othersTs, ctx.getLocalSettings().getUpdateAndroidTimestamp());
     assertTrue(apkFile.exists(), "apk file must exist after the install completed");
     assertTrue(
         java.util.Arrays.equals(data, Files.readAllBytes(apkFile.toPath())),
         "installed apk file must contain the received data");
-    assertTrue(java.util.Arrays.equals(sig, ctx.getLocalSettings().getUpdateAndroidSignature()));
   }
 
   @Test


### PR DESCRIPTION
## Problem

`InboundCommandProcessorUpdateHardeningTest.validUpdate_offloadsDiskWriteToThreadPool` is on the known-flaky list. It polled a **fixed CWD-relative `update` file** for 5 s. Surefire runs `forkCount=8` with a shared working directory, and `installJarUpdate` wrote hardcoded `tmp_redpanda.jar` -> `Files.move` -> `update` in that shared CWD. Other test classes (`InboundCommandProcessorAsyncUpdatesTest`, `InboundCommandProcessorMoreCoverageTest`) delete CWD `tmp_redpanda.jar` in their cleanup — running in another fork, that delete can land in the write->move window, the move fails, no `update` file ever appears, and the 5 s poll times out. Same fork-CWD-coupling class as fixed in #246 for `redpanda.jar` (`redpanda.update.jar.path`) and by the per-fork `redpanda.android.update.file` property.

## Changes

**Production (`InboundCommandProcessor`)** — no behavior change with the property unset:
- new `redpanda.update.install.path` property + `updateInstallPath()` (default `update`, the #246 pattern)
- `updateInstallTmpPath()` derives the `tmp_redpanda.jar` staging file as a **sibling** of the install destination, so `Files.move` never crosses a filesystem boundary and a test override relocates both files together
- `installJarUpdate` uses these paths instead of hardcoded literals

**Test (`InboundCommandProcessorUpdateHardeningTest`)**:
- `@TempDir` + both path properties (`redpanda.update.install.path`, `redpanda.update.apk.path`) redirect all update files into a per-test temp dir; all file assertions follow. The class no longer touches any shared CWD file.
- Deterministic signal instead of file polling: the restart trigger is the *last* step of the jar install, so both positive-path jar tests await a `CountDownLatch` on `restartAction` and then assert file content/settings/writer thread directly.
- `cleanup()` resets `restartAction` to a **no-op** instead of the production default `System.exit(0)`: if a positive-path test times out before its 2 s-delayed restart thread fires, restoring `System.exit(0)` would let that straggler kill the whole Surefire fork mid-suite.
- Remaining poll (android path, which has no restart signal) bumped to 10 s.

## Verification

- `mvn test -Dtest=InboundCommandProcessorUpdateHardeningTest` 6x green locally (15 tests each)
- full `mvn verify` green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm