### PR TITLE
docs(channel-dht): point at the mobile record-format cross-check (TD022)

### DIFF
--- a/src/main/java/im/redpanda/outbound/ChannelDht.java
+++ b/src/main/java/im/redpanda/outbound/ChannelDht.java
@@ -69,6 +69,14 @@ public final class ChannelDht {
    * every record of a different size, so nodes on the old bucket drop records published by upgraded
    * clients and vice versa. Roll the network out before the clients; channels whose record is
    * dropped in the meantime keep healing over the in-band {@code oh_update} announce.
+   *
+   * <p>The clients are gated on this constant (TD022): redpanda-mobile's e2e suite {@code
+   * channel_record_format_crosscheck_test.dart} runs this class out of the downloaded {@code
+   * redpanda.jar} of our <em>latest release</em> and fails by name if its own {@code
+   * ChannelRendezvous.recordSizeBytes} — or the derived key, rotating Kademlia id or record
+   * signature — disagrees. So changing the format here turns the mobile CI red as soon as this
+   * lands in a release, which is the intended reminder to ship the client change; it is not a
+   * mobile regression.
    */
   public static final int RECORD_SIZE_BYTES = 1024;
 

--- a/src/test/java/im/redpanda/outbound/ChannelDhtTest.java
+++ b/src/test/java/im/redpanda/outbound/ChannelDhtTest.java
@@ -118,6 +118,16 @@ class ChannelDhtTest {
     // (channel_rendezvous_test.dart). Both sides sign the same bytes, so a one-sided change to
     // RECORD_SIZE_BYTES — the kind that silently makes every published record undeliverable —
     // fails here instead of in the field.
+    //
+    // TD022: this vector is only half of the check. It keeps THIS side from drifting away from
+    // its own constant, but a hand-copied twin in the other repo cannot notice that the two
+    // disagree. The live half lives in redpanda-mobile's e2e suite
+    // channel_record_format_crosscheck_test.dart, which computes these same values by running
+    // ChannelDht out of the downloaded redpanda.jar of our latest release and comparing them
+    // against ChannelRendezvous. So when a deliberate format change makes this test red, the
+    // fix is not "regenerate the vector" alone: update the same vector in
+    // channel_rendezvous_test.dart, and expect mobile CI to go red — by name, with the
+    // deployment-order hint — from the release that ships this change until the client follows.
     byte[] secret = new byte[32];
     for (int i = 0; i < secret.length; i++) {
       secret[i] = (byte) i;


### PR DESCRIPTION
Comment-only companion to redpanda-mobile#95 (TD022, fix direction (c)).

## Why

The channel-rendezvous record format is a two-sided contract with no version byte on the wire, and this repo is where breaking changes to it originate. When `RECORD_SIZE_BYTES` went 512 → 1024 in #289 and shipped in a release before the client followed, mobile `main` published 512-byte records into 1024-byte nodes. Nothing named the cause — the only symptom was `t44_rendezvous_heal` burning its recovery budget on the mobile side, written off as a timing flake.

Direction (a) landed in #298 (`WRONG_SIZE` now logs a WARN with expected/actual). (c) is the CI gate, and it lives on the mobile side because that is the CI that downloads our `latest` release JAR: `channel_record_format_crosscheck_test.dart` runs `ChannelDht` straight out of that JAR and compares bucket size, record TTL, derived record pubkey, rotating kademlia id and record signature against its own `ChannelRendezvous`.

That gate is completely invisible from this repo — and it is the wrong thing to learn by surprise. A deliberate format change here turns mobile CI red from the release that ships it until the client catches up. That is the intended reminder, not a mobile regression, and the person changing the format should know it before they merge, not after.

## What

Two comments, no behaviour change, pinned vector untouched:

- `ChannelDht.RECORD_SIZE_BYTES` javadoc — extends the existing "changing this is a breaking protocol change" paragraph with the concrete consequence in mobile CI.
- `ChannelDhtTest.buildRecordContent_matchesTheClientCrossCheckVector` — spells out that this pinned vector is only half the check. It keeps *this* side from drifting away from its own constant, but a hand-copied twin in the other repo cannot notice that the two disagree with each other; the live half is the mobile suite. So when a deliberate format change makes this test red, "regenerate the vector" is not the whole fix — the twin in `channel_rendezvous_test.dart` has to move too.

## Validation

`mvn verify` — exit 0 (SpotBugs findings in the output are the pre-existing ones on generated proto/store classes, unchanged by this PR).

## Note on ordering

This is a test/comment-only change, so it produces **no new release** and the JAR mobile CI downloads does not move. redpanda-mobile#95 is therefore independent of this PR and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm