### PR TITLE
T99: judged dead-code deletion round (TD042/TD043)

### DIFF
--- a/src/main/java/im/redpanda/core/ConnectionReaderThread.java
+++ b/src/main/java/im/redpanda/core/ConnectionReaderThread.java
@@ -750,8 +750,4 @@ public class ConnectionReaderThread implements Runnable {
     byteBuffer.position(byteBuffer.position() + length);
     return new String(byteBuffer.array(), byteBuffer.arrayOffset(), length);
   }
-
-  public static KademliaId parseKademliaId(ByteBuffer byteBuffer) {
-    return KademliaId.fromBuffer(byteBuffer);
-  }
 }

--- a/src/main/java/im/redpanda/core/KademliaId.java
+++ b/src/main/java/im/redpanda/core/KademliaId.java
@@ -5,7 +5,6 @@
  */
 package im.redpanda.core;
 
-import im.redpanda.crypt.AddressFormatException;
 import im.redpanda.crypt.Base58;
 import im.redpanda.crypt.Utils;
 import java.io.Serializable;
@@ -13,9 +12,12 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.Arrays;
-import java.util.BitSet;
 
 public class KademliaId implements Serializable {
+
+  // Pinned to the value computed before the 2026-08 dead-code removal (T99): instances are
+  // Java-serialized to disk (localSettings.dat, node store), so the UID must stay stable.
+  private static final long serialVersionUID = 4978904080119646082L;
 
   public static final transient int ID_LENGTH = 160;
   public static final transient int ID_LENGTH_BYTES = ID_LENGTH / 8;
@@ -160,46 +162,6 @@ public class KademliaId implements Serializable {
   }
 
   /**
-   * Generates a NodeId that is some distance away from this NodeId
-   *
-   * @param distance in number of bits
-   * @return NodeId The newly generated NodeId
-   */
-  public KademliaId generateNodeIdByDistance(int distance) {
-    byte[] result = new byte[ID_LENGTH / 8];
-
-    /*
-     * Since distance = ID_LENGTH - prefixLength, we need to fill that amount with
-     * 0's
-     */
-    int numByteZeroes = (ID_LENGTH - distance) / 8;
-    int numBitZeroes = 8 - (distance % 8);
-
-    /* Filling byte zeroes */
-    for (int i = 0; i < numByteZeroes; i++) {
-      result[i] = 0;
-    }
-
-    /* Filling bit zeroes */
-    BitSet bits = new BitSet(8);
-    bits.set(0, 8);
-
-    for (int i = 0; i < numBitZeroes; i++) {
-      /* Shift 1 zero into the start of the value */
-      bits.clear(i);
-    }
-    bits.flip(0, 8); // Flip the bits since they're in reverse order
-    result[numByteZeroes] = bits.toByteArray()[0];
-
-    /* Set the remaining bytes to Maximum value */
-    for (int i = numByteZeroes + 1; i < result.length; i++) {
-      result[i] = Byte.MAX_VALUE;
-    }
-
-    return this.xor(new KademliaId(result));
-  }
-
-  /**
    * Counts the number of leading 0's in this NodeId
    *
    * @return Integer The number of leading 0's
@@ -254,10 +216,6 @@ public class KademliaId implements Serializable {
   @Override
   public String toString() {
     return Base58.encode(keyBytes).substring(0, 10);
-  }
-
-  public static KademliaId fromBase58(String base58String) throws AddressFormatException {
-    return new KademliaId(Base58.decode(base58String));
   }
 
   /**

--- a/src/main/java/im/redpanda/core/NodeId.java
+++ b/src/main/java/im/redpanda/core/NodeId.java
@@ -38,6 +38,10 @@ import org.bouncycastle.crypto.signers.Ed25519Signer;
  */
 public class NodeId implements Serializable {
 
+  // Pinned to the value computed before the 2026-08 dead-code removal (T99): instances are
+  // Java-serialized to disk (localSettings.dat, node store), so the UID must stay stable.
+  private static final long serialVersionUID = 2928261161442787061L;
+
   /** Public export length: 32-byte Ed25519 verify key + 32-byte X25519 encryption key. */
   public static final int PUBLIC_KEYLEN = 64;
 
@@ -202,12 +206,6 @@ public class NodeId implements Serializable {
       throw new IllegalArgumentException("public keys in private export do not match private keys");
     }
     return new NodeId(signing, verify, encryption, encryptionPub);
-  }
-
-  public static NodeId fromBufferGetPublic(ByteBuffer buffer) {
-    byte[] publicKeyBytes = new byte[PUBLIC_KEYLEN];
-    buffer.get(publicKeyBytes);
-    return importPublic(publicKeyBytes);
   }
 
   /** Signs the bytes with Ed25519 — deterministic 64-byte signature (no hashing beforehand). */

--- a/src/main/java/im/redpanda/core/PeerInHandshake.java
+++ b/src/main/java/im/redpanda/core/PeerInHandshake.java
@@ -238,15 +238,6 @@ public class PeerInHandshake {
     this.nodeId = nodeId;
   }
 
-  public boolean isProtocolV23() {
-    return protocolVersion >= 23;
-  }
-
-  /** True if we opened this connection — the TCP "client" role of the v23 key schedule. */
-  public boolean isInitiatedByUs() {
-    return initiatedByUs;
-  }
-
   // -------------------------------------------------------------------------------------------
   // v23: ephemeral X25519 key exchange + HKDF key schedule
   // -------------------------------------------------------------------------------------------
@@ -261,10 +252,6 @@ public class PeerInHandshake {
 
   public void setEphemeralPublicFromThem(byte[] ephemeralPublicFromThem) {
     this.ephemeralPublicFromThem = ephemeralPublicFromThem;
-  }
-
-  public byte[] getEphemeralPublicFromThem() {
-    return ephemeralPublicFromThem;
   }
 
   /**
@@ -374,9 +361,5 @@ public class PeerInHandshake {
 
   public void setProtocolVersion(int protocolVersion) {
     this.protocolVersion = protocolVersion;
-  }
-
-  public int getProtocolVersion() {
-    return protocolVersion;
   }
 }

--- a/src/main/java/im/redpanda/core/PeerList.java
+++ b/src/main/java/im/redpanda/core/PeerList.java
@@ -1,12 +1,9 @@
 package im.redpanda.core;
 
-import im.redpanda.kademlia.PeerComparator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.jetbrains.annotations.Nullable;
@@ -98,7 +95,7 @@ public class PeerList {
 
   private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
 
-  public PeerList(ServerContext serverContext) {
+  public PeerList() {
     initBlacklist();
   }
 
@@ -481,63 +478,6 @@ public class PeerList {
     Log.put("clearing peer: " + peer.getIp() + ":" + peer.getPort(), 50);
     removeIpPortOnly(peer);
     peer.removeIpAndPort();
-  }
-
-  /**
-   * does not use connected peers or light clients
-   *
-   * @param targetId
-   * @return
-   */
-  public Peer getClosestGoodPeer(KademliaId targetId) {
-
-    Peer goodPeer = get(targetId);
-    if (goodPeer == null || !goodPeer.isConnected()) {
-
-      TreeSet<Peer> peers = new TreeSet<>(new PeerComparator(targetId));
-
-      // insert all nodes
-      Lock lock = getReadWriteLock().readLock();
-      lock.lock();
-      try {
-        ArrayList<Peer> peerArrayList = getPeerArrayList();
-
-        for (Peer peer : peerArrayList) {
-
-          // do not add the peer if the peer is not connected or the nodeId is unknown!
-          if (peer.getNodeId() == null || !peer.isConnected()) {
-            continue;
-          }
-
-          // remove all light clients
-          if (peer.isLightClient()) {
-            continue;
-          }
-
-          if (peer.getNode() == null) {
-            continue;
-          }
-
-          // if (targetId.getDistanceToUs(serverContext) <
-          // peer.getKademliaId().getDistance(targetId)) {
-          // continue;
-          // }
-
-          peers.add(peer);
-        }
-      } finally {
-        lock.unlock();
-      }
-
-      if (peers.size() == 0) {
-        // System.out.println(String.format("no peer found for destination %s which is
-        // near to target", targetId));
-        return null;
-      }
-
-      goodPeer = peers.first();
-    }
-    return goodPeer;
   }
 
   private void initBlacklist() {

--- a/src/main/java/im/redpanda/core/ServerContext.java
+++ b/src/main/java/im/redpanda/core/ServerContext.java
@@ -17,7 +17,7 @@ public class ServerContext {
   private int port;
   private LocalSettings localSettings;
   private final KadStoreManager kadStoreManager = new KadStoreManager(this);
-  private PeerList peerList = new PeerList(this);
+  private PeerList peerList = new PeerList();
   private NodeStore nodeStore;
   private Node node;
   private NodeId nodeId;

--- a/src/main/java/im/redpanda/outbound/OutboundHandleStore.java
+++ b/src/main/java/im/redpanda/outbound/OutboundHandleStore.java
@@ -31,13 +31,11 @@ public class OutboundHandleStore {
     private byte[] ohAuthPublicKey;
     private long createdAtMs;
     private long expiresAtMs;
-    private long lastSeenMs;
 
     public HandleRecord(byte[] ohAuthPublicKey, long createdAtMs, long expiresAtMs) {
       this.ohAuthPublicKey = ohAuthPublicKey;
       this.createdAtMs = createdAtMs;
       this.expiresAtMs = expiresAtMs;
-      this.lastSeenMs = System.currentTimeMillis();
     }
 
     public byte[] getOhAuthPublicKey() {
@@ -50,10 +48,6 @@ public class OutboundHandleStore {
 
     public long getExpiresAtMs() {
       return expiresAtMs;
-    }
-
-    public long getLastSeenMs() {
-      return lastSeenMs;
     }
   }
 

--- a/src/main/java/im/redpanda/store/HashMapCacheToDisk.java
+++ b/src/main/java/im/redpanda/store/HashMapCacheToDisk.java
@@ -122,10 +122,6 @@ public class HashMapCacheToDisk<K, V> extends HashMap<K, V> {
     return result;
   }
 
-  public Object getNative(Object key) {
-    return super.get(key);
-  }
-
   public Object removeNative(Object key) {
     return super.remove(key);
   }

--- a/src/main/java/im/redpanda/store/NodeStore.java
+++ b/src/main/java/im/redpanda/store/NodeStore.java
@@ -476,16 +476,6 @@ public class NodeStore {
     }
   }
 
-  public void printAllNotBlacklisted() {
-
-    for (Node node : nodeGraph.vertexSet()) {
-      // if (nodeBlacklist.containsKey(node)) {
-      // continue;
-      // }
-      System.out.println(node.toString() + " " + (node.isBlacklisted() ? "b" : ""));
-    }
-  }
-
   public void clearGraph() {
     nodeGraph = new DefaultDirectedWeightedGraph<>(NodeEdge.class);
     nodeGraph.addVertex(serverContext.getNode());

--- a/src/test/java/im/redpanda/flaschenpost/GMParserAdditionalTest.java
+++ b/src/test/java/im/redpanda/flaschenpost/GMParserAdditionalTest.java
@@ -109,9 +109,6 @@ class GMParserAdditionalTest {
   }
 
   private static class NullPeerList extends PeerList {
-    NullPeerList(ServerContext serverContext) {
-      super(serverContext);
-    }
 
     @Override
     public ArrayList<Peer> getPeerArrayList() {
@@ -752,7 +749,7 @@ class GMParserAdditionalTest {
   @Test
   void nullPeerArrayListReturnsGracefully() {
     ServerContext serverContext = ServerContext.buildDefaultServerContext();
-    serverContext.setPeerList(new NullPeerList(serverContext));
+    serverContext.setPeerList(new NullPeerList());
     NodeId destination = NodeId.generateWithSimpleKey();
 
     GMContent parsed =


### PR DESCRIPTION
## Summary
Judged deletion round for the 16 zero-reference public methods from dead-code sweep run #1 (TD042) plus the ignored `PeerList(ServerContext)` parameter (TD043). Net: **−162 lines, +9** (the +9 are the two pinned `serialVersionUID`s and comments).

**Deleted (8 plain leftovers):** `KademliaId.fromBase58` / `generateNodeIdByDistance`, `NodeId.fromBufferGetPublic`, `PeerList.getClosestGoodPeer`, `ConnectionReaderThread.parseKademliaId`, `NodeStore.printAllNotBlacklisted`, `HashMapCacheToDisk.getNative`, `OutboundHandleStore.getLastSeenMs` (+ its now write-only `lastSeenMs` field — `HandleRecord` has a pinned UID, field removal is a compatible serialization change).

**Deleted (4 `PeerInHandshake` accessors, judged individually):**
- `isProtocolV23()` — always true since the v22 removal; misleading dead predicate.
- `isInitiatedByUs()`, `getEphemeralPublicFromThem()`, `getProtocolVersion()` — trivial getters with zero callers; their fields/setters stay in active use (internal code reads the fields directly), one-line regeneration if ever needed.

**Kept deliberately:** vendored bitcoinj (`Base58.decodeToBigInteger`, `Sha256Hash.hashFileContents`) — no upstream-diff churn; `Job.updated`/`getReRunDelay` extension hooks.

**TD043:** `PeerList` never reads its `ServerContext` — parameter dropped (not stored), `ServerContext` + test subclass `NullPeerList` adjusted. This removes the last recurring PMD finding in `src/main`.

## Serialization guard (important)
Deleting static methods changes the *computed* `serialVersionUID`. The legacy-fixture test caught this for `NodeId` (`localSettings.dat` from existing nodes would fail to load with `InvalidClassException`). Both `KademliaId` and `NodeId` now pin their pre-change UIDs (`4978904080119646082L` / `2928261161442787061L`), verified with `serialver` against a `main` build — on-disk identities keep loading.

## Verification
- Every deleted method: `grep -rnw` over redpandaj (src+test, catches `::` refs) and current redpanda-mobile checkout — zero references beyond the definition.
- `mvn test`: 529/529 green (1 skipped, baseline), spotless clean.
- Next `/dead-code-cleanup` run should report TD042/TD043 as resolved (idempotency baseline shrinks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Mvonbn7KMt5c2j9Qo5ydm
